### PR TITLE
Move multidict requirement to asyncio extras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,10 @@ test/integration/python/tornado/gen-py
 test/integration/python/tornado/gen_py_tornado
 test/integration/python/asyncio/gen_py_asyncio
 
+# test reports
+unit_tests_py2.xml
+unit_tests_std_py2.xml
+unit_tests_py3.xml
+
 # Cross-compiled code
 pkg/

--- a/lib/python/Makefile
+++ b/lib/python/Makefile
@@ -4,6 +4,8 @@ PIP := pip
 EXCLUDE_GAE := --exclude-dir=frugal/gae --exclude-dir=frugal/tests/gae
 EXCLUDE_TORNADO := --exclude-dir=frugal/tornado --exclude-dir=frugal/tests/tornado
 EXCLUDE_AIO := --exclude-dir=frugal/aio --exclude-dir=frugal/tests/aio
+COVER := --with-coverage --cover-package=frugal
+LEVEL := --logging-level=ERROR
 
 all: deps
 
@@ -35,19 +37,19 @@ flake8-py3:
 	flake8 --exclude=tests,frugal/tornado,build
 
 unit-py2:
-	nosetests --exclude-dir=frugal/aio --exclude-dir=frugal/tests/aio --logging-level=ERROR --with-coverage --cover-package=frugal
+	nosetests $(EXCLUDE_AIO) $(LEVEL) $(COVER)
 
 unit-py3:
-	nosetests --exclude-dir=frugal/tornado --exclude-dir=frugal/tests/tornado --exclude-dir=frugal/gae --exclude-dir=frugal/tests/gae --logging-level=ERROR --with-coverage --cover-package=frugal
+	nosetests $(EXCLUDE_TORNADO) $(EXCLUDE_GAE) $(LEVEL) $(COVER)
 
 xunit-py2:
-	nosetests --exclude-dir=frugal/aio --exclude-dir=frugal/tests/aio --logging-level=ERROR --with-coverage --cover-package=frugal --with-xunit --xunit-file=unit_tests_py2.xml
+	nosetests $(EXCLUDE_AIO) $(LEVEL) $(COVER) --with-xunit --xunit-file=unit_tests_py2.xml
 
 xunit-py3:
-	nosetests --exclude-dir=frugal/tornado --exclude-dir=frugal/tests/tornado --exclude-dir=frugal/gae --exclude-dir=frugal/tests/gae --logging-level=ERROR --with-coverage --cover-package=frugal --with-xunit --xunit-file=unit_tests_py3.xml
+	nosetests $(EXCLUDE_TORNADO) $(EXCLUDE_GAE) $(LEVEL) $(COVER) --with-xunit --xunit-file=unit_tests_py3.xml
 
 xunit-std-py2:
-	nosetests $(EXCLUDE_GAE) $(EXCLUDE_TORNADO) $(EXCLUDE_AIO) --logging-level=ERROR --with-coverage --cover-package=frugal --with-xunit --xunit-file=unit_tests_std_py2.xml
+	nosetests $(EXCLUDE_GAE) $(EXCLUDE_TORNADO) $(EXCLUDE_AIO) $(LEVEL) $(COVER) --with-xunit --xunit-file=unit_tests_std_py2.xml
 
 
 install:

--- a/lib/python/Makefile
+++ b/lib/python/Makefile
@@ -1,6 +1,9 @@
 SHELL := /bin/bash
 PYTHON := python
 PIP := pip
+EXCLUDE_GAE := --exclude-dir=frugal/gae --exclude-dir=frugal/tests/gae
+EXCLUDE_TORNADO := --exclude-dir=frugal/tornado --exclude-dir=frugal/tests/tornado
+EXCLUDE_AIO := --exclude-dir=frugal/aio --exclude-dir=frugal/tests/aio
 
 all: deps
 
@@ -26,10 +29,10 @@ sniffer:
 	sniffer -x--with-doctest -x--logging-level=ERROR -x--with-coverage -x--cover-package=frugal
 
 flake8-py2:
-	flake8 --exclude=tests,frugal/aio
+	flake8 --exclude=tests,frugal/aio,build
 
 flake8-py3:
-	flake8 --exclude=tests,frugal/tornado
+	flake8 --exclude=tests,frugal/tornado,build
 
 unit-py2:
 	nosetests --exclude-dir=frugal/aio --exclude-dir=frugal/tests/aio --logging-level=ERROR --with-coverage --cover-package=frugal
@@ -42,6 +45,10 @@ xunit-py2:
 
 xunit-py3:
 	nosetests --exclude-dir=frugal/tornado --exclude-dir=frugal/tests/tornado --exclude-dir=frugal/gae --exclude-dir=frugal/tests/gae --logging-level=ERROR --with-coverage --cover-package=frugal --with-xunit --xunit-file=unit_tests_py3.xml
+
+xunit-std-py2:
+	nosetests $(EXCLUDE_GAE) $(EXCLUDE_TORNADO) $(EXCLUDE_AIO) --logging-level=ERROR --with-coverage --cover-package=frugal --with-xunit --xunit-file=unit_tests_std_py2.xml
+
 
 install:
 	$(PYTHON) setup.py sdist

--- a/lib/python/frugal/tests/aio/server/test_http_handler.py
+++ b/lib/python/frugal/tests/aio/server/test_http_handler.py
@@ -12,8 +12,9 @@
 import base64
 import mock
 
-from aiohttp import test_utils, CIMultiDict
+from aiohttp import test_utils
 from aiohttp.streams import StreamReader
+from multidict import CIMultiDict
 from thrift.protocol import TBinaryProtocol
 
 from frugal.protocol import FProtocolFactory

--- a/lib/python/requirements.txt
+++ b/lib/python/requirements.txt
@@ -1,4 +1,3 @@
-multidict==1.1.0
 six==1.10.0
 thrift==0.10.0
 requests==2.12.5

--- a/lib/python/requirements_dev_asyncio.txt
+++ b/lib/python/requirements_dev_asyncio.txt
@@ -1,5 +1,6 @@
 asyncio-nats-client==0.6.0
-aiohttp==0.22.3
+multidict==3.3.0
+aiohttp==2.3.1
 async-timeout==1.1.0
 
 -r requirements_dev_common.txt

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -22,7 +22,6 @@ setup(
     url='http://github.com/Workiva/frugal',
     packages=find_packages(exclude=('frugal.tests', 'frugal.tests.*')),
     install_requires=[
-        "multidict==1.1.0",
         "six==1.10.0",
         "thrift==0.10.0",
         "requests==2.12.5",
@@ -30,7 +29,8 @@ setup(
     extras_require={
         'tornado': ["nats-client==0.5.0"],
         'asyncio': ["async-timeout==1.1.0", "asyncio-nats-client==0.6.0",
-                    "aiohttp==0.22.3"],
+                    "multidict==3.3.0",
+                    "aiohttp==2.3.1"],
         'gae': ["webapp2==2.5.2"],
     }
 )

--- a/scripts/skynet/cross/setup_python.sh
+++ b/scripts/skynet/cross/setup_python.sh
@@ -11,4 +11,5 @@ else
 fi
 
 pip install -e ".[tornado]"
+python3.5 /usr/bin/pip3 install Cython==0.27.2
 python3.5 /usr/bin/pip3 install -e ".[asyncio]"

--- a/test/integration/python/asyncio/client.py
+++ b/test/integration/python/asyncio/client.py
@@ -51,7 +51,7 @@ async def main():
     elif args.transport_type == "http":
         # Set request and response capacity to 1mb
         max_size = 1048576
-        transport = FHttpTransport("http://localhost:{port}".format(
+        transport = FHttpTransport("http://127.0.0.1:{port}".format(
             port=args.port), request_capacity=max_size,
             response_capacity=max_size)
     else:

--- a/test/integration/python/common/utils.py
+++ b/test/integration/python/common/utils.py
@@ -58,7 +58,9 @@ def check_for_failure(actual, expected):
         except Exception:
             failed = True
     elif isinstance(expected, TTransportException):
-        if actual.type != expected.type:
+        if not isinstance(actual, TTransportException):
+            failed = True
+        elif actual.type != expected.type:
             failed = True
     elif isinstance(expected, Numberz):
         if type(actual) != type(expected):


### PR DESCRIPTION
This isolates the issue fix from https://github.com/Workiva/frugal/pull/930. I'll wait on adding the changes to the skynet cross tests until the switch from Godeps is complete. One of the cross test changes is to make it output a csv table with all the variables and outcome of each client/server combination test. It makes it so you can quickly find the factors associated with failures and would have made finding this fix a lot faster.

Move multidict to its proper place in asyncio extras

Fix issue where integration test couldn't handle some exceptions

Work around bug in aiohttp

Pull requests should be made against the 'develop' branch, not master.

@Workiva/messaging-pp