### PR TITLE
dart: add an equality operator and clone method for structs

### DIFF
--- a/examples/dart/gen-dart/v1_music/lib/src/f_album.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_album.dart
@@ -222,6 +222,27 @@ class Album implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is Album)) {
+      return false;
+    }
+    Album other = o as Album;
+    return this.tracks == other.tracks
+      && this.duration == other.duration
+      && this.aSIN == other.aSIN;
+  }
+
+  Album clone({
+    List<t_v1_music.Track> tracks: null,
+    double duration: null,
+    String aSIN: null,
+  }) {
+    return new Album()
+      ..tracks = tracks ?? this.tracks
+      ..duration = duration ?? this.duration
+      ..aSIN = aSIN ?? this.aSIN;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values

--- a/examples/dart/gen-dart/v1_music/lib/src/f_purchasing_error.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_purchasing_error.dart
@@ -164,6 +164,24 @@ class PurchasingError extends Error implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is PurchasingError)) {
+      return false;
+    }
+    PurchasingError other = o as PurchasingError;
+    return this.message == other.message
+      && this.error_code == other.error_code;
+  }
+
+  PurchasingError clone({
+    String message: null,
+    int error_code: null,
+  }) {
+    return new PurchasingError()
+      ..message = message ?? this.message
+      ..error_code = error_code ?? this.error_code;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -289,6 +289,24 @@ class buyAlbum_args implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is buyAlbum_args)) {
+      return false;
+    }
+    buyAlbum_args other = o as buyAlbum_args;
+    return this.aSIN == other.aSIN
+      && this.acct == other.acct;
+  }
+
+  buyAlbum_args clone({
+    String aSIN: null,
+    String acct: null,
+  }) {
+    return new buyAlbum_args()
+      ..aSIN = aSIN ?? this.aSIN
+      ..acct = acct ?? this.acct;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
@@ -460,6 +478,24 @@ class buyAlbum_result implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is buyAlbum_result)) {
+      return false;
+    }
+    buyAlbum_result other = o as buyAlbum_result;
+    return this.success == other.success
+      && this.error == other.error;
+  }
+
+  buyAlbum_result clone({
+    t_v1_music.Album success: null,
+    t_v1_music.PurchasingError error: null,
+  }) {
+    return new buyAlbum_result()
+      ..success = success ?? this.success
+      ..error = error ?? this.error;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
@@ -625,6 +661,24 @@ class enterAlbumGiveaway_args implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is enterAlbumGiveaway_args)) {
+      return false;
+    }
+    enterAlbumGiveaway_args other = o as enterAlbumGiveaway_args;
+    return this.email == other.email
+      && this.name == other.name;
+  }
+
+  enterAlbumGiveaway_args clone({
+    String email: null,
+    String name: null,
+  }) {
+    return new enterAlbumGiveaway_args()
+      ..email = email ?? this.email
+      ..name = name ?? this.name;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
@@ -742,6 +796,21 @@ class enterAlbumGiveaway_result implements thrift.TBase {
     ret.write(")");
 
     return ret.toString();
+  }
+
+  bool operator ==(Object o) {
+    if(o == null || !(o is enterAlbumGiveaway_result)) {
+      return false;
+    }
+    enterAlbumGiveaway_result other = o as enterAlbumGiveaway_result;
+    return this.success == other.success;
+  }
+
+  enterAlbumGiveaway_result clone({
+    bool success: null,
+  }) {
+    return new enterAlbumGiveaway_result()
+      ..success = success ?? this.success;
   }
 
   validate() {

--- a/examples/dart/gen-dart/v1_music/lib/src/f_track.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_track.dart
@@ -356,6 +356,36 @@ class Track implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is Track)) {
+      return false;
+    }
+    Track other = o as Track;
+    return this.title == other.title
+      && this.artist == other.artist
+      && this.publisher == other.publisher
+      && this.composer == other.composer
+      && this.duration == other.duration
+      && this.pro == other.pro;
+  }
+
+  Track clone({
+    String title: null,
+    String artist: null,
+    String publisher: null,
+    String composer: null,
+    double duration: null,
+    int pro: null,
+  }) {
+    return new Track()
+      ..title = title ?? this.title
+      ..artist = artist ?? this.artist
+      ..publisher = publisher ?? this.publisher
+      ..composer = composer ?? this.composer
+      ..duration = duration ?? this.duration
+      ..pro = pro ?? this.pro;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values

--- a/test/expected/dart/actual_base/f_api_exception.dart
+++ b/test/expected/dart/actual_base/f_api_exception.dart
@@ -72,6 +72,17 @@ class api_exception extends Error implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is api_exception)) {
+      return false;
+    }
+    return true;
+  }
+
+  api_exception clone() {
+    return new api_exception();
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -133,6 +133,17 @@ class basePing_args implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is basePing_args)) {
+      return false;
+    }
+    return true;
+  }
+
+  basePing_args clone() {
+    return new basePing_args();
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
@@ -203,6 +214,17 @@ class basePing_result implements thrift.TBase {
     ret.write(")");
 
     return ret.toString();
+  }
+
+  bool operator ==(Object o) {
+    if(o == null || !(o is basePing_result)) {
+      return false;
+    }
+    return true;
+  }
+
+  basePing_result clone() {
+    return new basePing_result();
   }
 
   validate() {

--- a/test/expected/dart/actual_base/f_nested_thing.dart
+++ b/test/expected/dart/actual_base/f_nested_thing.dart
@@ -129,6 +129,21 @@ class nested_thing implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is nested_thing)) {
+      return false;
+    }
+    nested_thing other = o as nested_thing;
+    return this.things == other.things;
+  }
+
+  nested_thing clone({
+    List<t_actual_base_dart.thing> things: null,
+  }) {
+    return new nested_thing()
+      ..things = things ?? this.things;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values

--- a/test/expected/dart/actual_base/f_thing.dart
+++ b/test/expected/dart/actual_base/f_thing.dart
@@ -162,6 +162,24 @@ class thing implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is thing)) {
+      return false;
+    }
+    thing other = o as thing;
+    return this.an_id == other.an_id
+      && this.a_string == other.a_string;
+  }
+
+  thing clone({
+    int an_id: null,
+    String a_string: null,
+  }) {
+    return new thing()
+      ..an_id = an_id ?? this.an_id
+      ..a_string = a_string ?? this.a_string;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -145,6 +145,17 @@ class getItem_args implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is getItem_args)) {
+      return false;
+    }
+    return true;
+  }
+
+  getItem_args clone() {
+    return new getItem_args();
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
@@ -314,6 +325,24 @@ class getItem_result implements thrift.TBase {
     ret.write(")");
 
     return ret.toString();
+  }
+
+  bool operator ==(Object o) {
+    if(o == null || !(o is getItem_result)) {
+      return false;
+    }
+    getItem_result other = o as getItem_result;
+    return this.success == other.success
+      && this.d == other.d;
+  }
+
+  getItem_result clone({
+    t_vendor_namespace.Item success: null,
+    t_excepts.InvalidData d: null,
+  }) {
+    return new getItem_result()
+      ..success = success ?? this.success
+      ..d = d ?? this.d;
   }
 
   validate() {

--- a/test/expected/dart/variety/f_awesome_exception.dart
+++ b/test/expected/dart/variety/f_awesome_exception.dart
@@ -173,6 +173,24 @@ class AwesomeException extends Error implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is AwesomeException)) {
+      return false;
+    }
+    AwesomeException other = o as AwesomeException;
+    return this.iD == other.iD
+      && this.reason == other.reason;
+  }
+
+  AwesomeException clone({
+    int iD: null,
+    String reason: null,
+  }) {
+    return new AwesomeException()
+      ..iD = iD ?? this.iD
+      ..reason = reason ?? this.reason;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values

--- a/test/expected/dart/variety/f_event.dart
+++ b/test/expected/dart/variety/f_event.dart
@@ -176,6 +176,24 @@ class Event implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is Event)) {
+      return false;
+    }
+    Event other = o as Event;
+    return this.iD == other.iD
+      && this.message == other.message;
+  }
+
+  Event clone({
+    int iD: null,
+    String message: null,
+  }) {
+    return new Event()
+      ..iD = iD ?? this.iD
+      ..message = message ?? this.message;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values

--- a/test/expected/dart/variety/f_event_wrapper.dart
+++ b/test/expected/dart/variety/f_event_wrapper.dart
@@ -611,6 +611,48 @@ class EventWrapper implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is EventWrapper)) {
+      return false;
+    }
+    EventWrapper other = o as EventWrapper;
+    return this.iD == other.iD
+      && this.ev == other.ev
+      && this.events == other.events
+      && this.events2 == other.events2
+      && this.eventMap == other.eventMap
+      && this.nums == other.nums
+      && this.enums == other.enums
+      && this.aBoolField == other.aBoolField
+      && this.a_union == other.a_union
+      && this.typedefOfTypedef == other.typedefOfTypedef;
+  }
+
+  EventWrapper clone({
+    int iD: null,
+    t_variety.Event ev: null,
+    List<t_variety.Event> events: null,
+    Set<t_variety.Event> events2: null,
+    Map<int, t_variety.Event> eventMap: null,
+    List<List<int>> nums: null,
+    List<int> enums: null,
+    bool aBoolField: null,
+    t_variety.TestingUnions a_union: null,
+    String typedefOfTypedef: null,
+  }) {
+    return new EventWrapper()
+      ..iD = iD ?? this.iD
+      ..ev = ev ?? this.ev
+      ..events = events ?? this.events
+      ..events2 = events2 ?? this.events2
+      ..eventMap = eventMap ?? this.eventMap
+      ..nums = nums ?? this.nums
+      ..enums = enums ?? this.enums
+      ..aBoolField = aBoolField ?? this.aBoolField
+      ..a_union = a_union ?? this.a_union
+      ..typedefOfTypedef = typedefOfTypedef ?? this.typedefOfTypedef;
+  }
+
   validate() {
     // check for required fields
     if(ev == null) {

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -473,6 +473,17 @@ class Ping_args implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is Ping_args)) {
+      return false;
+    }
+    return true;
+  }
+
+  Ping_args clone() {
+    return new Ping_args();
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
@@ -543,6 +554,17 @@ class Ping_result implements thrift.TBase {
     ret.write(")");
 
     return ret.toString();
+  }
+
+  bool operator ==(Object o) {
+    if(o == null || !(o is Ping_result)) {
+      return false;
+    }
+    return true;
+  }
+
+  Ping_result clone() {
+    return new Ping_result();
   }
 
   validate() {
@@ -753,6 +775,27 @@ class blah_args implements thrift.TBase {
     ret.write(")");
 
     return ret.toString();
+  }
+
+  bool operator ==(Object o) {
+    if(o == null || !(o is blah_args)) {
+      return false;
+    }
+    blah_args other = o as blah_args;
+    return this.num == other.num
+      && this.str == other.str
+      && this.event == other.event;
+  }
+
+  blah_args clone({
+    int num: null,
+    String str: null,
+    t_variety.Event event: null,
+  }) {
+    return new blah_args()
+      ..num = num ?? this.num
+      ..str = str ?? this.str
+      ..event = event ?? this.event;
   }
 
   validate() {
@@ -974,6 +1017,27 @@ class blah_result implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is blah_result)) {
+      return false;
+    }
+    blah_result other = o as blah_result;
+    return this.success == other.success
+      && this.awe == other.awe
+      && this.api == other.api;
+  }
+
+  blah_result clone({
+    int success: null,
+    t_variety.AwesomeException awe: null,
+    t_actual_base_dart.api_exception api: null,
+  }) {
+    return new blah_result()
+      ..success = success ?? this.success
+      ..awe = awe ?? this.awe
+      ..api = api ?? this.api;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
@@ -1148,6 +1212,24 @@ class oneWay_args implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is oneWay_args)) {
+      return false;
+    }
+    oneWay_args other = o as oneWay_args;
+    return this.id == other.id
+      && this.req == other.req;
+  }
+
+  oneWay_args clone({
+    int id: null,
+    Map<int, String> req: null,
+  }) {
+    return new oneWay_args()
+      ..id = id ?? this.id
+      ..req = req ?? this.req;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
@@ -1311,6 +1393,24 @@ class bin_method_args implements thrift.TBase {
     ret.write(")");
 
     return ret.toString();
+  }
+
+  bool operator ==(Object o) {
+    if(o == null || !(o is bin_method_args)) {
+      return false;
+    }
+    bin_method_args other = o as bin_method_args;
+    return this.bin == other.bin
+      && this.str == other.str;
+  }
+
+  bin_method_args clone({
+    Uint8List bin: null,
+    String str: null,
+  }) {
+    return new bin_method_args()
+      ..bin = bin ?? this.bin
+      ..str = str ?? this.str;
   }
 
   validate() {
@@ -1481,6 +1581,24 @@ class bin_method_result implements thrift.TBase {
     ret.write(")");
 
     return ret.toString();
+  }
+
+  bool operator ==(Object o) {
+    if(o == null || !(o is bin_method_result)) {
+      return false;
+    }
+    bin_method_result other = o as bin_method_result;
+    return this.success == other.success
+      && this.api == other.api;
+  }
+
+  bin_method_result clone({
+    Uint8List success: null,
+    t_actual_base_dart.api_exception api: null,
+  }) {
+    return new bin_method_result()
+      ..success = success ?? this.success
+      ..api = api ?? this.api;
   }
 
   validate() {
@@ -1689,6 +1807,27 @@ class param_modifiers_args implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is param_modifiers_args)) {
+      return false;
+    }
+    param_modifiers_args other = o as param_modifiers_args;
+    return this.opt_num == other.opt_num
+      && this.default_num == other.default_num
+      && this.req_num == other.req_num;
+  }
+
+  param_modifiers_args clone({
+    int opt_num: null,
+    int default_num: null,
+    int req_num: null,
+  }) {
+    return new param_modifiers_args()
+      ..opt_num = opt_num ?? this.opt_num
+      ..default_num = default_num ?? this.default_num
+      ..req_num = req_num ?? this.req_num;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
@@ -1806,6 +1945,21 @@ class param_modifiers_result implements thrift.TBase {
     ret.write(")");
 
     return ret.toString();
+  }
+
+  bool operator ==(Object o) {
+    if(o == null || !(o is param_modifiers_result)) {
+      return false;
+    }
+    param_modifiers_result other = o as param_modifiers_result;
+    return this.success == other.success;
+  }
+
+  param_modifiers_result clone({
+    int success: null,
+  }) {
+    return new param_modifiers_result()
+      ..success = success ?? this.success;
   }
 
   validate() {
@@ -1993,6 +2147,24 @@ class underlying_types_test_args implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is underlying_types_test_args)) {
+      return false;
+    }
+    underlying_types_test_args other = o as underlying_types_test_args;
+    return this.list_type == other.list_type
+      && this.set_type == other.set_type;
+  }
+
+  underlying_types_test_args clone({
+    List<int> list_type: null,
+    Set<int> set_type: null,
+  }) {
+    return new underlying_types_test_args()
+      ..list_type = list_type ?? this.list_type
+      ..set_type = set_type ?? this.set_type;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
@@ -2123,6 +2295,21 @@ class underlying_types_test_result implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is underlying_types_test_result)) {
+      return false;
+    }
+    underlying_types_test_result other = o as underlying_types_test_result;
+    return this.success == other.success;
+  }
+
+  underlying_types_test_result clone({
+    List<int> success: null,
+  }) {
+    return new underlying_types_test_result()
+      ..success = success ?? this.success;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
@@ -2193,6 +2380,17 @@ class getThing_args implements thrift.TBase {
     ret.write(")");
 
     return ret.toString();
+  }
+
+  bool operator ==(Object o) {
+    if(o == null || !(o is getThing_args)) {
+      return false;
+    }
+    return true;
+  }
+
+  getThing_args clone() {
+    return new getThing_args();
   }
 
   validate() {
@@ -2316,6 +2514,21 @@ class getThing_result implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is getThing_result)) {
+      return false;
+    }
+    getThing_result other = o as getThing_result;
+    return this.success == other.success;
+  }
+
+  getThing_result clone({
+    t_validStructs.Thing success: null,
+  }) {
+    return new getThing_result()
+      ..success = success ?? this.success;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
@@ -2386,6 +2599,17 @@ class getMyInt_args implements thrift.TBase {
     ret.write(")");
 
     return ret.toString();
+  }
+
+  bool operator ==(Object o) {
+    if(o == null || !(o is getMyInt_args)) {
+      return false;
+    }
+    return true;
+  }
+
+  getMyInt_args clone() {
+    return new getMyInt_args();
   }
 
   validate() {
@@ -2507,6 +2731,21 @@ class getMyInt_result implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is getMyInt_result)) {
+      return false;
+    }
+    getMyInt_result other = o as getMyInt_result;
+    return this.success == other.success;
+  }
+
+  getMyInt_result clone({
+    int success: null,
+  }) {
+    return new getMyInt_result()
+      ..success = success ?? this.success;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
@@ -2624,6 +2863,21 @@ class use_subdir_struct_args implements thrift.TBase {
     ret.write(")");
 
     return ret.toString();
+  }
+
+  bool operator ==(Object o) {
+    if(o == null || !(o is use_subdir_struct_args)) {
+      return false;
+    }
+    use_subdir_struct_args other = o as use_subdir_struct_args;
+    return this.a == other.a;
+  }
+
+  use_subdir_struct_args clone({
+    t_subdir_include_ns.A a: null,
+  }) {
+    return new use_subdir_struct_args()
+      ..a = a ?? this.a;
   }
 
   validate() {
@@ -2745,6 +2999,21 @@ class use_subdir_struct_result implements thrift.TBase {
     ret.write(")");
 
     return ret.toString();
+  }
+
+  bool operator ==(Object o) {
+    if(o == null || !(o is use_subdir_struct_result)) {
+      return false;
+    }
+    use_subdir_struct_result other = o as use_subdir_struct_result;
+    return this.success == other.success;
+  }
+
+  use_subdir_struct_result clone({
+    t_subdir_include_ns.A success: null,
+  }) {
+    return new use_subdir_struct_result()
+      ..success = success ?? this.success;
   }
 
   validate() {

--- a/test/expected/dart/variety/f_test_base.dart
+++ b/test/expected/dart/variety/f_test_base.dart
@@ -124,6 +124,21 @@ class TestBase implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is TestBase)) {
+      return false;
+    }
+    TestBase other = o as TestBase;
+    return this.base_struct == other.base_struct;
+  }
+
+  TestBase clone({
+    t_actual_base_dart.thing base_struct: null,
+  }) {
+    return new TestBase()
+      ..base_struct = base_struct ?? this.base_struct;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values

--- a/test/expected/dart/variety/f_test_lowercase.dart
+++ b/test/expected/dart/variety/f_test_lowercase.dart
@@ -120,6 +120,21 @@ class TestLowercase implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is TestLowercase)) {
+      return false;
+    }
+    TestLowercase other = o as TestLowercase;
+    return this.lowercaseInt == other.lowercaseInt;
+  }
+
+  TestLowercase clone({
+    int lowercaseInt: null,
+  }) {
+    return new TestLowercase()
+      ..lowercaseInt = lowercaseInt ?? this.lowercaseInt;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values

--- a/test/expected/dart/variety/f_testing_defaults.dart
+++ b/test/expected/dart/variety/f_testing_defaults.dart
@@ -1037,6 +1037,72 @@ class TestingDefaults implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is TestingDefaults)) {
+      return false;
+    }
+    TestingDefaults other = o as TestingDefaults;
+    return this.iD2 == other.iD2
+      && this.ev1 == other.ev1
+      && this.ev2 == other.ev2
+      && this.iD == other.iD
+      && this.thing == other.thing
+      && this.thing2 == other.thing2
+      && this.listfield == other.listfield
+      && this.iD3 == other.iD3
+      && this.bin_field == other.bin_field
+      && this.bin_field2 == other.bin_field2
+      && this.bin_field3 == other.bin_field3
+      && this.bin_field4 == other.bin_field4
+      && this.list2 == other.list2
+      && this.list3 == other.list3
+      && this.list4 == other.list4
+      && this.a_map == other.a_map
+      && this.status == other.status
+      && this.base_status == other.base_status;
+  }
+
+  TestingDefaults clone({
+    int iD2: null,
+    t_variety.Event ev1: null,
+    t_variety.Event ev2: null,
+    int iD: null,
+    String thing: null,
+    String thing2: null,
+    List<int> listfield: null,
+    int iD3: null,
+    Uint8List bin_field: null,
+    Uint8List bin_field2: null,
+    Uint8List bin_field3: null,
+    Uint8List bin_field4: null,
+    List<int> list2: null,
+    List<int> list3: null,
+    List<int> list4: null,
+    Map<String, String> a_map: null,
+    int status: null,
+    int base_status: null,
+  }) {
+    return new TestingDefaults()
+      ..iD2 = iD2 ?? this.iD2
+      ..ev1 = ev1 ?? this.ev1
+      ..ev2 = ev2 ?? this.ev2
+      ..iD = iD ?? this.iD
+      ..thing = thing ?? this.thing
+      ..thing2 = thing2 ?? this.thing2
+      ..listfield = listfield ?? this.listfield
+      ..iD3 = iD3 ?? this.iD3
+      ..bin_field = bin_field ?? this.bin_field
+      ..bin_field2 = bin_field2 ?? this.bin_field2
+      ..bin_field3 = bin_field3 ?? this.bin_field3
+      ..bin_field4 = bin_field4 ?? this.bin_field4
+      ..list2 = list2 ?? this.list2
+      ..list3 = list3 ?? this.list3
+      ..list4 = list4 ?? this.list4
+      ..a_map = a_map ?? this.a_map
+      ..status = status ?? this.status
+      ..base_status = base_status ?? this.base_status;
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values

--- a/test/expected/dart/variety/f_testing_unions.dart
+++ b/test/expected/dart/variety/f_testing_unions.dart
@@ -379,6 +379,36 @@ class TestingUnions implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is TestingUnions)) {
+      return false;
+    }
+    TestingUnions other = o as TestingUnions;
+    return this.anID == other.anID
+      && this.aString == other.aString
+      && this.someotherthing == other.someotherthing
+      && this.anInt16 == other.anInt16
+      && this.requests == other.requests
+      && this.bin_field_in_union == other.bin_field_in_union;
+  }
+
+  TestingUnions clone({
+    int anID: null,
+    String aString: null,
+    int someotherthing: null,
+    int anInt16: null,
+    Map<int, String> requests: null,
+    Uint8List bin_field_in_union: null,
+  }) {
+    return new TestingUnions()
+      ..anID = anID ?? this.anID
+      ..aString = aString ?? this.aString
+      ..someotherthing = someotherthing ?? this.someotherthing
+      ..anInt16 = anInt16 ?? this.anInt16
+      ..requests = requests ?? this.requests
+      ..bin_field_in_union = bin_field_in_union ?? this.bin_field_in_union;
+  }
+
   validate() {
     // check exactly one field is set
     int setFields = 0;

--- a/test/expected/dart/vendor_namespace/f_item.dart
+++ b/test/expected/dart/vendor_namespace/f_item.dart
@@ -72,6 +72,17 @@ class Item implements thrift.TBase {
     return ret.toString();
   }
 
+  bool operator ==(Object o) {
+    if(o == null || !(o is Item)) {
+      return false;
+    }
+    return true;
+  }
+
+  Item clone() {
+    return new Item();
+  }
+
   validate() {
     // check for required fields
     // check that fields of type enum have valid values


### PR DESCRIPTION
ticket: https://jira.atl.workiva.net/browse/INFENG-4889

Adds an `==` method and `clone()` method to dart structs, which take optional arguments to replace the current fields with.

@Workiva/messaging-pp @Workiva/infre-product @tayloranderson-wf 
