### PR TITLE
Java: Use ExecutorService.execute instead of submit if Future is unused

### DIFF
--- a/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
@@ -267,7 +267,7 @@ public class FNatsServer implements FServer {
                 return;
             }
 
-            executorService.submit(
+            executorService.execute(
                     new Request(message.getData(), System.currentTimeMillis(), message.getReplyTo(),
                             highWatermark, inputProtoFactory, outputProtoFactory, processor, conn));
         };

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FAdapterTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FAdapterTransport.java
@@ -82,7 +82,7 @@ public class FAdapterTransport extends FAsyncTransport {
         }
 
         readExecutor = executorFactory.newExecutor();
-        readExecutor.submit(newTransportReader());
+        readExecutor.execute(newTransportReader());
         super.open();
     }
 

--- a/lib/java/src/test/java/com/workiva/frugal/server/FNatsServerTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/server/FNatsServerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -107,8 +108,6 @@ public class FNatsServerTest {
     @Test
     public void testRequestHandler() {
         ExecutorService executor = mock(ExecutorService.class);
-        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
-        when(executor.submit(captor.capture())).thenReturn(null);
         FNatsServer server =
                 new FNatsServer.Builder(mockConn, mockProcessor, mockProtocolFactory, new String[]{subject})
                         .withExecutorService(executor).build();
@@ -119,7 +118,8 @@ public class FNatsServerTest {
 
         handler.onMessage(msg);
 
-        verify(executor).submit(captor.getValue());
+        ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(executor).execute(captor.capture());
         assertEquals(FNatsServer.Request.class, captor.getValue().getClass());
         FNatsServer.Request request = (FNatsServer.Request) captor.getValue();
         assertArrayEquals(data, request.frameBytes);
@@ -134,7 +134,6 @@ public class FNatsServerTest {
     @Test
     public void testRequestHandler_noReply() {
         ExecutorService executor = mock(ExecutorService.class);
-        when(executor.submit(any(Runnable.class))).thenReturn(null);
         FNatsServer server =
                 new FNatsServer.Builder(mockConn, mockProcessor, mockProtocolFactory, new String[]{subject})
                 .withExecutorService(executor).build();
@@ -144,7 +143,7 @@ public class FNatsServerTest {
 
         handler.onMessage(msg);
 
-        verify(executor, times(0)).submit(any(Runnable.class));
+        verifyNoMoreInteractions(executor);
     }
 
     @Test

--- a/lib/java/src/test/java/com/workiva/frugal/transport/FAdapterTransportTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/transport/FAdapterTransportTest.java
@@ -86,7 +86,7 @@ public class FAdapterTransportTest {
         tr.open();
 
         verify(mockExecutorFactory).newExecutor();
-        verify(mockExecutor).submit(any(Runnable.class));
+        verify(mockExecutor).execute(any(Runnable.class));
 
         assertTrue(tr.isOpen());
 


### PR DESCRIPTION
If an exception is thrown from a task passed to `ExecutorService.submit`, the exception is captured in the returned `Future`.  If the `Future` is ignored, the exception message+stack is lost, which is problematic if `Error` is thrown from a request processor.  Use `ExecutorService.execute` in those cases, which allows the default exception handler to print the exception message+stack.

@Workiva/messaging-pp 
