### PR TITLE
bump asyncio-nat-client version to 0.6.0

### DIFF
--- a/lib/python/requirements_dev_asyncio.txt
+++ b/lib/python/requirements_dev_asyncio.txt
@@ -1,4 +1,4 @@
-asyncio-nats-client==0.3.1
+asyncio-nats-client==0.6.0
 aiohttp==0.22.3
 async-timeout==1.1.0
 

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -29,7 +29,7 @@ setup(
     ],
     extras_require={
         'tornado': ["nats-client==0.5.0"],
-        'asyncio': ["async-timeout==1.1.0", "asyncio-nats-client==0.3.1",
+        'asyncio': ["async-timeout==1.1.0", "asyncio-nats-client==0.6.0",
                     "aiohttp==0.22.3"],
         'gae': ["webapp2==2.5.2"],
     }


### PR DESCRIPTION
https://github.com/Workiva/frugal/blob/master/lib/python/requirements_dev_asyncio.txt

frugal[asyncio] points to asyncio-nats-client==0.3.1

https://github.com/Workiva/messaging-sdk/blob/master/lib/python/messaging_sdk/aio/nats.py#L94

messaging_sdk pass tls parameters, but tls is introduced in asyncio-nats-client 0.6.0 https://github.com/nats-io/asyncio-nats/blame/master/nats/aio/client.py#L151