### PR TITLE
don't show dependencies multiple times in the html index

### DIFF
--- a/lib/python/requirements.txt
+++ b/lib/python/requirements.txt
@@ -1,3 +1,4 @@
+multidict==1.1.0
+six==1.10.0
 thrift==0.10.0
 requests==2.12.5
-six==1.10.0

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -22,6 +22,7 @@ setup(
     url='http://github.com/Workiva/frugal',
     packages=find_packages(exclude=('frugal.tests', 'frugal.tests.*')),
     install_requires=[
+        "six==1.10.0",
         "thrift==0.10.0",
         "requests==2.12.5",
     ],

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -22,6 +22,7 @@ setup(
     url='http://github.com/Workiva/frugal',
     packages=find_packages(exclude=('frugal.tests', 'frugal.tests.*')),
     install_requires=[
+        "multidict==1.1.0",
         "six==1.10.0",
         "thrift==0.10.0",
         "requests==2.12.5",

--- a/test/expected/dart/variety/f_awesome_exception.dart
+++ b/test/expected/dart/variety/f_awesome_exception.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data' show Uint8List;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:variety/variety.dart' as t_variety;
 import 'package:actual_base_dart/actual_base_dart.dart' as t_actual_base_dart;
+import 'package:intermediate_include/intermediate_include.dart' as t_intermediate_include;
 import 'package:validStructs/validStructs.dart' as t_validStructs;
 import 'package:ValidTypes/ValidTypes.dart' as t_ValidTypes;
 import 'package:subdir_include_ns/subdir_include_ns.dart' as t_subdir_include_ns;

--- a/test/expected/dart/variety/f_event.dart
+++ b/test/expected/dart/variety/f_event.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data' show Uint8List;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:variety/variety.dart' as t_variety;
 import 'package:actual_base_dart/actual_base_dart.dart' as t_actual_base_dart;
+import 'package:intermediate_include/intermediate_include.dart' as t_intermediate_include;
 import 'package:validStructs/validStructs.dart' as t_validStructs;
 import 'package:ValidTypes/ValidTypes.dart' as t_ValidTypes;
 import 'package:subdir_include_ns/subdir_include_ns.dart' as t_subdir_include_ns;

--- a/test/expected/dart/variety/f_event_wrapper.dart
+++ b/test/expected/dart/variety/f_event_wrapper.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data' show Uint8List;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:variety/variety.dart' as t_variety;
 import 'package:actual_base_dart/actual_base_dart.dart' as t_actual_base_dart;
+import 'package:intermediate_include/intermediate_include.dart' as t_intermediate_include;
 import 'package:validStructs/validStructs.dart' as t_validStructs;
 import 'package:ValidTypes/ValidTypes.dart' as t_ValidTypes;
 import 'package:subdir_include_ns/subdir_include_ns.dart' as t_subdir_include_ns;

--- a/test/expected/dart/variety/f_test_base.dart
+++ b/test/expected/dart/variety/f_test_base.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data' show Uint8List;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:variety/variety.dart' as t_variety;
 import 'package:actual_base_dart/actual_base_dart.dart' as t_actual_base_dart;
+import 'package:intermediate_include/intermediate_include.dart' as t_intermediate_include;
 import 'package:validStructs/validStructs.dart' as t_validStructs;
 import 'package:ValidTypes/ValidTypes.dart' as t_ValidTypes;
 import 'package:subdir_include_ns/subdir_include_ns.dart' as t_subdir_include_ns;

--- a/test/expected/dart/variety/f_test_lowercase.dart
+++ b/test/expected/dart/variety/f_test_lowercase.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data' show Uint8List;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:variety/variety.dart' as t_variety;
 import 'package:actual_base_dart/actual_base_dart.dart' as t_actual_base_dart;
+import 'package:intermediate_include/intermediate_include.dart' as t_intermediate_include;
 import 'package:validStructs/validStructs.dart' as t_validStructs;
 import 'package:ValidTypes/ValidTypes.dart' as t_ValidTypes;
 import 'package:subdir_include_ns/subdir_include_ns.dart' as t_subdir_include_ns;

--- a/test/expected/dart/variety/f_testing_defaults.dart
+++ b/test/expected/dart/variety/f_testing_defaults.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data' show Uint8List;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:variety/variety.dart' as t_variety;
 import 'package:actual_base_dart/actual_base_dart.dart' as t_actual_base_dart;
+import 'package:intermediate_include/intermediate_include.dart' as t_intermediate_include;
 import 'package:validStructs/validStructs.dart' as t_validStructs;
 import 'package:ValidTypes/ValidTypes.dart' as t_ValidTypes;
 import 'package:subdir_include_ns/subdir_include_ns.dart' as t_subdir_include_ns;

--- a/test/expected/dart/variety/f_testing_unions.dart
+++ b/test/expected/dart/variety/f_testing_unions.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data' show Uint8List;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:variety/variety.dart' as t_variety;
 import 'package:actual_base_dart/actual_base_dart.dart' as t_actual_base_dart;
+import 'package:intermediate_include/intermediate_include.dart' as t_intermediate_include;
 import 'package:validStructs/validStructs.dart' as t_validStructs;
 import 'package:ValidTypes/ValidTypes.dart' as t_ValidTypes;
 import 'package:subdir_include_ns/subdir_include_ns.dart' as t_subdir_include_ns;

--- a/test/expected/dart/variety/f_variety_constants.dart
+++ b/test/expected/dart/variety/f_variety_constants.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data' show Uint8List;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:variety/variety.dart' as t_variety;
 import 'package:actual_base_dart/actual_base_dart.dart' as t_actual_base_dart;
+import 'package:intermediate_include/intermediate_include.dart' as t_intermediate_include;
 import 'package:validStructs/validStructs.dart' as t_validStructs;
 import 'package:ValidTypes/ValidTypes.dart' as t_ValidTypes;
 import 'package:subdir_include_ns/subdir_include_ns.dart' as t_subdir_include_ns;

--- a/test/expected/dart/variety/variety.dart
+++ b/test/expected/dart/variety/variety.dart
@@ -16,4 +16,6 @@ export 'src/f_its_an_enum.dart' show ItsAnEnum;
 
 export 'src/f_foo_service.dart' show FFoo;
 export 'src/f_foo_service.dart' show FFooClient;
+export 'src/f_foo_transitive_deps_service.dart' show FFooTransitiveDeps;
+export 'src/f_foo_transitive_deps_service.dart' show FFooTransitiveDepsClient;
 export 'src/f_events_scope.dart' show EventsPublisher, EventsSubscriber;

--- a/test/expected/go/variety/f_types.txt
+++ b/test/expected/go/variety/f_types.txt
@@ -12,6 +12,7 @@ import (
 	"git.apache.org/thrift.git/lib/go/thrift"
 	"github.com/Workiva/frugal/test/out/ValidTypes"
 	"github.com/Workiva/frugal/test/out/actual_base/golang"
+	"github.com/Workiva/frugal/test/out/intermediate_include"
 	"github.com/Workiva/frugal/test/out/subdir_include"
 	"github.com/Workiva/frugal/test/out/validStructs"
 )
@@ -22,6 +23,7 @@ var _ = fmt.Printf
 var _ = bytes.Equal
 
 var _ = golang.GoUnusedProtection__
+var _ = intermediate_include.GoUnusedProtection__
 var _ = validStructs.GoUnusedProtection__
 var _ = ValidTypes.GoUnusedProtection__
 var _ = subdir_include.GoUnusedProtection__

--- a/test/expected/html/index.html
+++ b/test/expected/html/index.html
@@ -72,6 +72,31 @@
 				</tr>
 				
 				<tr>
+					<td><a href="intermediate_include.html">intermediate_include</a></td>
+					<td>
+					
+						<a href="intermediate_include.html#svc_IntermediateFoo">IntermediateFoo</a><br />
+						<ul>
+						
+							<li><a href="intermediate_include.html#fn_IntermediateFoo_IntermeidateFoo">IntermeidateFoo</a></li>
+						
+						</ul>
+					
+					</td>
+					<td>
+					
+					</td>
+					<td>
+					
+					
+					
+					</td>
+					<td>
+					
+					</td>
+				</tr>
+				
+				<tr>
 					<td><a href="subdir_include.html">subdir_include</a></td>
 					<td>
 					
@@ -135,6 +160,13 @@
 							<li><a href="variety.html#fn_Foo_getMyInt">getMyInt</a></li>
 						
 							<li><a href="variety.html#fn_Foo_use_subdir_struct">use_subdir_struct</a></li>
+						
+						</ul>
+					
+						<a href="variety.html#svc_FooTransitiveDeps">FooTransitiveDeps</a><br />
+						<ul>
+						
+							<li><a href="variety.html#fn_FooTransitiveDeps_ping">ping</a></li>
 						
 						</ul>
 					

--- a/test/expected/html/standalone/index.html
+++ b/test/expected/html/standalone/index.html
@@ -257,6 +257,31 @@ code { line-height: 20px; }
 				</tr>
 				
 				<tr>
+					<td><a href="intermediate_include.html">intermediate_include</a></td>
+					<td>
+					
+						<a href="intermediate_include.html#svc_IntermediateFoo">IntermediateFoo</a><br />
+						<ul>
+						
+							<li><a href="intermediate_include.html#fn_IntermediateFoo_IntermeidateFoo">IntermeidateFoo</a></li>
+						
+						</ul>
+					
+					</td>
+					<td>
+					
+					</td>
+					<td>
+					
+					
+					
+					</td>
+					<td>
+					
+					</td>
+				</tr>
+				
+				<tr>
 					<td><a href="subdir_include.html">subdir_include</a></td>
 					<td>
 					
@@ -320,6 +345,13 @@ code { line-height: 20px; }
 							<li><a href="variety.html#fn_Foo_getMyInt">getMyInt</a></li>
 						
 							<li><a href="variety.html#fn_Foo_use_subdir_struct">use_subdir_struct</a></li>
+						
+						</ul>
+					
+						<a href="variety.html#svc_FooTransitiveDeps">FooTransitiveDeps</a><br />
+						<ul>
+						
+							<li><a href="variety.html#fn_FooTransitiveDeps_ping">ping</a></li>
 						
 						</ul>
 					

--- a/test/expected/html/standalone/variety.html
+++ b/test/expected/html/standalone/variety.html
@@ -227,6 +227,13 @@ code { line-height: 20px; }
 						
 						</ul>
 					
+						<a href="#svc_FooTransitiveDeps">FooTransitiveDeps</a><br />
+						<ul>
+						
+							<li><a href="#fn_FooTransitiveDeps_ping">ping</a></li>
+						
+						</ul>
+					
 					</td>
 					<td>
 					
@@ -1196,6 +1203,21 @@ code { line-height: 20px; }
 			<div class="definition">
 				<h4 id="fn_Foo_use_subdir_struct">Function: Foo.use_subdir_struct</h4>
 				<pre><code><a href="subdir_include.html#struct_A">subdir_include.A</a> use_subdir_struct(<a href="subdir_include.html#struct_A">subdir_include.A</a> a)</code></pre>
+				
+			</div>
+			
+			
+			<h3 id="svc_FooTransitiveDeps">Service: FooTransitiveDeps</h3>
+			
+			<div class="extends">
+				<em>extends</em> <code><a href="intermediate_include.html#svc_IntermediateFoo">intermediate_include.IntermediateFoo</a></code>
+			</div>
+			
+			
+			
+			<div class="definition">
+				<h4 id="fn_FooTransitiveDeps_ping">Function: FooTransitiveDeps.ping</h4>
+				<pre><code>void ping()</code></pre>
 				
 			</div>
 			

--- a/test/expected/html/variety.html
+++ b/test/expected/html/variety.html
@@ -42,6 +42,13 @@
 						
 						</ul>
 					
+						<a href="#svc_FooTransitiveDeps">FooTransitiveDeps</a><br />
+						<ul>
+						
+							<li><a href="#fn_FooTransitiveDeps_ping">ping</a></li>
+						
+						</ul>
+					
 					</td>
 					<td>
 					
@@ -1011,6 +1018,21 @@
 			<div class="definition">
 				<h4 id="fn_Foo_use_subdir_struct">Function: Foo.use_subdir_struct</h4>
 				<pre><code><a href="subdir_include.html#struct_A">subdir_include.A</a> use_subdir_struct(<a href="subdir_include.html#struct_A">subdir_include.A</a> a)</code></pre>
+				
+			</div>
+			
+			
+			<h3 id="svc_FooTransitiveDeps">Service: FooTransitiveDeps</h3>
+			
+			<div class="extends">
+				<em>extends</em> <code><a href="intermediate_include.html#svc_IntermediateFoo">intermediate_include.IntermediateFoo</a></code>
+			</div>
+			
+			
+			
+			<div class="definition">
+				<h4 id="fn_FooTransitiveDeps_ping">Function: FooTransitiveDeps.ping</h4>
+				<pre><code>void ping()</code></pre>
 				
 			</div>
 			

--- a/test/expected/python.asyncio/variety/constants.py
+++ b/test/expected/python.asyncio/variety/constants.py
@@ -10,6 +10,9 @@ from .ttypes import *
 import actual_base.python.ttypes
 import actual_base.python.constants
 
+import intermediate_include.ttypes
+import intermediate_include.constants
+
 import validStructs.ttypes
 import validStructs.constants
 

--- a/test/expected/python.asyncio/variety/ttypes.py
+++ b/test/expected/python.asyncio/variety/ttypes.py
@@ -7,6 +7,8 @@
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 import actual_base.python.ttypes
 import actual_base.python.constants
+import intermediate_include.ttypes
+import intermediate_include.constants
 import validStructs.ttypes
 import validStructs.constants
 import ValidTypes.ttypes

--- a/test/expected/python.tornado/variety/constants.py
+++ b/test/expected/python.tornado/variety/constants.py
@@ -10,6 +10,9 @@ from .ttypes import *
 import actual_base.python.ttypes
 import actual_base.python.constants
 
+import intermediate_include.ttypes
+import intermediate_include.constants
+
 import validStructs.ttypes
 import validStructs.constants
 

--- a/test/expected/python.tornado/variety/ttypes.py
+++ b/test/expected/python.tornado/variety/ttypes.py
@@ -7,6 +7,8 @@
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 import actual_base.python.ttypes
 import actual_base.python.constants
+import intermediate_include.ttypes
+import intermediate_include.constants
 import validStructs.ttypes
 import validStructs.constants
 import ValidTypes.ttypes

--- a/test/expected/python/variety/constants.py
+++ b/test/expected/python/variety/constants.py
@@ -10,6 +10,9 @@ from .ttypes import *
 import actual_base.python.ttypes
 import actual_base.python.constants
 
+import intermediate_include.ttypes
+import intermediate_include.constants
+
 import validStructs.ttypes
 import validStructs.constants
 

--- a/test/expected/python/variety/ttypes.py
+++ b/test/expected/python/variety/ttypes.py
@@ -7,6 +7,8 @@
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 import actual_base.python.ttypes
 import actual_base.python.constants
+import intermediate_include.ttypes
+import intermediate_include.constants
 import validStructs.ttypes
 import validStructs.constants
 import ValidTypes.ttypes

--- a/test/idl/intermediate_include.frugal
+++ b/test/idl/intermediate_include.frugal
@@ -1,0 +1,6 @@
+
+include "base.frugal"
+
+service IntermediateFoo {
+    void IntermeidateFoo()
+}

--- a/test/idl/variety.frugal
+++ b/test/idl/variety.frugal
@@ -4,6 +4,7 @@ namespace java variety.java
 namespace py variety.python
 
 include "base.frugal"
+include "intermediate_include.frugal"
 include "validStructs.frugal"
 include "ValidTypes.frugal"
 include "subdir_includes/subdir_include.frugal"
@@ -170,6 +171,10 @@ service Foo extends base.BaseFoo {
     ValidTypes.MyInt getMyInt(),
 
     subdir_include.A use_subdir_struct(1:subdir_include.A a),
+}
+
+service FooTransitiveDeps extends intermediate_include.IntermediateFoo {
+	void ping()
 }
 
 /**@


### PR DESCRIPTION
If a dependency was included multiple times via a transitive dependency, like `b` depends on `a` and `c` depends on both `b` and `a`, then `a` shouldn't be shown multiple times in the index generated by the html generator.

@Workiva/messaging-pp @markcampanelli-wf 