### PR TITLE
dart: add getRequestHeaders param to FHttpTransport

### DIFF
--- a/lib/dart/lib/src/frugal/transport/f_http_transport.dart
+++ b/lib/dart/lib/src/frugal/transport/f_http_transport.dart
@@ -13,6 +13,9 @@
 
 part of frugal.src.frugal;
 
+/// typedef for passed in function that generates headers given an [FContext]
+typedef Map<String, String> GetHeadersWithContext(FContext ctx);
+
 /// An [FTransport] that makes frugal requests via HTTP.
 class FHttpTransport extends FTransport {
   /// HTTP status code for an unauthorized reqeuest.
@@ -37,7 +40,7 @@ class FHttpTransport extends FTransport {
 
   /// Function that accepts an FContext that should return a Map<String, String>
   /// of headers to be added to every request
-  var _getRequestHeaders;
+  final GetHeadersWithContext _getRequestHeaders;
 
   /// Create an [FHttpTransport] instance with the given w_transport [Client],
   /// uri, and optional size restrictions, and headers.
@@ -56,8 +59,9 @@ class FHttpTransport extends FTransport {
       {int requestSizeLimit: 0,
       this.responseSizeLimit: 0,
       Map<String, String> additionalHeaders,
-      var getRequestHeaders: null})
-      : super(requestSizeLimit: requestSizeLimit) {
+      GetHeadersWithContext getRequestHeaders: null})
+      : _getRequestHeaders = getRequestHeaders,
+        super(requestSizeLimit: requestSizeLimit) {
     _headers = additionalHeaders ?? {};
     // add and potentially overwrite with default headers
     _headers.addAll({
@@ -68,8 +72,6 @@ class FHttpTransport extends FTransport {
     if (responseSizeLimit > 0) {
       _headers['x-frugal-payload-limit'] = responseSizeLimit.toString();
     }
-
-    _getRequestHeaders = getRequestHeaders;
   }
 
   @override

--- a/lib/dart/lib/src/frugal/transport/f_http_transport.dart
+++ b/lib/dart/lib/src/frugal/transport/f_http_transport.dart
@@ -35,6 +35,10 @@ class FHttpTransport extends FTransport {
 
   Map<String, String> _headers;
 
+  /// Function that accepts an FContext that should return a Map<String, String>
+  /// of headers to be added to every request
+  var _getRequestHeaders;
+
   /// Create an [FHttpTransport] instance with the given w_transport [Client],
   /// uri, and optional size restrictions, and headers.
   ///
@@ -44,18 +48,28 @@ class FHttpTransport extends FTransport {
   ///   * accept
   ///   * x-frugal-payload-limit
   /// headers will be overwritten.
+  ///
+  /// Additionally, a function that accepts an FContext can be passed in
+  /// that should return additional headers to be appended to each request
+  /// using the getRequestHeaders param.
   FHttpTransport(this.client, this.uri,
       {int requestSizeLimit: 0,
       this.responseSizeLimit: 0,
-      Map<String, String> additionalHeaders})
+      Map<String, String> additionalHeaders,
+      var getRequestHeaders: null})
       : super(requestSizeLimit: requestSizeLimit) {
     _headers = additionalHeaders ?? {};
-    _headers['content-type'] = 'application/x-frugal';
-    _headers['content-transfer-encoding'] = 'base64';
-    _headers['accept'] = 'application/x-frugal';
+    // add and potentially overwrite with default headers
+    _headers.addAll({
+      'content-type': 'application/x-frugal',
+      'content-transfer-encoding': 'base64',
+      'accept': 'application/x-frugal'
+    });
     if (responseSizeLimit > 0) {
       _headers['x-frugal-payload-limit'] = responseSizeLimit.toString();
     }
+
+    _getRequestHeaders = getRequestHeaders;
   }
 
   @override
@@ -76,12 +90,17 @@ class FHttpTransport extends FTransport {
   Future<TTransport> request(FContext ctx, Uint8List payload) async {
     _preflightRequestCheck(payload);
 
+    // append dynamic headers first
+    Map<String, String> requestHeaders = _getRequestHeaders(ctx) ?? {};
+    // add and potentially overwrite with default headers
+    requestHeaders.addAll(_headers);
+
     // Encode request payload
     var requestBody = BASE64.encode(payload);
 
     // Configure the request
     wt.Request request = client.newRequest()
-      ..headers = _headers
+      ..headers = requestHeaders
       ..uri = uri
       ..body = requestBody;
 

--- a/lib/dart/lib/src/frugal/transport/f_http_transport.dart
+++ b/lib/dart/lib/src/frugal/transport/f_http_transport.dart
@@ -60,7 +60,7 @@ class FHttpTransport extends FTransport {
       this.responseSizeLimit: 0,
       Map<String, String> additionalHeaders,
       GetHeadersWithContext getRequestHeaders: null})
-      : _getRequestHeaders = getRequestHeaders ?? ((fcontext) => {}),
+      : _getRequestHeaders = getRequestHeaders ?? ((_) => {}),
         super(requestSizeLimit: requestSizeLimit) {
     _headers = additionalHeaders ?? {};
     // add and potentially overwrite with default headers

--- a/lib/dart/lib/src/frugal/transport/f_http_transport.dart
+++ b/lib/dart/lib/src/frugal/transport/f_http_transport.dart
@@ -60,7 +60,7 @@ class FHttpTransport extends FTransport {
       this.responseSizeLimit: 0,
       Map<String, String> additionalHeaders,
       GetHeadersWithContext getRequestHeaders: null})
-      : _getRequestHeaders = getRequestHeaders,
+      : _getRequestHeaders = getRequestHeaders ?? ((fcontext) => {}),
         super(requestSizeLimit: requestSizeLimit) {
     _headers = additionalHeaders ?? {};
     // add and potentially overwrite with default headers
@@ -93,8 +93,7 @@ class FHttpTransport extends FTransport {
     _preflightRequestCheck(payload);
 
     // append dynamic headers first
-    Map<String, String> requestHeaders =
-        _getRequestHeaders != null ? _getRequestHeaders(ctx) : {};
+    Map<String, String> requestHeaders = _getRequestHeaders(ctx);
     // add and potentially overwrite with default headers
     requestHeaders.addAll(_headers);
 

--- a/lib/dart/lib/src/frugal/transport/f_http_transport.dart
+++ b/lib/dart/lib/src/frugal/transport/f_http_transport.dart
@@ -91,7 +91,8 @@ class FHttpTransport extends FTransport {
     _preflightRequestCheck(payload);
 
     // append dynamic headers first
-    Map<String, String> requestHeaders = _getRequestHeaders(ctx) ?? {};
+    Map<String, String> requestHeaders =
+        _getRequestHeaders != null ? _getRequestHeaders(ctx) : {};
     // add and potentially overwrite with default headers
     requestHeaders.addAll(_headers);
 


### PR DESCRIPTION
dart equivalent of recent python changes - https://github.com/Workiva/frugal/pull/928

Allows consumer to pass in a function that accepts an FContext using the `getRequestHeaders` parameter.  This function should return additional request headers to be appended on a per-request basis.

@Workiva/messaging-pp