### PR TITLE
Better asyncio exception handling

### DIFF
--- a/compiler/generator/python/asyncio.go
+++ b/compiler/generator/python/asyncio.go
@@ -275,7 +275,7 @@ func (a *AsyncIOGenerator) generateProcessorFunction(method *parser.Method) stri
 	contents += tabtab + "except Exception as e:\n"
 	if !method.Oneway {
 		contents += tabtabtab + "async with self._lock:\n"
-		contents += tabtabtabtab + fmt.Sprintf("e = _write_application_exception(ctx, oprot, \"%s\", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=e.args[0])\n", methodLower)
+		contents += tabtabtabtab + fmt.Sprintf("e = _write_application_exception(ctx, oprot, \"%s\", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))\n", methodLower)
 	}
 	contents += tabtabtab + "raise e from None\n"
 	if !method.Oneway {

--- a/compiler/generator/python/asyncio.go
+++ b/compiler/generator/python/asyncio.go
@@ -275,9 +275,9 @@ func (a *AsyncIOGenerator) generateProcessorFunction(method *parser.Method) stri
 	contents += tabtab + "except Exception as e:\n"
 	if !method.Oneway {
 		contents += tabtabtab + "async with self._lock:\n"
-		contents += tabtabtabtab + fmt.Sprintf("e = _write_application_exception(ctx, oprot, \"%s\", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))\n", methodLower)
+		contents += tabtabtabtab + fmt.Sprintf("_write_application_exception(ctx, oprot, \"%s\", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))\n", methodLower)
 	}
-	contents += tabtabtab + "raise e from None\n"
+	contents += tabtabtab + "raise\n"
 	if !method.Oneway {
 		contents += tabtab + "async with self._lock:\n"
 		contents += tabtabtab + "try:\n"

--- a/test/expected/python.asyncio/actual_base/f_BaseFoo.py
+++ b/test/expected/python.asyncio/actual_base/f_BaseFoo.py
@@ -121,8 +121,8 @@ class _basePing(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "basePing", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
-            raise e from None
+                _write_application_exception(ctx, oprot, "basePing", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
+            raise
         async with self._lock:
             try:
                 oprot.write_response_headers(ctx)

--- a/test/expected/python.asyncio/actual_base/f_BaseFoo.py
+++ b/test/expected/python.asyncio/actual_base/f_BaseFoo.py
@@ -121,7 +121,7 @@ class _basePing(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "basePing", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=e.args[0])
+                e = _write_application_exception(ctx, oprot, "basePing", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
             raise e from None
         async with self._lock:
             try:

--- a/test/expected/python.asyncio/service_extension_same_file/f_BasePinger.py
+++ b/test/expected/python.asyncio/service_extension_same_file/f_BasePinger.py
@@ -121,8 +121,8 @@ class _basePing(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "basePing", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
-            raise e from None
+                _write_application_exception(ctx, oprot, "basePing", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
+            raise
         async with self._lock:
             try:
                 oprot.write_response_headers(ctx)

--- a/test/expected/python.asyncio/service_extension_same_file/f_BasePinger.py
+++ b/test/expected/python.asyncio/service_extension_same_file/f_BasePinger.py
@@ -121,7 +121,7 @@ class _basePing(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "basePing", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=e.args[0])
+                e = _write_application_exception(ctx, oprot, "basePing", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
             raise e from None
         async with self._lock:
             try:

--- a/test/expected/python.asyncio/service_extension_same_file/f_Pinger.py
+++ b/test/expected/python.asyncio/service_extension_same_file/f_Pinger.py
@@ -121,8 +121,8 @@ class _ping(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "ping", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
-            raise e from None
+                _write_application_exception(ctx, oprot, "ping", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
+            raise
         async with self._lock:
             try:
                 oprot.write_response_headers(ctx)

--- a/test/expected/python.asyncio/service_extension_same_file/f_Pinger.py
+++ b/test/expected/python.asyncio/service_extension_same_file/f_Pinger.py
@@ -121,7 +121,7 @@ class _ping(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "ping", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=e.args[0])
+                e = _write_application_exception(ctx, oprot, "ping", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
             raise e from None
         async with self._lock:
             try:

--- a/test/expected/python.asyncio/variety/f_Foo.py
+++ b/test/expected/python.asyncio/variety/f_Foo.py
@@ -525,8 +525,8 @@ class _Ping(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "ping", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
-            raise e from None
+                _write_application_exception(ctx, oprot, "ping", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
+            raise
         async with self._lock:
             try:
                 oprot.write_response_headers(ctx)
@@ -567,8 +567,8 @@ class _blah(FProcessorFunction):
             result.api = api
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "blah", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
-            raise e from None
+                _write_application_exception(ctx, oprot, "blah", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
+            raise
         async with self._lock:
             try:
                 oprot.write_response_headers(ctx)
@@ -602,7 +602,7 @@ class _oneWay(FProcessorFunction):
                 _write_application_exception(ctx, oprot, "oneWay", exception=ex)
                 return
         except Exception as e:
-            raise e from None
+            raise
 
 
 class _bin_method(FProcessorFunction):
@@ -628,8 +628,8 @@ class _bin_method(FProcessorFunction):
             result.api = api
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "bin_method", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
-            raise e from None
+                _write_application_exception(ctx, oprot, "bin_method", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
+            raise
         async with self._lock:
             try:
                 oprot.write_response_headers(ctx)
@@ -666,8 +666,8 @@ class _param_modifiers(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "param_modifiers", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
-            raise e from None
+                _write_application_exception(ctx, oprot, "param_modifiers", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
+            raise
         async with self._lock:
             try:
                 oprot.write_response_headers(ctx)
@@ -704,8 +704,8 @@ class _underlying_types_test(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "underlying_types_test", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
-            raise e from None
+                _write_application_exception(ctx, oprot, "underlying_types_test", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
+            raise
         async with self._lock:
             try:
                 oprot.write_response_headers(ctx)
@@ -742,8 +742,8 @@ class _getThing(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "getThing", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
-            raise e from None
+                _write_application_exception(ctx, oprot, "getThing", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
+            raise
         async with self._lock:
             try:
                 oprot.write_response_headers(ctx)
@@ -780,8 +780,8 @@ class _getMyInt(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "getMyInt", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
-            raise e from None
+                _write_application_exception(ctx, oprot, "getMyInt", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
+            raise
         async with self._lock:
             try:
                 oprot.write_response_headers(ctx)
@@ -818,8 +818,8 @@ class _use_subdir_struct(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "use_subdir_struct", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
-            raise e from None
+                _write_application_exception(ctx, oprot, "use_subdir_struct", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
+            raise
         async with self._lock:
             try:
                 oprot.write_response_headers(ctx)

--- a/test/expected/python.asyncio/variety/f_Foo.py
+++ b/test/expected/python.asyncio/variety/f_Foo.py
@@ -525,7 +525,7 @@ class _Ping(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "ping", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=e.args[0])
+                e = _write_application_exception(ctx, oprot, "ping", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
             raise e from None
         async with self._lock:
             try:
@@ -567,7 +567,7 @@ class _blah(FProcessorFunction):
             result.api = api
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "blah", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=e.args[0])
+                e = _write_application_exception(ctx, oprot, "blah", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
             raise e from None
         async with self._lock:
             try:
@@ -628,7 +628,7 @@ class _bin_method(FProcessorFunction):
             result.api = api
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "bin_method", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=e.args[0])
+                e = _write_application_exception(ctx, oprot, "bin_method", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
             raise e from None
         async with self._lock:
             try:
@@ -666,7 +666,7 @@ class _param_modifiers(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "param_modifiers", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=e.args[0])
+                e = _write_application_exception(ctx, oprot, "param_modifiers", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
             raise e from None
         async with self._lock:
             try:
@@ -704,7 +704,7 @@ class _underlying_types_test(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "underlying_types_test", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=e.args[0])
+                e = _write_application_exception(ctx, oprot, "underlying_types_test", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
             raise e from None
         async with self._lock:
             try:
@@ -742,7 +742,7 @@ class _getThing(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "getThing", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=e.args[0])
+                e = _write_application_exception(ctx, oprot, "getThing", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
             raise e from None
         async with self._lock:
             try:
@@ -780,7 +780,7 @@ class _getMyInt(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "getMyInt", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=e.args[0])
+                e = _write_application_exception(ctx, oprot, "getMyInt", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
             raise e from None
         async with self._lock:
             try:
@@ -818,7 +818,7 @@ class _use_subdir_struct(FProcessorFunction):
                 return
         except Exception as e:
             async with self._lock:
-                e = _write_application_exception(ctx, oprot, "use_subdir_struct", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=e.args[0])
+                e = _write_application_exception(ctx, oprot, "use_subdir_struct", ex_code=TApplicationExceptionType.INTERNAL_ERROR, message=str(e))
             raise e from None
         async with self._lock:
             try:


### PR DESCRIPTION
```python
Python 3.6.3 (default, Oct  4 2017, 06:09:15)
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from graph_api.asyncio.api_data_types.ttypes import GraphServiceError
>>> e = GraphServiceError(isTransient=True)
>>> print(e.args)
()
>>> print(str(e))
GraphServiceError(isTransient=True, code=None, message=None, location=None)
>>>
```
@brianshannan-wf 