### PR TITLE
Consume messaging-docker-images 0.0.19

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -9,7 +9,7 @@ run:  # local tests only, never run in Skynet
 contact: messaging@workiva.com
 
 # https://dev.webfilings.org/zuul/release/461082
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:180641
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:208164
 
 env:
   - IN_SKYNET_CLI=true
@@ -43,7 +43,7 @@ requires:
 contact: messaging@workiva.com
 
 # https://dev.webfilings.org/zuul/release/461082
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:180641
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:208164
 
 env:
   - PYTHONIOENCODING=utf-8

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -2,7 +2,7 @@ project: frugal
 language: golang
 
 # https://dev.webfilings.org/zuul/release/461082
-runner_image: drydock-prod.workiva.net/workiva/messaging-docker-images:180641
+runner_image: drydock-prod.workiva.net/workiva/messaging-docker-images:208164
 
 script:
     - ./scripts/smithy.sh


### PR DESCRIPTION

Pulls Included in Release:
* [MSG-384 Add gosimple linter](https://github.com/Workiva/messaging-docker-images/pull/29)


Requested by: @jacobmoss-wf

@@jacobmoss-wf @@jacobmoss-wf
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5198026715955200/logs/)