### PR TITLE
update pubspec for os dart

### DIFF
--- a/lib/dart/CHANGELOG.md
+++ b/lib/dart/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+This project adheres to [Semantic Versioning](http://semver.org/)
+
+## [Unreleased]
+
+## [2.8.1] - 2017-08-15
+
+## [2.8.0] - 2017-08-10
+
+## [2.7.1] - 2017-07-25
+
+## [2.7.0] - 2017-07-11
+

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -24,5 +24,5 @@ environment:
   sdk: '>=1.13.0 <2.0.0'
 homepage: https://github.com/Workiva/frugal/lib/dart
 name: frugal
-publish_to: https://pub.workiva.org
+documentation:
 version: 2.8.1


### PR DESCRIPTION
@Workiva/messaging-pp 

Leaving out `publish_to` will default to `pub.dartlang.org`
Leaving `documentation` blank will auto generate documentation on pub package page

useful stuff ...
[publishing info](https://www.dartlang.org/tools/pub/publishing)
[pub publish command](https://www.dartlang.org/tools/pub/cmd/pub-lish)
[publish on travis deploy](https://stackoverflow.com/questions/37029028/how-can-i-dart-pub-publish-on-travis-ci-deploy)