### PR TITLE
go: add WithRequestHeadersFromFContext to FHttpTransportBuilder

### DIFF
--- a/lib/go/http_transport.go
+++ b/lib/go/http_transport.go
@@ -324,20 +324,20 @@ func (h *fHTTPTransport) makeRequest(fCtx FContext, requestPayload []byte) ([]by
 	// add dynamic headers from fcontext first
 	if h.getRequestHeaders != nil {
 		for key, value := range h.getRequestHeaders(fCtx) {
-			request.Header.Add(key, value)
+			request.Header.Set(key, value)
 		}
 	}
 	// now add manually passed in request headers
 	if h.requestHeaders != nil {
 		for key, value := range h.requestHeaders {
-			request.Header.Add(key, value)
+			request.Header.Set(key, value)
 		}
 	}
 
 	// Add request headers
-	request.Header.Add(contentTypeHeader, frugalContentType)
-	request.Header.Add(acceptHeader, frugalContentType)
-	request.Header.Add(contentTransferEncodingHeader, base64Encoding)
+	request.Header.Set(contentTypeHeader, frugalContentType)
+	request.Header.Set(acceptHeader, frugalContentType)
+	request.Header.Set(contentTransferEncodingHeader, base64Encoding)
 	if h.responseSizeLimit > 0 {
 		request.Header.Add(payloadLimitHeader, strconv.FormatUint(uint64(h.responseSizeLimit), 10))
 	}

--- a/lib/go/http_transport.go
+++ b/lib/go/http_transport.go
@@ -138,6 +138,8 @@ func NewFrugalHandlerFunc(processor FProcessor, protocolFactory *FProtocolFactor
 	}
 }
 
+type GetHeadersWithContext func(FContext) map[string]string
+
 // FHTTPTransportBuilder configures and builds HTTP FTransport instances.
 type FHTTPTransportBuilder struct {
 	client            *http.Client
@@ -145,7 +147,7 @@ type FHTTPTransportBuilder struct {
 	requestSizeLimit  uint
 	responseSizeLimit uint
 	requestHeaders    map[string]string
-	getRequestHeaders func(FContext) map[string]string
+	getRequestHeaders GetHeadersWithContext
 }
 
 // NewFHTTPTransportBuilder creates a builder which configures and builds HTTP
@@ -181,7 +183,7 @@ func (h *FHTTPTransportBuilder) WithRequestHeaders(requestHeaders map[string]str
 // withRequestHeadersFromFContext adds custom request headers to each request
 // with a provided function that accepts an FContext and returns map of
 // string key-value pairs
-func (h *FHTTPTransportBuilder) WithRequestHeadersFromFContext(getRequestHeaders func(FContext) map[string]string) *FHTTPTransportBuilder {
+func (h *FHTTPTransportBuilder) WithRequestHeadersFromFContext(getRequestHeaders GetHeadersWithContext) *FHTTPTransportBuilder {
 	h.getRequestHeaders = getRequestHeaders
 	return h
 }
@@ -210,7 +212,7 @@ type fHTTPTransport struct {
 	responseSizeLimit uint
 	isOpen            bool
 	requestHeaders    map[string]string
-	getRequestHeaders func(FContext) map[string]string
+	getRequestHeaders GetHeadersWithContext
 }
 
 // Open initializes the transport for use.

--- a/lib/go/http_transport.go
+++ b/lib/go/http_transport.go
@@ -145,7 +145,7 @@ type FHTTPTransportBuilder struct {
 	requestSizeLimit  uint
 	responseSizeLimit uint
 	requestHeaders    map[string]string
-	getRequestHeaders func(map[string]string)
+	getRequestHeaders func(FContext) map[string]string
 }
 
 // NewFHTTPTransportBuilder creates a builder which configures and builds HTTP
@@ -181,7 +181,7 @@ func (h *FHTTPTransportBuilder) WithRequestHeaders(requestHeaders map[string]str
 // withRequestHeadersFromFContext adds custom request headers to each request
 // with a provided function that accepts an FContext and returns map of
 // string key-value pairs
-func (h *FHTTPTransportBuilder) WithRequestHeadersFromFContext(getRequestHeaders func(map[string]string)) *FHTTPTransportBuilder {
+func (h *FHTTPTransportBuilder) WithRequestHeadersFromFContext(getRequestHeaders func(FContext) map[string]string) *FHTTPTransportBuilder {
 	h.getRequestHeaders = getRequestHeaders
 	return h
 }
@@ -210,7 +210,7 @@ type fHTTPTransport struct {
 	responseSizeLimit uint
 	isOpen            bool
 	requestHeaders    map[string]string
-	getRequestHeaders func(map[string]string)
+	getRequestHeaders func(FContext) map[string]string
 }
 
 // Open initializes the transport for use.


### PR DESCRIPTION
go equivalent of recent python changes - https://github.com/Workiva/frugal/pull/928

Allows consumer to pass in a function that accepts an FContext.  This function should return additional request headers to be appended on a per-request basis.

Also fixes issue where default request headers would not have been overwritten.  `http.Header.Add` will append to existing headers, not overwrite them.

@Workiva/messaging-pp