### PR TITLE
change log name in dart generated code

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1502,7 +1502,7 @@ func (g *Generator) generateClient(service *parser.Service) string {
 		contents += fmt.Sprintf("class F%sClient implements F%s {\n",
 			servTitle, servTitle)
 	}
-	contents += fmt.Sprintf(tab+"static final logging.Logger _log = new logging.Logger('%s');\n", servTitle)
+	contents += fmt.Sprintf(tab+"static final logging.Logger _frugalLog = new logging.Logger('%s');\n", servTitle)
 	contents += tab + "Map<String, frugal.FMethod> _methods;\n\n"
 
 	if service.Extends != "" {
@@ -1557,7 +1557,7 @@ func (g *Generator) generateClientMethod(service *parser.Service, method *parser
 		g.generateReturnArg(method), nameLower, g.generateInputArgs(method.Arguments))
 
 	if deprecated {
-		contents += fmt.Sprintf(tabtab+"_log.warning(\"Call to deprecated function '%s.%s'\");\n", service.Name, nameLower)
+		contents += fmt.Sprintf(tabtab+"_frugalLog.warning(\"Call to deprecated function '%s.%s'\");\n", service.Name, nameLower)
 	}
 
 	contents += fmt.Sprintf(tabtab+"return this._methods['%s']([ctx%s]) as Future%s;\n",

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -26,7 +26,7 @@ abstract class FStore {
 /// Services are the API for client and server interaction.
 /// Users can buy an album or enter a giveaway for a free album.
 class FStoreClient implements FStore {
-  static final logging.Logger _log = new logging.Logger('Store');
+  static final logging.Logger _frugalLog = new logging.Logger('Store');
   Map<String, frugal.FMethod> _methods;
 
   FStoreClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {
@@ -86,7 +86,7 @@ class FStoreClient implements FStore {
   }
   @Deprecated("use something else")
   Future<bool> enterAlbumGiveaway(frugal.FContext ctx, String email, String name) {
-    _log.warning("Call to deprecated function 'Store.enterAlbumGiveaway'");
+    _frugalLog.warning("Call to deprecated function 'Store.enterAlbumGiveaway'");
     return this._methods['enterAlbumGiveaway']([ctx, email, name]) as Future<bool>;
   }
 

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -19,7 +19,7 @@ abstract class FBaseFoo {
 }
 
 class FBaseFooClient implements FBaseFoo {
-  static final logging.Logger _log = new logging.Logger('BaseFoo');
+  static final logging.Logger _frugalLog = new logging.Logger('BaseFoo');
   Map<String, frugal.FMethod> _methods;
 
   FBaseFooClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -21,7 +21,7 @@ abstract class FMyService {
 }
 
 class FMyServiceClient implements FMyService {
-  static final logging.Logger _log = new logging.Logger('MyService');
+  static final logging.Logger _frugalLog = new logging.Logger('MyService');
   Map<String, frugal.FMethod> _methods;
 
   FMyServiceClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -47,7 +47,7 @@ abstract class FFoo extends t_actual_base_dart.FBaseFoo {
 /// This is a thrift service. Frugal will generate bindings that include
 /// a frugal Context for each service call.
 class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
-  static final logging.Logger _log = new logging.Logger('Foo');
+  static final logging.Logger _frugalLog = new logging.Logger('Foo');
   Map<String, frugal.FMethod> _methods;
 
   FFooClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware])
@@ -74,7 +74,7 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
   /// Ping the server.
   @Deprecated("use something else")
   Future ping(frugal.FContext ctx) {
-    _log.warning("Call to deprecated function 'Foo.ping'");
+    _frugalLog.warning("Call to deprecated function 'Foo.ping'");
     return this._methods['ping']([ctx]) as Future;
   }
 


### PR DESCRIPTION
This naming of our logger was causing a conflict when an IDL as `log()` as a service method. This added a frugal prefix, which I intended to be viewed as a "reserved" prefix, implying users should not use this prefix for the names in their IDL

@Workiva/messaging-pp @markerickson-wf 