### PR TITLE
Python: Add param to allow for additional request headers to FHTTPTransport #927

### DIFF
--- a/lib/python/frugal/aio/transport/http_transport.py
+++ b/lib/python/frugal/aio/transport/http_transport.py
@@ -29,7 +29,7 @@ class FHttpTransport(FTransportBase):
     This allows messages of arbitrary sizes to be sent and received.
     """
     def __init__(self, url, request_capacity=0, response_capacity=0,
-                 request_header_funcs=[]):
+                 request_header_func=None):
         """
         Create an HTTP transport.
 
@@ -39,18 +39,18 @@ class FHttpTransport(FTransportBase):
                               request. Set to 0 for no size restrictions.
             response_capacity: The maximum size allowed to be read in a
                                response. Set to 0 for no size restrictions
-            request_header_funcs: An optional list of functions that
-                                  return a dictionary of request headers
-                                  to be added to the request. Set to
-                                  an empty list by default.
+            request_header_func: An optional lambda function that will
+                                 return a dictionary of request headers when
+                                 called to be added to the request. Set to
+                                 None by default.
         """
         super().__init__(request_capacity)
         self._url = url
         self._headers = {}
 
         # Add user-supplied headers first to avoid removing the native headers
-        for func in request_header_funcs:
-            for header, value in func.items():
+        if request_header_func is not None:
+            for header, value in request_header_func().items():
                 if header is not None and value is not None:
                     self._headers[header] = value
 

--- a/lib/python/frugal/aio/transport/http_transport.py
+++ b/lib/python/frugal/aio/transport/http_transport.py
@@ -28,7 +28,8 @@ class FHttpTransport(FTransportBase):
     FHttpTransport is an FTransport that uses http as the underlying transport.
     This allows messages of arbitrary sizes to be sent and received.
     """
-    def __init__(self, url, request_capacity=0, response_capacity=0):
+    def __init__(self, url, request_capacity=0, response_capacity=0,
+                 additional_headers=None):
         """
         Create an HTTP transport.
 
@@ -38,6 +39,9 @@ class FHttpTransport(FTransportBase):
                               request. Set to 0 for no size restrictions.
             response_capacity: The maximum size allowed to be read in a
                                response. Set to 0 for no size restrictions
+            additional_headers: Additional headers to be appended onto
+                                the request. Set to None by default, expects
+                                a dict of key-value pairs
         """
         super().__init__(request_capacity)
         self._url = url
@@ -49,6 +53,10 @@ class FHttpTransport(FTransportBase):
         }
         if response_capacity > 0:
             self._headers['x-frugal-payload-limit'] = str(response_capacity)
+        # append additional provided headers
+        if additional_headers is not None:
+            for header, value in additional_headers.items():
+                self._headers[header] = str(value)
 
     def is_open(self):
         """Always returns True"""

--- a/lib/python/frugal/aio/transport/http_transport.py
+++ b/lib/python/frugal/aio/transport/http_transport.py
@@ -29,7 +29,7 @@ class FHttpTransport(FTransportBase):
     This allows messages of arbitrary sizes to be sent and received.
     """
     def __init__(self, url, request_capacity=0, response_capacity=0,
-                 request_header_func=None):
+                 get_request_headers=None):
         """
         Create an HTTP transport.
 
@@ -39,25 +39,19 @@ class FHttpTransport(FTransportBase):
                               request. Set to 0 for no size restrictions.
             response_capacity: The maximum size allowed to be read in a
                                response. Set to 0 for no size restrictions
-            request_header_func: An optional lambda function that will
-                                 return a dictionary of request headers when
-                                 called to be added to the request. Set to
-                                 None by default.
+            get_request_headers: An optional function that accepts an FContext.
+                                 Should return a dictionary of additional
+                                 request headers to be appended onto the request
         """
         super().__init__(request_capacity)
         self._url = url
-        self._headers = {}
+        self.get_request_headers = get_request_headers
 
-        # Add user-supplied headers first to avoid removing the native headers
-        if request_header_func is not None:
-            for header, value in request_header_func().items():
-                if header is not None and value is not None:
-                    self._headers[header] = value
-
-        self._headers['content-type'] = 'application/x-frugal'
-        self._headers['content-transfer-encoding'] = 'base64'
-        self._headers['accept'] = 'application/x-frugal'
-
+        self._headers = {
+            'content-type': 'application/x-frugal',
+            'content-transfer-encoding': 'base64',
+            'accept': 'application/x-frugal',
+        }
         if response_capacity > 0:
             self._headers['x-frugal-payload-limit'] = str(response_capacity)
 
@@ -129,12 +123,20 @@ class FHttpTransport(FTransportBase):
         Throws:
             TTransportException if the request timed out.
         """
+        # construct headers for request
+        request_headers = {}
+        if self.get_request_headers is not None:
+            request_headers = self.get_request_headers(context)
+        # apply the default headers so their values cannot be modified
+        for header, value in self._headers.items():
+            request_headers[header] = value
+
         with ClientSession() as session:
             try:
                 with async_timeout.timeout(context.timeout / 1000):
                     async with session.post(self._url,
                                             data=payload,
-                                            headers=self._headers) as response:
+                                            headers=request_headers) as response:
                         return response.status, await response.content.read()
             except asyncio.TimeoutError:
                 raise TTransportException(

--- a/lib/python/frugal/aio/transport/http_transport.py
+++ b/lib/python/frugal/aio/transport/http_transport.py
@@ -41,11 +41,11 @@ class FHttpTransport(FTransportBase):
                                response. Set to 0 for no size restrictions
             get_request_headers: An optional function that accepts an FContext.
                                  Should return a dictionary of additional
-                                 request headers to be appended onto the request
+                                 request headers to be appended to the request
         """
         super().__init__(request_capacity)
         self._url = url
-        self.get_request_headers = get_request_headers
+        self._get_request_headers = get_request_headers
 
         self._headers = {
             'content-type': 'application/x-frugal',
@@ -125,8 +125,8 @@ class FHttpTransport(FTransportBase):
         """
         # construct headers for request
         request_headers = {}
-        if self.get_request_headers is not None:
-            request_headers = self.get_request_headers(context)
+        if self._get_request_headers is not None:
+            request_headers = self._get_request_headers(context)
         # apply the default headers so their values cannot be modified
         for header, value in self._headers.items():
             request_headers[header] = value
@@ -136,7 +136,8 @@ class FHttpTransport(FTransportBase):
                 with async_timeout.timeout(context.timeout / 1000):
                     async with session.post(self._url,
                                             data=payload,
-                                            headers=request_headers) as response:
+                                            headers=request_headers) \
+                            as response:
                         return response.status, await response.content.read()
             except asyncio.TimeoutError:
                 raise TTransportException(

--- a/lib/python/frugal/aio/transport/http_transport.py
+++ b/lib/python/frugal/aio/transport/http_transport.py
@@ -128,8 +128,7 @@ class FHttpTransport(FTransportBase):
         if self._get_request_headers is not None:
             request_headers = self._get_request_headers(context)
         # apply the default headers so their values cannot be modified
-        for header, value in self._headers.items():
-            request_headers[header] = value
+        request_headers.update(self._headers)
 
         with ClientSession() as session:
             try:

--- a/lib/python/frugal/tests/aio/transport/test_http_transport.py
+++ b/lib/python/frugal/tests/aio/transport/test_http_transport.py
@@ -92,26 +92,18 @@ class TestFHttpTransport(utils.AsyncIOTestCase):
     @utils.async_runner
     async def test_request_extra_headers_with_context(self):
 
-        def generate_test_header1(fcontext):
-            return { 'first-header': fcontext.correlation_id}
-
-        def generate_test_header2():
+        def generate_test_header(fcontext):
             return {
-                'second-header': 'test2',
-                'third-header': 'test3'
+                'first-header': fcontext.correlation_id,
+                'second-header': 'test'
             }
-
-        def generate_test_header_empty():
-            return {}
 
         test_context = FContext()
         transport_with_headers = FHttpTransport(
             self.url,
             request_capacity=self.request_capacity,
             response_capacity=self.response_capacity,
-            request_header_funcs=[generate_test_header1(test_context),
-                                  generate_test_header2(),
-                                  generate_test_header_empty()]
+            request_header_func=lambda: generate_test_header(test_context)
         )
         expected_headers = {
             'content-type': 'application/x-frugal',
@@ -119,8 +111,7 @@ class TestFHttpTransport(utils.AsyncIOTestCase):
             'accept': 'application/x-frugal',
             'x-frugal-payload-limit': '200',
             'first-header': test_context.correlation_id,
-            'second-header': 'test2',
-            'third-header': 'test3'
+            'second-header': 'test'
         }
         print(transport_with_headers._headers)
         self.assertEqual(transport_with_headers._headers, expected_headers)

--- a/lib/python/frugal/tests/aio/transport/test_http_transport.py
+++ b/lib/python/frugal/tests/aio/transport/test_http_transport.py
@@ -22,7 +22,7 @@ from frugal.tests.aio import utils
 
 
 class FHttpTransportWithContext(FHttpTransport):
-    def get_headers(self, fcontext):
+    def get_request_headers(self, fcontext):
         """
         override default implementation to add user supplied headers from FContext
         :param fcontext:

--- a/lib/python/frugal/tests/aio/transport/test_http_transport.py
+++ b/lib/python/frugal/tests/aio/transport/test_http_transport.py
@@ -33,8 +33,17 @@ class TestFHttpTransport(utils.AsyncIOTestCase):
             request_capacity=self.request_capacity,
             response_capacity=self.response_capacity
         )
+        self.transport_headers = FHttpTransport(
+            self.url,
+            request_capacity=self.request_capacity,
+            response_capacity=self.response_capacity,
+            additional_headers={
+                "extra-header": "test header"
+            }
+        )
         self.make_request_mock = mock.Mock()
         self.transport._make_request = self.make_request_mock
+        self.transport_headers._make_request = self.make_request_mock
 
         self.headers = {
             'content-type': 'application/x-frugal',
@@ -78,9 +87,34 @@ class TestFHttpTransport(utils.AsyncIOTestCase):
         response_future = Future()
         response_future.set_result((200, response_encoded))
         self.make_request_mock.return_value = response_future
+        self.assertEqual(self.headers, self.transport._headers)
 
         ctx = FContext()
         response_transport = await self.transport.request(
+            ctx, request_frame)
+
+        self.assertEqual(response_data, response_transport.getvalue())
+        self.assertTrue(self.make_request_mock.called)
+        request_args = self.make_request_mock.call_args[0]
+        self.assertEqual(request_args[0], ctx)
+        self.assertEqual(request_args[1], base64.b64encode(request_frame))
+
+    @utils.async_runner
+    async def test_request_additional_header(self):
+        request_data = bytearray([4, 5, 6, 7, 8, 9, 10, 11, 13, 12, 3])
+        request_frame = bytearray([0, 0, 0, 11]) + request_data
+
+        response_data = bytearray([23, 24, 25, 26, 27, 28, 29])
+        response_frame = bytearray([0, 0, 0, 7]) + response_data
+        response_encoded = base64.b64encode(response_frame)
+        response_future = Future()
+        response_future.set_result((200, response_encoded))
+        self.make_request_mock.return_value = response_future
+        self.assertTrue("extra-header" in self.transport_headers._headers)
+        self.assertTrue(self.transport_headers._headers['extra-header'] == "test header")
+
+        ctx = FContext()
+        response_transport = await self.transport_headers.request(
             ctx, request_frame)
 
         self.assertEqual(response_data, response_transport.getvalue())

--- a/lib/python/frugal/tests/aio/transport/test_http_transport.py
+++ b/lib/python/frugal/tests/aio/transport/test_http_transport.py
@@ -98,23 +98,12 @@ class TestFHttpTransport(utils.AsyncIOTestCase):
                 'second-header': 'test'
             }
 
-        test_context = FContext()
         transport_with_headers = FHttpTransport(
             self.url,
             request_capacity=self.request_capacity,
             response_capacity=self.response_capacity,
-            request_header_func=lambda: generate_test_header(test_context)
+            get_request_headers=generate_test_header
         )
-        expected_headers = {
-            'content-type': 'application/x-frugal',
-            'content-transfer-encoding': 'base64',
-            'accept': 'application/x-frugal',
-            'x-frugal-payload-limit': '200',
-            'first-header': test_context.correlation_id,
-            'second-header': 'test'
-        }
-        print(transport_with_headers._headers)
-        self.assertEqual(transport_with_headers._headers, expected_headers)
 
         transport_with_headers._make_request = self.make_request_mock
 

--- a/lib/python/frugal/tests/tornado/transport/test_http_transport.py
+++ b/lib/python/frugal/tests/tornado/transport/test_http_transport.py
@@ -151,6 +151,58 @@ class TestFHttpTransport(AsyncTestCase):
         self.assertEqual(request.headers, expected_headers)
 
     @gen_test
+    def test_request_extra_headers_with_context_modify_defaults(self):
+
+        def generate_test_header(fcontext):
+            return {
+                'first-header': fcontext.correlation_id,
+                'second-header': 'test',
+                'content-type': 'these should',
+                'content-transfer-encoding': 'not be',
+                'accept': 'the final values'
+            }
+
+        transport_with_headers = FHttpTransport(
+            url=self.url,
+            request_capacity=self.request_capacity,
+            response_capacity=self.response_capacity,
+            get_request_headers=generate_test_header
+        )
+
+        transport_with_headers._http = self.http_mock
+
+        request_data = bytearray([4, 5, 6, 8, 9, 10, 11, 13, 12, 3])
+        request_frame = bytearray([0, 0, 0, 10]) + request_data
+
+        response_mock = mock.Mock(spec=HTTPResponse)
+        response_data = bytearray([23, 24, 25, 26, 27, 28, 29])
+        response_frame = bytearray([0, 0, 0, 10]) + response_data
+        response_encoded = base64.b64encode(response_frame)
+        response_mock.body = response_encoded
+        response_future = Future()
+        response_future.set_result(response_mock)
+        self.http_mock.fetch.return_value = response_future
+
+        ctx = FContext()
+        response_transport = yield transport_with_headers.request(ctx, request_frame)
+        expected_headers = {
+            'content-type': 'application/x-frugal',
+            'content-transfer-encoding': 'base64',
+            'accept': 'application/x-frugal',
+            'x-frugal-payload-limit': '200',
+            'first-header': ctx.correlation_id,
+            'second-header': 'test',
+        }
+
+        self.assertEqual(response_data, response_transport.getvalue())
+        self.assertTrue(self.http_mock.fetch.called)
+        request = self.http_mock.fetch.call_args[0][0]
+        self.assertEqual(request.url, self.url)
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(request.body, base64.b64encode(request_frame))
+        self.assertEqual(request.headers, expected_headers)
+
+    @gen_test
     def test_request_too_much_data(self):
         self.transport._http = self.http_mock
         with self.assertRaises(TTransportException) as cm:

--- a/lib/python/frugal/tests/tornado/transport/test_http_transport.py
+++ b/lib/python/frugal/tests/tornado/transport/test_http_transport.py
@@ -110,21 +110,12 @@ class TestFHttpTransport(AsyncTestCase):
                 'second-header': 'test'
             }
 
-        test_context = FContext()
         transport_with_headers = FHttpTransport(
             url=self.url,
             request_capacity=self.request_capacity,
             response_capacity=self.response_capacity,
-            request_header_func=lambda: generate_test_header(test_context)
+            get_request_headers=generate_test_header
         )
-        expected_headers = {
-            'content-type': 'application/x-frugal',
-            'content-transfer-encoding': 'base64',
-            'accept': 'application/x-frugal',
-            'x-frugal-payload-limit': '200',
-            'first-header': test_context.correlation_id,
-            'second-header': 'test',
-        }
 
         transport_with_headers._http = self.http_mock
 
@@ -142,6 +133,14 @@ class TestFHttpTransport(AsyncTestCase):
 
         ctx = FContext()
         response_transport = yield transport_with_headers.request(ctx, request_frame)
+        expected_headers = {
+            'content-type': 'application/x-frugal',
+            'content-transfer-encoding': 'base64',
+            'accept': 'application/x-frugal',
+            'x-frugal-payload-limit': '200',
+            'first-header': ctx.correlation_id,
+            'second-header': 'test',
+        }
 
         self.assertEqual(response_data, response_transport.getvalue())
         self.assertTrue(self.http_mock.fetch.called)

--- a/lib/python/frugal/tests/tornado/transport/test_http_transport.py
+++ b/lib/python/frugal/tests/tornado/transport/test_http_transport.py
@@ -104,26 +104,18 @@ class TestFHttpTransport(AsyncTestCase):
     @gen_test
     def test_request_extra_headers_with_context(self):
 
-        def generate_test_header1(fcontext):
-            return { 'first-header': fcontext.correlation_id}
-
-        def generate_test_header2():
+        def generate_test_header(fcontext):
             return {
-                'second-header': 'test2',
-                'third-header': 'test3'
+                'first-header': fcontext.correlation_id,
+                'second-header': 'test'
             }
-
-        def generate_test_header_empty():
-            return {}
 
         test_context = FContext()
         transport_with_headers = FHttpTransport(
             url=self.url,
             request_capacity=self.request_capacity,
             response_capacity=self.response_capacity,
-            request_header_funcs=[generate_test_header1(test_context),
-                                  generate_test_header2(),
-                                  generate_test_header_empty()]
+            request_header_func=lambda: generate_test_header(test_context)
         )
         expected_headers = {
             'content-type': 'application/x-frugal',
@@ -131,8 +123,7 @@ class TestFHttpTransport(AsyncTestCase):
             'accept': 'application/x-frugal',
             'x-frugal-payload-limit': '200',
             'first-header': test_context.correlation_id,
-            'second-header': 'test2',
-            'third-header': 'test3'
+            'second-header': 'test',
         }
 
         transport_with_headers._http = self.http_mock

--- a/lib/python/frugal/tests/tornado/transport/test_http_transport.py
+++ b/lib/python/frugal/tests/tornado/transport/test_http_transport.py
@@ -26,7 +26,7 @@ from frugal.tornado.transport.http_transport import FHttpTransport
 
 
 class FHttpTransportWithContext(FHttpTransport):
-    def get_headers(self, fcontext):
+    def get_request_headers(self, fcontext):
         """
         override default implementation to add user supplied headers from FContext
         :param fcontext:
@@ -148,7 +148,7 @@ class TestFHttpTransport(AsyncTestCase):
         self.assertEqual(request.body, base64.b64encode(request_frame))
 
         expected_headers = self.headers
-        for header, value in self.transport_with_headers.get_headers(ctx).iteritems():
+        for header, value in self.transport_with_headers.get_request_headers(ctx).iteritems():
             if header is not None and value is not None:
                 expected_headers[header] = str(value)
         self.assertEqual(request.headers, expected_headers)

--- a/lib/python/frugal/tornado/transport/http_transport.py
+++ b/lib/python/frugal/tornado/transport/http_transport.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 class FHttpTransport(FTransportBase):
     def __init__(self, url, request_capacity=0, response_capacity=0,
-                 request_header_funcs=[]):
+                 request_header_func=None):
         """
         Create an HTTP transport.
 
@@ -38,10 +38,10 @@ class FHttpTransport(FTransportBase):
                               request. Set to 0 for no size restrictions.
             response_capacity: The maximum size allowed to be read in a
                                response. Set to 0 for no size restrictions.
-            request_header_funcs: An optional list of functions that
-                                  return a dictionary of request headers
-                                  to be added to the request. Set to
-                                  an empty list by default.
+            request_header_func: An optional lambda function that will
+                                 return a dictionary of request headers when
+                                 called to be added to the request. Set to
+                                 None by default.
         """
         super(FHttpTransport, self).__init__(
             request_size_limit=request_capacity)
@@ -50,8 +50,8 @@ class FHttpTransport(FTransportBase):
         self._headers = {}
 
         # Add user-supplied headers first to avoid removing the native headers
-        for func in request_header_funcs:
-            for header, value in func.iteritems():
+        if request_header_func is not None:
+            for header, value in request_header_func().iteritems():
                 if header is not None and value is not None:
                     self._headers[header] = value
 

--- a/lib/python/frugal/tornado/transport/http_transport.py
+++ b/lib/python/frugal/tornado/transport/http_transport.py
@@ -94,8 +94,7 @@ class FHttpTransport(FTransportBase):
         if self._get_request_headers is not None:
             request_headers = self._get_request_headers(context)
         # apply the default headers so their values cannot be modified
-        for header, value in self._headers.iteritems():
-            request_headers[header] = value
+        request_headers.update(self._headers)
 
         self._preflight_request_check(payload)
         encoded = base64.b64encode(payload)

--- a/lib/python/frugal/tornado/transport/http_transport.py
+++ b/lib/python/frugal/tornado/transport/http_transport.py
@@ -40,13 +40,13 @@ class FHttpTransport(FTransportBase):
                                response. Set to 0 for no size restrictions.
             get_request_headers: An optional function that accepts an FContext.
                                  Should return a dictionary of additional
-                                 request headers to be appended onto the request
+                                 request headers to be appended to the request
         """
         super(FHttpTransport, self).__init__(
             request_size_limit=request_capacity)
         self._url = url
         self._http = AsyncHTTPClient()
-        self.get_request_headers = get_request_headers
+        self._get_request_headers = get_request_headers
 
         # create headers
         self._headers = {
@@ -91,8 +91,8 @@ class FHttpTransport(FTransportBase):
         """
         # construct headers for request
         request_headers = {}
-        if self.get_request_headers is not None:
-            request_headers = self.get_request_headers(context)
+        if self._get_request_headers is not None:
+            request_headers = self._get_request_headers(context)
         # apply the default headers so their values cannot be modified
         for header, value in self._headers.iteritems():
             request_headers[header] = value

--- a/lib/python/frugal/tornado/transport/http_transport.py
+++ b/lib/python/frugal/tornado/transport/http_transport.py
@@ -27,7 +27,8 @@ logger = logging.getLogger(__name__)
 
 
 class FHttpTransport(FTransportBase):
-    def __init__(self, url, request_capacity=0, response_capacity=0):
+    def __init__(self, url, request_capacity=0, response_capacity=0,
+                 additional_headers=None):
         """
         Create an HTTP transport.
 
@@ -37,6 +38,9 @@ class FHttpTransport(FTransportBase):
                               request. Set to 0 for no size restrictions.
             response_capacity: The maximum size allowed to be read in a
                                response. Set to 0 for no size restrictions.
+            additional_headers: Additional headers to be appended onto
+                                the request. Set to None by default, expects
+                                a dict of key-value pairs
         """
         super(FHttpTransport, self).__init__(
             request_size_limit=request_capacity)
@@ -51,6 +55,10 @@ class FHttpTransport(FTransportBase):
         }
         if response_capacity > 0:
             self._headers['x-frugal-payload-limit'] = str(response_capacity)
+        # append additional provided headers
+        if additional_headers is not None:
+            for header, value in additional_headers.iteritems():
+                self._headers[header] = str(value)
 
         self._execute = None
 


### PR DESCRIPTION
added `get_request_header` function to tornado and asyncio's `FHttpTransport`.  By default it will not add any additional headers onto the request so existing implementation is not effected, but can be overridden by a consumer to append additional headers.

Addresses #920 and based off changes in #922 

