### PR TITLE
dart: Add deprecated comment to abstract classes

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1464,7 +1464,10 @@ func (g *Generator) generateInterface(service *parser.Service) string {
 			contents += g.GenerateInlineComment(method.Comment, tab+"/")
 		}
 
-		if _, ok := method.Annotations.Deprecated(); ok {
+		if deprecationValue, deprecated := method.Annotations.Deprecated(); deprecated {
+			if deprecationValue != "" {
+				contents += g.GenerateInlineComment([]string{"Deprecated: "+deprecationValue}, tab+"/")
+			}
 			contents += tab + "@deprecated\n"
 		}
 
@@ -1547,10 +1550,9 @@ func (g *Generator) generateClientMethod(service *parser.Service, method *parser
 	deprecationValue, deprecated := method.Annotations.Deprecated()
 	if deprecated {
 		if deprecationValue != "" {
-			contents += fmt.Sprintf(tab+"@Deprecated(\"%s\")\n", deprecationValue)
-		} else {
-			contents += tab + "@deprecated\n"
+			contents += g.GenerateInlineComment([]string{"Deprecated: "+deprecationValue}, tab+"/")
 		}
+		contents += tab + "@deprecated\n"
 	}
 
 	// Generate wrapper method

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -22,6 +22,7 @@ import 'package:variety/variety.dart' as t_variety;
 abstract class FFoo extends t_actual_base_dart.FBaseFoo {
 
   /// Ping the server.
+  /// Deprecated: use something else
   @deprecated
   Future ping(frugal.FContext ctx);
 
@@ -72,7 +73,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
   frugal.FProtocolFactory _protocolFactory;
 
   /// Ping the server.
-  @Deprecated("use something else")
+  /// Deprecated: use something else
+  @deprecated
   Future ping(frugal.FContext ctx) {
     _frugalLog.warning("Call to deprecated function 'Foo.ping'");
     return this._methods['ping']([ctx]) as Future;


### PR DESCRIPTION
Currently, the message from the `(deprecated="...")` annotation is not propagated to the abstract base class ("interface"), so it is not easily visible to clients.  Add `/// Deprecated: ...`.

Additionally, use the same pattern in the client class rather than `@Deprecated("...")` since that syntax sets an "expires" member that is used to describe when the member will be removed rather than being used as a general string to describe the deprecation, which is how it is used elsewhere.

@Workiva/messaging-pp 