### PR TITLE
[WIP] Inner provider middleware

### DIFF
--- a/compiler/generator/golang/generator.go
+++ b/compiler/generator/golang/generator.go
@@ -1248,7 +1248,8 @@ func (g *Generator) GeneratePublisher(file *os.File, scope *parser.Scope) error 
 	publisher += "\t\tprotocolFactory:  protocolFactory,\n"
 	publisher += "\t\tmethods:   methods,\n"
 	publisher += "\t}\n"
-	publisher += "\tmiddleware = append(middleware, provider.GetMiddleware()...)\n"
+	publisher += "\tmiddleware = append(provider.GetInnerMiddleware(), middleware...)\n"
+	publisher += "\tmiddleware = append(middleware, provider.GetOuterMiddleware()...)\n"
 	for _, op := range scope.Operations {
 		publisher += fmt.Sprintf("\tmethods[\"publish%s\"] = frugal.NewMethod(publisher, publisher.publish%s, \"publish%s\", middleware)\n",
 			op.Name, op.Name, op.Name)
@@ -1405,13 +1406,15 @@ func (g *Generator) GenerateSubscriber(file *os.File, scope *parser.Scope) error
 
 	subscriber += fmt.Sprintf("func New%sSubscriber(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) %sSubscriber {\n",
 		scopeCamel, scopeCamel)
-	subscriber += "\tmiddleware = append(middleware, provider.GetMiddleware()...)\n"
+	subscriber += "\tmiddleware = append(provider.GetInnerMiddleware(), middleware...)\n"
+	subscriber += "\tmiddleware = append(middleware, provider.GetOuterMiddleware()...)\n"
 	subscriber += fmt.Sprintf("\treturn &%sSubscriber{provider: provider, middleware: middleware}\n", scopeLower)
 	subscriber += "}\n\n"
 
 	subscriber += fmt.Sprintf("func New%sErrorableSubscriber(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) %sErrorableSubscriber {\n",
 		scopeCamel, scopeCamel)
-	subscriber += "\tmiddleware = append(middleware, provider.GetMiddleware()...)\n"
+	subscriber += "\tmiddleware = append(provider.GetInnerMiddleware(), middleware...)\n"
+	subscriber += "\tmiddleware = append(middleware, provider.GetOuterMiddleware()...)\n"
 	subscriber += fmt.Sprintf("\treturn &%sSubscriber{provider: provider, middleware: middleware}\n", scopeLower)
 	subscriber += "}\n\n"
 
@@ -1599,7 +1602,8 @@ func (g *Generator) generateClient(service *parser.Service) string {
 	contents += "\t\tprotocolFactory: provider.GetProtocolFactory(),\n"
 	contents += "\t\tmethods:         methods,\n"
 	contents += "\t}\n"
-	contents += "\tmiddleware = append(middleware, provider.GetMiddleware()...)\n"
+	contents += "\tmiddleware = append(provider.GetInnerMiddleware(), middleware...)\n"
+	contents += "\tmiddleware = append(middleware, provider.GetOuterMiddleware()...)\n"
 	for _, method := range service.Methods {
 		name := parser.LowercaseFirstLetter(method.Name)
 		contents += fmt.Sprintf("\tmethods[\"%s\"] = frugal.NewMethod(client, client.%s, \"%s\", middleware)\n", name, name, name)

--- a/lib/go/provider.go
+++ b/lib/go/provider.go
@@ -38,6 +38,7 @@ func NewFScopeProvider(pub FPublisherTransportFactory, sub FSubscriberTransportF
 }
 
 // NewFScopeProvider2
+// TODO better name
 func NewFScopeProvider2(pub FPublisherTransportFactory, sub FSubscriberTransportFactory,
 	prot *FProtocolFactory, outerMiddleware []ServiceMiddleware, innerMiddleware []ServiceMiddleware) *FScopeProvider {
 	return &FScopeProvider{
@@ -89,7 +90,8 @@ func (p *FScopeProvider) GetInnerMiddleware() []ServiceMiddleware {
 type FServiceProvider struct {
 	transport       FTransport
 	protocolFactory *FProtocolFactory
-	middleware      []ServiceMiddleware
+	outerMiddleware      []ServiceMiddleware
+	innerMiddleware []ServiceMiddleware
 }
 
 // NewFServiceProvider creates a new FServiceProvider containing the given
@@ -98,7 +100,20 @@ func NewFServiceProvider(transport FTransport, protocolFactory *FProtocolFactory
 	return &FServiceProvider{
 		transport:       transport,
 		protocolFactory: protocolFactory,
-		middleware:      middleware,
+		outerMiddleware: middleware,
+		innerMiddleware: []ServiceMiddleware{},
+	}
+}
+
+// NewFServiceProvider2
+// TODO better name
+func NewFServiceProvider2(transport FTransport, prot *FProtocolFactory,
+	outerMiddleware []ServiceMiddleware, innerMiddleware []ServiceMiddleware) *FServiceProvider {
+	return &FServiceProvider{
+		transport: transport,
+		protocolFactory: prot,
+		outerMiddleware: outerMiddleware,
+		innerMiddleware: innerMiddleware,
 	}
 }
 
@@ -113,8 +128,21 @@ func (f *FServiceProvider) GetProtocolFactory() *FProtocolFactory {
 }
 
 // GetMiddleware returns the ServiceMiddleware stored on this FServiceProvider.
-func (f *FServiceProvider) GetMiddleware() []ServiceMiddleware {
-	middleware := make([]ServiceMiddleware, len(f.middleware))
-	copy(middleware, f.middleware)
+// DEPRECATED: replaced by GetOuterMiddleware() for more specificity
+func (p *FServiceProvider) GetMiddleware() []ServiceMiddleware {
+	return p.GetMiddleware()
+}
+
+// GetOuterMiddleware
+func (p *FServiceProvider) GetOuterMiddleware() []ServiceMiddleware {
+	middleware := make([]ServiceMiddleware, len(p.outerMiddleware))
+	copy(middleware, p.outerMiddleware)
+	return middleware
+}
+
+// GetInnerMiddleware
+func (p *FServiceProvider) GetInnerMiddleware() []ServiceMiddleware {
+	middleware := make([]ServiceMiddleware, len(p.innerMiddleware))
+	copy(middleware, p.innerMiddleware)
 	return middleware
 }

--- a/lib/go/provider.go
+++ b/lib/go/provider.go
@@ -21,7 +21,8 @@ type FScopeProvider struct {
 	publisherTransportFactory  FPublisherTransportFactory
 	subscriberTransportFactory FSubscriberTransportFactory
 	protocolFactory            *FProtocolFactory
-	middleware                 []ServiceMiddleware
+	outerMiddleware            []ServiceMiddleware
+	innerMiddleware            []ServiceMiddleware
 }
 
 // NewFScopeProvider creates a new FScopeProvider using the given factories.
@@ -31,7 +32,20 @@ func NewFScopeProvider(pub FPublisherTransportFactory, sub FSubscriberTransportF
 		publisherTransportFactory:  pub,
 		subscriberTransportFactory: sub,
 		protocolFactory:            prot,
-		middleware:                 middleware,
+		outerMiddleware:            middleware,
+		innerMiddleware:            []ServiceMiddleware{},
+	}
+}
+
+// NewFScopeProvider2
+func NewFScopeProvider2(pub FPublisherTransportFactory, sub FSubscriberTransportFactory,
+	prot *FProtocolFactory, outerMiddleware []ServiceMiddleware, innerMiddleware []ServiceMiddleware) *FScopeProvider {
+	return &FScopeProvider{
+		publisherTransportFactory: pub,
+		subscriberTransportFactory: sub,
+		protocolFactory: prot,
+		outerMiddleware: outerMiddleware,
+		innerMiddleware: innerMiddleware,
 	}
 }
 
@@ -50,9 +64,22 @@ func (p *FScopeProvider) NewSubscriber() (FSubscriberTransport, *FProtocolFactor
 }
 
 // GetMiddleware returns the ServiceMiddleware stored on this FScopeProvider.
+// DEPRECATED: replaced by GetOuterMiddleware() for more specificity
 func (p *FScopeProvider) GetMiddleware() []ServiceMiddleware {
-	middleware := make([]ServiceMiddleware, len(p.middleware))
-	copy(middleware, p.middleware)
+	return p.GetMiddleware()
+}
+
+// GetOuterMiddleware
+func (p *FScopeProvider) GetOuterMiddleware() []ServiceMiddleware {
+	middleware := make([]ServiceMiddleware, len(p.outerMiddleware))
+	copy(middleware, p.outerMiddleware)
+	return middleware
+}
+
+// GetInnerMiddleware
+func (p *FScopeProvider) GetInnerMiddleware() []ServiceMiddleware {
+	middleware := make([]ServiceMiddleware, len(p.innerMiddleware))
+	copy(middleware, p.innerMiddleware)
 	return middleware
 }
 

--- a/test/expected/go/actual_base/f_basefoo_service.txt
+++ b/test/expected/go/actual_base/f_basefoo_service.txt
@@ -35,7 +35,8 @@ func NewFBaseFooClient(provider *frugal.FServiceProvider, middleware ...frugal.S
 		protocolFactory: provider.GetProtocolFactory(),
 		methods:         methods,
 	}
-	middleware = append(middleware, provider.GetMiddleware()...)
+	middleware = append(provider.GetInnerMiddleware(), middleware...)
+	middleware = append(middleware, provider.GetOuterMiddleware()...)
 	methods["basePing"] = frugal.NewMethod(client, client.basePing, "basePing", middleware)
 	return client
 }

--- a/test/expected/go/variety/f_events_scope.txt
+++ b/test/expected/go/variety/f_events_scope.txt
@@ -38,7 +38,8 @@ func NewEventsPublisher(provider *frugal.FScopeProvider, middleware ...frugal.Se
 		protocolFactory: protocolFactory,
 		methods:         methods,
 	}
-	middleware = append(middleware, provider.GetMiddleware()...)
+	middleware = append(provider.GetInnerMiddleware(), middleware...)
+	middleware = append(middleware, provider.GetOuterMiddleware()...)
 	methods["publishEventCreated"] = frugal.NewMethod(publisher, publisher.publishEventCreated, "publishEventCreated", middleware)
 	methods["publishSomeInt"] = frugal.NewMethod(publisher, publisher.publishSomeInt, "publishSomeInt", middleware)
 	methods["publishSomeStr"] = frugal.NewMethod(publisher, publisher.publishSomeStr, "publishSomeStr", middleware)
@@ -232,12 +233,14 @@ type eventsSubscriber struct {
 }
 
 func NewEventsSubscriber(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) EventsSubscriber {
-	middleware = append(middleware, provider.GetMiddleware()...)
+	middleware = append(provider.GetInnerMiddleware(), middleware...)
+	middleware = append(middleware, provider.GetOuterMiddleware()...)
 	return &eventsSubscriber{provider: provider, middleware: middleware}
 }
 
 func NewEventsErrorableSubscriber(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) EventsErrorableSubscriber {
-	middleware = append(middleware, provider.GetMiddleware()...)
+	middleware = append(provider.GetInnerMiddleware(), middleware...)
+	middleware = append(middleware, provider.GetOuterMiddleware()...)
 	return &eventsSubscriber{provider: provider, middleware: middleware}
 }
 

--- a/test/expected/go/variety/f_foo_service.txt
+++ b/test/expected/go/variety/f_foo_service.txt
@@ -59,7 +59,8 @@ func NewFFooClient(provider *frugal.FServiceProvider, middleware ...frugal.Servi
 		protocolFactory: provider.GetProtocolFactory(),
 		methods:         methods,
 	}
-	middleware = append(middleware, provider.GetMiddleware()...)
+	middleware = append(provider.GetInnerMiddleware(), middleware...)
+	middleware = append(middleware, provider.GetOuterMiddleware()...)
 	methods["ping"] = frugal.NewMethod(client, client.ping, "ping", middleware)
 	methods["blah"] = frugal.NewMethod(client, client.blah, "blah", middleware)
 	methods["oneWay"] = frugal.NewMethod(client, client.oneWay, "oneWay", middleware)

--- a/test/expected/go/variety_async/f_foo_service.txt
+++ b/test/expected/go/variety_async/f_foo_service.txt
@@ -59,7 +59,8 @@ func NewFFooClient(provider *frugal.FServiceProvider, middleware ...frugal.Servi
 		protocolFactory: provider.GetProtocolFactory(),
 		methods:         methods,
 	}
-	middleware = append(middleware, provider.GetMiddleware()...)
+	middleware = append(provider.GetInnerMiddleware(), middleware...)
+	middleware = append(middleware, provider.GetOuterMiddleware()...)
 	methods["ping"] = frugal.NewMethod(client, client.ping, "ping", middleware)
 	methods["blah"] = frugal.NewMethod(client, client.blah, "blah", middleware)
 	methods["oneWay"] = frugal.NewMethod(client, client.oneWay, "oneWay", middleware)

--- a/test/expected/go/vendor/f_myscope_scope.txt
+++ b/test/expected/go/vendor/f_myscope_scope.txt
@@ -33,7 +33,8 @@ func NewMyScopePublisher(provider *frugal.FScopeProvider, middleware ...frugal.S
 		protocolFactory: protocolFactory,
 		methods:         methods,
 	}
-	middleware = append(middleware, provider.GetMiddleware()...)
+	middleware = append(provider.GetInnerMiddleware(), middleware...)
+	middleware = append(middleware, provider.GetOuterMiddleware()...)
 	methods["publishnewItem"] = frugal.NewMethod(publisher, publisher.publishnewItem, "publishnewItem", middleware)
 	return publisher
 }
@@ -92,12 +93,14 @@ type myScopeSubscriber struct {
 }
 
 func NewMyScopeSubscriber(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) MyScopeSubscriber {
-	middleware = append(middleware, provider.GetMiddleware()...)
+	middleware = append(provider.GetInnerMiddleware(), middleware...)
+	middleware = append(middleware, provider.GetOuterMiddleware()...)
 	return &myScopeSubscriber{provider: provider, middleware: middleware}
 }
 
 func NewMyScopeErrorableSubscriber(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) MyScopeErrorableSubscriber {
-	middleware = append(middleware, provider.GetMiddleware()...)
+	middleware = append(provider.GetInnerMiddleware(), middleware...)
+	middleware = append(middleware, provider.GetOuterMiddleware()...)
 	return &myScopeSubscriber{provider: provider, middleware: middleware}
 }
 

--- a/test/expected/go/vendor/f_myservice_service.txt
+++ b/test/expected/go/vendor/f_myservice_service.txt
@@ -37,7 +37,8 @@ func NewFMyServiceClient(provider *frugal.FServiceProvider, middleware ...frugal
 		protocolFactory: provider.GetProtocolFactory(),
 		methods:         methods,
 	}
-	middleware = append(middleware, provider.GetMiddleware()...)
+	middleware = append(provider.GetInnerMiddleware(), middleware...)
+	middleware = append(middleware, provider.GetOuterMiddleware()...)
 	methods["getItem"] = frugal.NewMethod(client, client.getItem, "getItem", middleware)
 	return client
 }


### PR DESCRIPTION
A use case has come up where potentially sensitive information should be stripped from an FContext on a publish call, as that can potentially get back to clients. This could be done easily in an enforced middleware, but would need a slightly different pattern than is currently supported.

Currently we only allow enforced middleware to be the outermost middleware, while we would want this middleware to be at the innermost level, so other middleware couldn't add it back.

This seemed like the best solution, as it accomplishes the goal in an easy to consume way and shouldn't break anything.

TODO if this gets approval add to other languages

@Workiva/messaging-pp @tylertreat @brettkail-wk 