### PR TITLE
Acquire lock to read from transport

### DIFF
--- a/lib/go/adapter_transport.go
+++ b/lib/go/adapter_transport.go
@@ -117,6 +117,8 @@ func (f *fAdapterTransport) readLoop() {
 }
 
 func (f *fAdapterTransport) readFrame(framedTransport *TFramedTransport) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	_, err := framedTransport.Read([]byte{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Executing Close on an Adapter races the readLoop goroutine to read a frame from the transport.

@stevenosborne-wf 
@patkujawa-wf 
@ericklaus-wf 