### PR TITLE
change version of multidict

### DIFF
--- a/lib/python/requirements_dev_asyncio.txt
+++ b/lib/python/requirements_dev_asyncio.txt
@@ -1,5 +1,5 @@
 asyncio-nats-client==0.6.0
-multidict==3.3.0
+multidict==3.1.3 # DO NOT CHANGE without verifying asyncio nats with tls works
 aiohttp==2.3.2
 async-timeout==1.1.0
 

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -28,9 +28,13 @@ setup(
     ],
     extras_require={
         'tornado': ["nats-client==0.5.0"],
-        'asyncio': ["async-timeout==1.1.0", "asyncio-nats-client==0.6.0",
-                    "multidict==3.3.0",
-                    "aiohttp==2.3.2"],
+        'asyncio': [
+            "async-timeout==1.1.0",
+            "asyncio-nats-client==0.6.0",
+            # DO NOT CHANGE without verifying asyncio nats with tls works
+            "multidict==3.1.3",
+            "aiohttp==2.3.2",
+        ],
         'gae': ["webapp2==2.5.2"],
     }
 )


### PR DESCRIPTION
This was somehow breaking asyncio nats with tls. I spent the day trying to figure out how/why and didn't come up with anything, so I decided to just bump the version down.

The problem is somewhere in https://github.com/aio-libs/multidict/compare/v3.1.3...v3.2.0#diff but I wasn't able to nail it down further

@Workiva/messaging-pp 
