### PR TITLE
handle returning nil in a go middleware properly

### DIFF
--- a/compiler/generator/golang/generator.go
+++ b/compiler/generator/golang/generator.go
@@ -1689,7 +1689,9 @@ func (g *Generator) generateClientMethod(service *parser.Service, method *parser
 	contents += fmt.Sprintf("\t\tpanic(fmt.Sprintf(\"Middleware returned %%d arguments, expected %s\", len(ret)))\n", numReturn)
 	contents += "\t}\n"
 	if method.ReturnType != nil {
-		contents += fmt.Sprintf("\tr = ret[0].(%s)\n", g.getGoTypeFromThriftType(method.ReturnType))
+		contents += "\tif ret[0] != nil {\n"
+		contents += fmt.Sprintf("\t\tr = ret[0].(%s)\n", g.getGoTypeFromThriftType(method.ReturnType))
+		contents += "\t}\n"
 		contents += "\tif ret[1] != nil {\n"
 		contents += "\t\terr = ret[1].(error)\n"
 		contents += "\t}\n"

--- a/examples/dart/web/index.html
+++ b/examples/dart/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Thrift Tutorial</title>
+    <title>Frugal Tutorial</title>
     <link rel="stylesheet" href="styles.css">
     <script async src="client.dart" type="application/dart"></script>
     <script async src="packages/browser/dart.js"></script>

--- a/examples/go/gen-go/v1/music/f_store_service.go
+++ b/examples/go/gen-go/v1/music/f_store_service.go
@@ -52,7 +52,9 @@ func (f *FStoreClient) BuyAlbum(ctx frugal.FContext, asin string, acct string) (
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].(*Album)
+	if ret[0] != nil {
+		r = ret[0].(*Album)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}
@@ -141,7 +143,9 @@ func (f *FStoreClient) EnterAlbumGiveaway(ctx frugal.FContext, email string, nam
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].(bool)
+	if ret[0] != nil {
+		r = ret[0].(bool)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}

--- a/test/expected/go/variety/f_foo_service.txt
+++ b/test/expected/go/variety/f_foo_service.txt
@@ -159,7 +159,9 @@ func (f *FFooClient) Blah(ctx frugal.FContext, num int32, str string, event *Eve
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].(int64)
+	if ret[0] != nil {
+		r = ret[0].(int64)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}
@@ -289,7 +291,9 @@ func (f *FFooClient) BinMethod(ctx frugal.FContext, bin []byte, str string) (r [
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].([]byte)
+	if ret[0] != nil {
+		r = ret[0].([]byte)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}
@@ -376,7 +380,9 @@ func (f *FFooClient) ParamModifiers(ctx frugal.FContext, opt_num int32, default_
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].(int64)
+	if ret[0] != nil {
+		r = ret[0].(int64)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}
@@ -460,7 +466,9 @@ func (f *FFooClient) UnderlyingTypesTest(ctx frugal.FContext, list_type []ID, se
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].([]ID)
+	if ret[0] != nil {
+		r = ret[0].([]ID)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}
@@ -543,7 +551,9 @@ func (f *FFooClient) GetThing(ctx frugal.FContext) (r *validStructs.Thing, err e
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].(*validStructs.Thing)
+	if ret[0] != nil {
+		r = ret[0].(*validStructs.Thing)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}
@@ -623,7 +633,9 @@ func (f *FFooClient) GetMyInt(ctx frugal.FContext) (r ValidTypes.MyInt, err erro
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].(ValidTypes.MyInt)
+	if ret[0] != nil {
+		r = ret[0].(ValidTypes.MyInt)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}
@@ -703,7 +715,9 @@ func (f *FFooClient) UseSubdirStruct(ctx frugal.FContext, a *subdir_include.A) (
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].(*subdir_include.A)
+	if ret[0] != nil {
+		r = ret[0].(*subdir_include.A)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}

--- a/test/expected/go/variety_async/f_foo_service.txt
+++ b/test/expected/go/variety_async/f_foo_service.txt
@@ -168,7 +168,9 @@ func (f *FFooClient) Blah(ctx frugal.FContext, num int32, str string, event *Eve
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].(int64)
+	if ret[0] != nil {
+		r = ret[0].(int64)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}
@@ -322,7 +324,9 @@ func (f *FFooClient) BinMethod(ctx frugal.FContext, bin []byte, str string) (r [
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].([]byte)
+	if ret[0] != nil {
+		r = ret[0].([]byte)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}
@@ -423,7 +427,9 @@ func (f *FFooClient) ParamModifiers(ctx frugal.FContext, opt_num int32, default_
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].(int64)
+	if ret[0] != nil {
+		r = ret[0].(int64)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}
@@ -521,7 +527,9 @@ func (f *FFooClient) UnderlyingTypesTest(ctx frugal.FContext, list_type []ID, se
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].([]ID)
+	if ret[0] != nil {
+		r = ret[0].([]ID)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}
@@ -618,7 +626,9 @@ func (f *FFooClient) GetThing(ctx frugal.FContext) (r *validStructs.Thing, err e
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].(*validStructs.Thing)
+	if ret[0] != nil {
+		r = ret[0].(*validStructs.Thing)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}
@@ -712,7 +722,9 @@ func (f *FFooClient) GetMyInt(ctx frugal.FContext) (r ValidTypes.MyInt, err erro
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].(ValidTypes.MyInt)
+	if ret[0] != nil {
+		r = ret[0].(ValidTypes.MyInt)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}
@@ -806,7 +818,9 @@ func (f *FFooClient) UseSubdirStruct(ctx frugal.FContext, a *subdir_include.A) (
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].(*subdir_include.A)
+	if ret[0] != nil {
+		r = ret[0].(*subdir_include.A)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}

--- a/test/expected/go/vendor/f_myservice_service.txt
+++ b/test/expected/go/vendor/f_myservice_service.txt
@@ -47,7 +47,9 @@ func (f *FMyServiceClient) GetItem(ctx frugal.FContext) (r *vendor_namespace.Ite
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
-	r = ret[0].(*vendor_namespace.Item)
+	if ret[0] != nil {
+		r = ret[0].(*vendor_namespace.Item)
+	}
 	if ret[1] != nil {
 		err = ret[1].(error)
 	}


### PR DESCRIPTION
If a client side middleware returns nil for the rpc return value (such as in the case of an error where the middleware doesn't necessarily know what type to return) we were trying to type assert nil to the proper type, causing a panic.

@Workiva/messaging-pp @Workiva/infre-product @tannermiller-wf 
