### PR TITLE
Update to thrift==0.10.0

### DIFF
--- a/lib/python/requirements.txt
+++ b/lib/python/requirements.txt
@@ -1,3 +1,3 @@
-w-thrift==1.0.0-dev5
+thrift==0.10.0
 requests==2.12.5
 six==1.10.0

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -22,7 +22,7 @@ setup(
     url='http://github.com/Workiva/frugal',
     packages=find_packages(exclude=('frugal.tests', 'frugal.tests.*')),
     install_requires=[
-        "w-thrift==1.0.0-dev5",
+        "thrift==0.10.0",
         "requests==2.12.5",
     ],
     extras_require={


### PR DESCRIPTION
Update to thrift 0.10.0 instead of our fork of thrift which is in an in between state of 0.9.3 and 0.10.0. Cross language tests are passing, which execute a lot of functionality.

@Workiva/messaging-pp 