### PR TITLE
dart: exposes GetHeadersWithContext

### DIFF
--- a/lib/dart/lib/frugal.dart
+++ b/lib/dart/lib/frugal.dart
@@ -36,6 +36,7 @@ export 'src/frugal.dart'
         FTransportMonitor,
         FrugalTApplicationErrorType,
         FrugalTTransportErrorType,
+        GetHeadersWithContext,
         InvocationHandler,
         Middleware,
         TMemoryOutputBuffer,


### PR DESCRIPTION
GetHeadersWithContext was not exposed in #934 

@Workiva/messaging-pp 