### PR TITLE
Java: Improve exception handling

### DIFF
--- a/compiler/generator/java/generator.go
+++ b/compiler/generator/java/generator.go
@@ -3035,7 +3035,7 @@ func (g *Generator) generateServer(service *parser.Service) string {
 		contents += tabtabtabtab + "} catch (TException e) {\n"
 		contents += tabtabtabtabtab + "synchronized (WRITE_LOCK) {\n"
 		contents += tabtabtabtabtabtab + fmt.Sprintf(
-			"e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, \"%s\", \"Internal error processing %s: \" + e.getMessage());\n",
+			"e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, \"%s\", \"Internal error processing %s: \" + e.getMessage()).initCause(e);\n",
 			methodLower, method.Name)
 		contents += tabtabtabtabtab + "}\n"
 		contents += tabtabtabtabtab + "throw e;\n"

--- a/lib/java/src/main/java/com/workiva/frugal/processor/FBaseProcessor.java
+++ b/lib/java/src/main/java/com/workiva/frugal/processor/FBaseProcessor.java
@@ -54,6 +54,7 @@ public abstract class FBaseProcessor implements FProcessor {
                 // Don't raise an exception because the server should still send a response to the client.
                 LOGGER.error("Exception occurred while processing request with correlation id "
                         + ctx.getCorrelationId(), e);
+                // writeApplicationException was already called by the generated processor.
             } catch (RuntimeException e) {
                 LOGGER.error("User handler code threw unhandled exception on request with correlation id "
                         + ctx.getCorrelationId(), e);

--- a/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
@@ -327,7 +327,7 @@ public class FNatsServer implements FServer {
                     conn.flush();
                 } catch (Exception ignored) {
                 }
-                throw e;
+                return;
             }
 
             if (!output.hasWriteData()) {

--- a/lib/java/src/test/java/com/workiva/frugal/server/FNatsServerTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/server/FNatsServerTest.java
@@ -163,7 +163,7 @@ public class FNatsServerTest {
         verify(mockConn).publish(reply, expected);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
     public void testRequestProcessRuntimeException() throws TException, IOException {
         byte[] data = "xxxxhello".getBytes();
         long timestamp = System.currentTimeMillis();
@@ -173,7 +173,11 @@ public class FNatsServerTest {
         mockProtocolFactory = new FProtocolFactory(new TJSONProtocol.Factory());
         FNatsServer.Request request = new FNatsServer.Request(data, timestamp, reply, highWatermark,
                 mockProtocolFactory, mockProtocolFactory, processor, mockConn);
+
         request.run();
+
+        byte[] expected = new byte[]{0, 0, 0, 0};
+        verify(mockConn).publish(reply, expected);
     }
 
     @Test

--- a/test/expected/java/actual_base/FBaseFoo.java
+++ b/test/expected/java/actual_base/FBaseFoo.java
@@ -180,7 +180,7 @@ public class FBaseFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "basePing", "Internal error processing basePing: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "basePing", "Internal error processing basePing: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}

--- a/test/expected/java/boxed_primitives/FFoo.java
+++ b/test/expected/java/boxed_primitives/FFoo.java
@@ -563,7 +563,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "ping", "Internal error processing Ping: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "ping", "Internal error processing Ping: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -617,7 +617,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "blah", "Internal error processing blah: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "blah", "Internal error processing blah: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -685,7 +685,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -735,7 +735,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -785,7 +785,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -835,7 +835,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "getThing", "Internal error processing getThing: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "getThing", "Internal error processing getThing: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -885,7 +885,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -935,7 +935,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}

--- a/test/expected/java/variety/FFoo.java
+++ b/test/expected/java/variety/FFoo.java
@@ -563,7 +563,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "ping", "Internal error processing Ping: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "ping", "Internal error processing Ping: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -617,7 +617,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "blah", "Internal error processing blah: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "blah", "Internal error processing blah: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -685,7 +685,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -735,7 +735,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -785,7 +785,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -835,7 +835,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "getThing", "Internal error processing getThing: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "getThing", "Internal error processing getThing: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -885,7 +885,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -935,7 +935,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}

--- a/test/expected/java/variety_async/FFoo.java
+++ b/test/expected/java/variety_async/FFoo.java
@@ -646,7 +646,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "ping", "Internal error processing Ping: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "ping", "Internal error processing Ping: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -700,7 +700,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "blah", "Internal error processing blah: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "blah", "Internal error processing blah: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -768,7 +768,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -818,7 +818,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -868,7 +868,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -918,7 +918,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "getThing", "Internal error processing getThing: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "getThing", "Internal error processing getThing: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -968,7 +968,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}
@@ -1018,7 +1018,7 @@ public class FFoo {
 					return;
 				} catch (TException e) {
 					synchronized (WRITE_LOCK) {
-						e = writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: " + e.getMessage());
+						e = (TApplicationException) writeApplicationException(ctx, oprot, TApplicationExceptionType.INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: " + e.getMessage()).initCause(e);
 					}
 					throw e;
 				}


### PR DESCRIPTION
(Updated #953 to fix build by keeping the same `TApplicationException` message.)

Three commits are intended to be reviewed independently, but all three improve Java exception handling:

1. Improve logging of undeclared `TException`.  See commit message for more details.
2. Document lack of `writeApplicationException` for `TException` in `FBaseProcessor`.  Noticed while trying to understand the exception handling of item 1 above.
3. Don't log RuntimeException twice for NATS.  As of commit 21758e33, RuntimeException are logged twice: once in `FBaseProcessor` and again by the Java uncaught exception handler.

@Workiva/messaging-pp 