### PR TITLE
Memory fixes for GRC

### DIFF
--- a/lib/dart/lib/src/frugal.dart
+++ b/lib/dart/lib/src/frugal.dart
@@ -22,6 +22,7 @@ import 'dart:typed_data';
 import 'package:logging/logging.dart';
 import 'package:thrift/thrift.dart';
 import 'package:uuid/uuid.dart';
+import 'package:w_common/disposable.dart';
 import 'package:w_transport/w_transport.dart' as wt;
 
 part 'frugal/f_context.dart';

--- a/lib/dart/lib/src/frugal/transport/base_f_transport_monitor.dart
+++ b/lib/dart/lib/src/frugal/transport/base_f_transport_monitor.dart
@@ -17,7 +17,7 @@ part of frugal.src.frugal;
 /// with exponential backoff behavior and a capped number of retries. Its
 /// behavior can be customized by extending this class and overriding desired
 /// callbacks.
-class BaseFTransportMonitor extends FTransportMonitor {
+class BaseFTransportMonitor extends FTransportMonitor with Disposable {
   /// Default maximum reopen attempts.
   static const int DEFAULT_MAX_REOPEN_ATTEMPTS = 60;
 
@@ -44,6 +44,9 @@ class BaseFTransportMonitor extends FTransportMonitor {
     this._maxReopenAttempts = maxReopenAttempts;
     this._initialWait = initialWait;
     this._maxWait = maxWait;
+
+    manageStreamController(_onConnectController);
+    manageStreamController(_onDisconnectController);
   }
 
   /// Listen to connect events.

--- a/lib/dart/lib/src/frugal/transport/base_f_transport_monitor.dart
+++ b/lib/dart/lib/src/frugal/transport/base_f_transport_monitor.dart
@@ -17,7 +17,8 @@ part of frugal.src.frugal;
 /// with exponential backoff behavior and a capped number of retries. Its
 /// behavior can be customized by extending this class and overriding desired
 /// callbacks.
-class BaseFTransportMonitor extends FTransportMonitor with Disposable {
+@Deprecated('3.0.0')
+class BaseFTransportMonitor extends FTransportMonitor {
   /// Default maximum reopen attempts.
   static const int DEFAULT_MAX_REOPEN_ATTEMPTS = 60;
 

--- a/lib/dart/lib/src/frugal/transport/f_transport.dart
+++ b/lib/dart/lib/src/frugal/transport/f_transport.dart
@@ -35,8 +35,10 @@ abstract class FTransport extends Disposable {
   Stream<Object> get onClose => _closeController.stream;
 
   /// Set an [FTransportMonitor] on the transport.
+  @Deprecated('3.0.0')
   set monitor(FTransportMonitor monitor) {
     _monitor = new MonitorRunner(monitor, this);
+    manageDisposable(_monitor);
   }
 
   /// Queries whether the transport is open.

--- a/lib/dart/lib/src/frugal/transport/f_transport.dart
+++ b/lib/dart/lib/src/frugal/transport/f_transport.dart
@@ -18,7 +18,7 @@ part of frugal.src.frugal;
 /// framed data. Therefore, instead of exposing read, write, and flush, the
 /// transport has a simple [oneway] and [request] methods that send framed
 /// frugal requests.
-abstract class FTransport {
+abstract class FTransport extends Disposable {
   MonitorRunner _monitor;
   StreamController _closeController = new StreamController.broadcast();
 
@@ -27,7 +27,9 @@ abstract class FTransport {
   final int requestSizeLimit;
 
   /// Create an [FTransport] with the optional [requestSizeLimit].
-  FTransport({this.requestSizeLimit});
+  FTransport({this.requestSizeLimit}) {
+    manageStreamController(_closeController);
+  }
 
   /// Listen to close events on the transport.
   Stream<Object> get onClose => _closeController.stream;

--- a/lib/dart/lib/src/frugal/transport/f_transport_monitor.dart
+++ b/lib/dart/lib/src/frugal/transport/f_transport_monitor.dart
@@ -20,7 +20,8 @@ part of frugal.src.frugal;
 ///
 /// [BaseFTransportMonitor] is a basic implementation with backoffs and max
 /// attempts. This can be extended or reimplemented to provide custom logic.
-abstract class FTransportMonitor {
+@Deprecated('3.0.0')
+abstract class FTransportMonitor extends Disposable {
   /// Called when the transport is closed cleanly by a call to [FTransport]
   /// close with no error.
   void onClosedCleanly();

--- a/lib/dart/lib/src/frugal/transport/monitor_runner.dart
+++ b/lib/dart/lib/src/frugal/transport/monitor_runner.dart
@@ -14,7 +14,8 @@
 part of frugal.src.frugal;
 
 /// Runs an [FTransportMonitor] when a transport is closed.
-class MonitorRunner {
+@Deprecated('3.0.0')
+class MonitorRunner extends Disposable {
   final Logger _log = new Logger('FTransportMonitor');
   FTransportMonitor _monitor;
   FTransport _transport;
@@ -26,7 +27,9 @@ class MonitorRunner {
 
   /// Create a new [MonitorRunner] with the given [FTransportMonitor] and
   /// [FTransport].
-  MonitorRunner(this._monitor, this._transport);
+  MonitorRunner(this._monitor, this._transport) {
+    manageDisposable(_monitor);
+  }
 
   /// Indicates if the monitor is waiting to run or gave up.
   bool get _sleeping => (_reopenTimer != null || _failed);

--- a/lib/dart/lib/src/frugal/transport/t_framed_transport.dart
+++ b/lib/dart/lib/src/frugal/transport/t_framed_transport.dart
@@ -15,7 +15,7 @@ part of frugal.src.frugal;
 
 /// A framed implementation of [TTransport]. Has stream for consuming
 /// entire frames. Disallows direct reads.
-class _TFramedTransport extends TTransport {
+class _TFramedTransport extends TTransport with Disposable {
   final Logger log = new Logger('frugal.transport._TFramedTransport');
   static const int _headerByteCount = 4;
 
@@ -51,6 +51,8 @@ class _TFramedTransport extends TTransport {
           log.log(Level.WARNING, 'Unhandled TSocketState $state');
       }
     });
+
+    manageStreamController(_frameStream);
   }
 
   void _reset({bool isOpen: false}) {

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.7
   uuid: ^0.5.0
+  w_common: ^1.8.1
   w_transport: '>=2.9.4 <4.0.0'
 description: A frugal client for Dart
 dev_dependencies:

--- a/lib/dart/test/transport/f_transport_test.dart
+++ b/lib/dart/test/transport/f_transport_test.dart
@@ -76,4 +76,4 @@ class _FTransportImpl extends FTransport {
 }
 
 /// Mock transport monitor.
-class MockTransportMonitor extends Mock implements FTransportMonitor {}
+class MockTransportMonitor extends FTransportMonitor with Mock {}


### PR DESCRIPTION
I'm not sure how much of this is necessary as, in the browser, transports are usually very long lived. For the case of the nats transport (not in this repo, but extends classes in here) I believe one is instantiated at load time and used for the duration of the session.

Either way, I think the completer cleanup on messages needed to happen.

@Workiva/messaging-pp 
@Workiva/performance-reviewers I was told one of you could look over this to make sure everything looks fine