### PR TITLE
Use older version of travis worker so build passes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 dist: trusty
+group: deprecated-2017Q3
 language: go
 
 go:


### PR DESCRIPTION
@Workiva/messaging-pp travis-ci updated their default builder. Pinning to the previous version that we know passes until have time to figure it out, as to not hold up releases and other PRs.