### PR TITLE
upgrade aiohttp to fix yarl issue

### DIFF
--- a/lib/python/requirements_dev_asyncio.txt
+++ b/lib/python/requirements_dev_asyncio.txt
@@ -1,6 +1,6 @@
 asyncio-nats-client==0.6.0
 multidict==3.1.3 # DO NOT CHANGE without verifying asyncio nats with tls works
-aiohttp==2.3.2
+aiohttp==2.3.8
 async-timeout==1.1.0
 
 -r requirements_dev_common.txt

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -33,7 +33,7 @@ setup(
             "asyncio-nats-client==0.6.0",
             # DO NOT CHANGE without verifying asyncio nats with tls works
             "multidict==3.1.3",
-            "aiohttp==2.3.2",
+            "aiohttp==2.3.8",
         ],
         'gae': ["webapp2==2.5.2"],
     }


### PR DESCRIPTION
@Workiva/messaging-pp @Workiva/infre-product 

yarl released 1.0 which had some breaking changes, and aiohttp was pinned to yarl version >0.11, causing problems in our build
