### PR TITLE
Python make generated struct hashable

### DIFF
--- a/compiler/generator/python/generator.go
+++ b/compiler/generator/python/generator.go
@@ -764,6 +764,7 @@ func (g *Generator) GenerateServiceImports(file *os.File, s *parser.Service) err
 	imports += "from frugal.processor import FBaseProcessor\n"
 	imports += "from frugal.processor import FProcessorFunction\n"
 	imports += "from frugal.util.deprecate import deprecated\n"
+	imports += "from frugal.util import make_hashable\n"
 	imports += "from thrift.Thrift import TApplicationException\n"
 	imports += "from thrift.Thrift import TMessageType\n"
 	imports += "from thrift.transport.TTransport import TTransportException\n\n"

--- a/compiler/generator/python/generator.go
+++ b/compiler/generator/python/generator.go
@@ -499,7 +499,7 @@ func (g *Generator) generateMagicMethods(s *parser.Struct) string {
 	contents += tab + "def __hash__(self):\n"
 	contents += tabtab + "value = 17\n"
 	for _, field := range s.Fields {
-		contents += fmt.Sprintf(tabtab+"value = (value * 31) ^ hash(self.%s)\n", field.Name)
+		contents += fmt.Sprintf(tabtab+"value = (value * 31) ^ hash(make_hashable(self.%s))\n", field.Name)
 	}
 	contents += tabtab + "return value\n\n"
 
@@ -746,6 +746,7 @@ func (g *Generator) GenerateTypesImports(file *os.File, isArgsOrResult bool) err
 	if isArgsOrResult {
 		contents += "from .ttypes import *\n"
 	}
+	contents += "from frugal.util import make_hashable\n"
 	contents += "from thrift.transport import TTransport\n"
 	contents += "from thrift.protocol import TBinaryProtocol, TProtocol\n"
 

--- a/lib/python/frugal/tests/util/test_make_hashable.py
+++ b/lib/python/frugal/tests/util/test_make_hashable.py
@@ -1,0 +1,47 @@
+# Copyright 2017 Workiva
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from frugal.util import make_hashable
+
+
+class TestMakeHashable(unittest.TestCase):
+    def test_make_hashable_basic(self):
+        s = 'asdfadsf'
+        self.assertEqual(s, make_hashable(s))
+
+    def test_make_hashable_complex(self):
+        data = {
+            1: [[{1, 2}, {3, 4}], [{5, 6}, {7, 8}]],
+            2: [[{10, 11}, {12, 13}], [{14, 15}, {16, 17}]],
+        }
+        expected = (
+            (
+                1,
+                (
+                    (frozenset([1, 2]), frozenset([3, 4])),
+                    (frozenset([5, 6]), frozenset([7, 8])),
+                ),
+            ),
+            (
+                2,
+                (
+                    (frozenset([10, 11]), frozenset([12, 13])),
+                    (frozenset([14, 15]), frozenset([16, 17])),
+                )
+            ),
+        )
+        # make sure that doesn't throw an error
+        hash(expected)
+        self.assertEqual(expected, make_hashable(data))
+
+

--- a/lib/python/frugal/tests/util/test_make_hashable.py
+++ b/lib/python/frugal/tests/util/test_make_hashable.py
@@ -24,7 +24,7 @@ class TestMakeHashable(unittest.TestCase):
             1: [[{1, 2}, {3, 4}], [{5, 6}, {7, 8}]],
             2: [[{10, 11}, {12, 13}], [{14, 15}, {16, 17}]],
         }
-        expected = (
+        expected = frozenset([
             (
                 1,
                 (
@@ -39,7 +39,7 @@ class TestMakeHashable(unittest.TestCase):
                     (frozenset([14, 15]), frozenset([16, 17])),
                 )
             ),
-        )
+        ])
         # make sure that doesn't throw an error
         hash(expected)
         self.assertEqual(expected, make_hashable(data))

--- a/lib/python/frugal/util/__init__.py
+++ b/lib/python/frugal/util/__init__.py
@@ -20,12 +20,11 @@ def make_hashable(thing):
     :param thing: The data to create a hashable representation of.
     """
     if isinstance(thing, list):
-        return tuple([make_hashable(elem) for elem in thing])
+        return tuple(make_hashable(elem) for elem in thing)
     elif isinstance(thing, set):
-        return frozenset([make_hashable(elem) for elem in thing])
+        return frozenset(make_hashable(elem) for elem in thing)
     elif isinstance(thing, dict):
-        new_dict = {make_hashable(k): make_hashable(v)
-                    for k, v in six.iteritems(thing)}
-        return frozenset(six.iteritems(new_dict))
+        return frozenset((make_hashable(k), make_hashable(v))
+                         for k, v in six.iteritems(thing))
     else:
         return thing

--- a/lib/python/frugal/util/__init__.py
+++ b/lib/python/frugal/util/__init__.py
@@ -26,6 +26,6 @@ def make_hashable(thing):
     elif isinstance(thing, dict):
         new_dict = {make_hashable(k): make_hashable(v)
                     for k, v in six.iteritems(thing)}
-        return tuple(six.iteritems(new_dict))
+        return frozenset(six.iteritems(new_dict))
     else:
         return thing

--- a/lib/python/frugal/util/__init__.py
+++ b/lib/python/frugal/util/__init__.py
@@ -13,6 +13,12 @@ import six
 
 
 def make_hashable(thing):
+    """
+    Creates a representation of some input data with immutable collections,
+    so the output is hashable.
+
+    :param thing: The data to create a hashable representation of.
+    """
     if isinstance(thing, list):
         return tuple([make_hashable(elem) for elem in thing])
     elif isinstance(thing, set):

--- a/lib/python/frugal/util/__init__.py
+++ b/lib/python/frugal/util/__init__.py
@@ -8,3 +8,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import six
+
+
+def make_hashable(thing):
+    if isinstance(thing, list):
+        return tuple([make_hashable(elem) for elem in thing])
+    elif isinstance(thing, set):
+        return frozenset([make_hashable(elem) for elem in thing])
+    elif isinstance(thing, dict):
+        new_dict = {make_hashable(k): make_hashable(v)
+                    for k, v in six.iteritems(thing)}
+        return tuple(six.iteritems(new_dict))
+    else:
+        return thing

--- a/test/expected/python.asyncio/actual_base/ttypes.py
+++ b/test/expected/python.asyncio/actual_base/ttypes.py
@@ -6,6 +6,7 @@
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 
+from frugal.util import make_hashable
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol
 
@@ -81,8 +82,8 @@ class thing(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.an_id)
-        value = (value * 31) ^ hash(self.a_string)
+        value = (value * 31) ^ hash(make_hashable(self.an_id))
+        value = (value * 31) ^ hash(make_hashable(self.a_string))
         return value
 
     def __repr__(self):
@@ -145,7 +146,7 @@ class nested_thing(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.things)
+        value = (value * 31) ^ hash(make_hashable(self.things))
         return value
 
     def __repr__(self):

--- a/test/expected/python.asyncio/variety/f_Foo.py
+++ b/test/expected/python.asyncio/variety/f_Foo.py
@@ -984,9 +984,9 @@ class blah_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.num)
-        value = (value * 31) ^ hash(self.Str)
-        value = (value * 31) ^ hash(self.event)
+        value = (value * 31) ^ hash(make_hashable(self.num))
+        value = (value * 31) ^ hash(make_hashable(self.Str))
+        value = (value * 31) ^ hash(make_hashable(self.event))
         return value
 
     def __repr__(self):
@@ -1064,9 +1064,9 @@ class blah_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
-        value = (value * 31) ^ hash(self.awe)
-        value = (value * 31) ^ hash(self.api)
+        value = (value * 31) ^ hash(make_hashable(self.success))
+        value = (value * 31) ^ hash(make_hashable(self.awe))
+        value = (value * 31) ^ hash(make_hashable(self.api))
         return value
 
     def __repr__(self):
@@ -1141,8 +1141,8 @@ class oneWay_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.id)
-        value = (value * 31) ^ hash(self.req)
+        value = (value * 31) ^ hash(make_hashable(self.id))
+        value = (value * 31) ^ hash(make_hashable(self.req))
         return value
 
     def __repr__(self):
@@ -1207,8 +1207,8 @@ class bin_method_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.bin)
-        value = (value * 31) ^ hash(self.Str)
+        value = (value * 31) ^ hash(make_hashable(self.bin))
+        value = (value * 31) ^ hash(make_hashable(self.Str))
         return value
 
     def __repr__(self):
@@ -1274,8 +1274,8 @@ class bin_method_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
-        value = (value * 31) ^ hash(self.api)
+        value = (value * 31) ^ hash(make_hashable(self.success))
+        value = (value * 31) ^ hash(make_hashable(self.api))
         return value
 
     def __repr__(self):
@@ -1353,9 +1353,9 @@ class param_modifiers_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.opt_num)
-        value = (value * 31) ^ hash(self.default_num)
-        value = (value * 31) ^ hash(self.req_num)
+        value = (value * 31) ^ hash(make_hashable(self.opt_num))
+        value = (value * 31) ^ hash(make_hashable(self.default_num))
+        value = (value * 31) ^ hash(make_hashable(self.req_num))
         return value
 
     def __repr__(self):
@@ -1409,7 +1409,7 @@ class param_modifiers_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):
@@ -1490,8 +1490,8 @@ class underlying_types_test_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.list_type)
-        value = (value * 31) ^ hash(self.set_type)
+        value = (value * 31) ^ hash(make_hashable(self.list_type))
+        value = (value * 31) ^ hash(make_hashable(self.set_type))
         return value
 
     def __repr__(self):
@@ -1553,7 +1553,7 @@ class underlying_types_test_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):
@@ -1645,7 +1645,7 @@ class getThing_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):
@@ -1736,7 +1736,7 @@ class getMyInt_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):
@@ -1791,7 +1791,7 @@ class use_subdir_struct_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.a)
+        value = (value * 31) ^ hash(make_hashable(self.a))
         return value
 
     def __repr__(self):
@@ -1846,7 +1846,7 @@ class use_subdir_struct_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):

--- a/test/expected/python.asyncio/variety/ttypes.py
+++ b/test/expected/python.asyncio/variety/ttypes.py
@@ -16,6 +16,7 @@ import ValidTypes.constants
 import subdir_include.ttypes
 import subdir_include.constants
 
+from frugal.util import make_hashable
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol
 
@@ -113,7 +114,7 @@ class TestBase(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.base_struct)
+        value = (value * 31) ^ hash(make_hashable(self.base_struct))
         return value
 
     def __repr__(self):
@@ -167,7 +168,7 @@ class TestLowercase(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.lowercaseInt)
+        value = (value * 31) ^ hash(make_hashable(self.lowercaseInt))
         return value
 
     def __repr__(self):
@@ -237,8 +238,8 @@ class Event(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.ID)
-        value = (value * 31) ^ hash(self.Message)
+        value = (value * 31) ^ hash(make_hashable(self.ID))
+        value = (value * 31) ^ hash(make_hashable(self.Message))
         return value
 
     def __repr__(self):
@@ -580,24 +581,24 @@ class TestingDefaults(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.ID2)
-        value = (value * 31) ^ hash(self.ev1)
-        value = (value * 31) ^ hash(self.ev2)
-        value = (value * 31) ^ hash(self.ID)
-        value = (value * 31) ^ hash(self.thing)
-        value = (value * 31) ^ hash(self.thing2)
-        value = (value * 31) ^ hash(self.listfield)
-        value = (value * 31) ^ hash(self.ID3)
-        value = (value * 31) ^ hash(self.bin_field)
-        value = (value * 31) ^ hash(self.bin_field2)
-        value = (value * 31) ^ hash(self.bin_field3)
-        value = (value * 31) ^ hash(self.bin_field4)
-        value = (value * 31) ^ hash(self.list2)
-        value = (value * 31) ^ hash(self.list3)
-        value = (value * 31) ^ hash(self.list4)
-        value = (value * 31) ^ hash(self.a_map)
-        value = (value * 31) ^ hash(self.status)
-        value = (value * 31) ^ hash(self.base_status)
+        value = (value * 31) ^ hash(make_hashable(self.ID2))
+        value = (value * 31) ^ hash(make_hashable(self.ev1))
+        value = (value * 31) ^ hash(make_hashable(self.ev2))
+        value = (value * 31) ^ hash(make_hashable(self.ID))
+        value = (value * 31) ^ hash(make_hashable(self.thing))
+        value = (value * 31) ^ hash(make_hashable(self.thing2))
+        value = (value * 31) ^ hash(make_hashable(self.listfield))
+        value = (value * 31) ^ hash(make_hashable(self.ID3))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field2))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field3))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field4))
+        value = (value * 31) ^ hash(make_hashable(self.list2))
+        value = (value * 31) ^ hash(make_hashable(self.list3))
+        value = (value * 31) ^ hash(make_hashable(self.list4))
+        value = (value * 31) ^ hash(make_hashable(self.a_map))
+        value = (value * 31) ^ hash(make_hashable(self.status))
+        value = (value * 31) ^ hash(make_hashable(self.base_status))
         return value
 
     def __repr__(self):
@@ -807,16 +808,16 @@ class EventWrapper(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.ID)
-        value = (value * 31) ^ hash(self.Ev)
-        value = (value * 31) ^ hash(self.Events)
-        value = (value * 31) ^ hash(self.Events2)
-        value = (value * 31) ^ hash(self.EventMap)
-        value = (value * 31) ^ hash(self.Nums)
-        value = (value * 31) ^ hash(self.Enums)
-        value = (value * 31) ^ hash(self.aBoolField)
-        value = (value * 31) ^ hash(self.a_union)
-        value = (value * 31) ^ hash(self.typedefOfTypedef)
+        value = (value * 31) ^ hash(make_hashable(self.ID))
+        value = (value * 31) ^ hash(make_hashable(self.Ev))
+        value = (value * 31) ^ hash(make_hashable(self.Events))
+        value = (value * 31) ^ hash(make_hashable(self.Events2))
+        value = (value * 31) ^ hash(make_hashable(self.EventMap))
+        value = (value * 31) ^ hash(make_hashable(self.Nums))
+        value = (value * 31) ^ hash(make_hashable(self.Enums))
+        value = (value * 31) ^ hash(make_hashable(self.aBoolField))
+        value = (value * 31) ^ hash(make_hashable(self.a_union))
+        value = (value * 31) ^ hash(make_hashable(self.typedefOfTypedef))
         return value
 
     def __repr__(self):
@@ -950,12 +951,12 @@ class TestingUnions(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.AnID)
-        value = (value * 31) ^ hash(self.aString)
-        value = (value * 31) ^ hash(self.someotherthing)
-        value = (value * 31) ^ hash(self.AnInt16)
-        value = (value * 31) ^ hash(self.Requests)
-        value = (value * 31) ^ hash(self.bin_field_in_union)
+        value = (value * 31) ^ hash(make_hashable(self.AnID))
+        value = (value * 31) ^ hash(make_hashable(self.aString))
+        value = (value * 31) ^ hash(make_hashable(self.someotherthing))
+        value = (value * 31) ^ hash(make_hashable(self.AnInt16))
+        value = (value * 31) ^ hash(make_hashable(self.Requests))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field_in_union))
         return value
 
     def __repr__(self):
@@ -1023,8 +1024,8 @@ class AwesomeException(TException):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.ID)
-        value = (value * 31) ^ hash(self.Reason)
+        value = (value * 31) ^ hash(make_hashable(self.ID))
+        value = (value * 31) ^ hash(make_hashable(self.Reason))
         return value
 
     def __repr__(self):

--- a/test/expected/python.tornado/actual_base/ttypes.py
+++ b/test/expected/python.tornado/actual_base/ttypes.py
@@ -6,6 +6,7 @@
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 
+from frugal.util import make_hashable
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol
 
@@ -81,8 +82,8 @@ class thing(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.an_id)
-        value = (value * 31) ^ hash(self.a_string)
+        value = (value * 31) ^ hash(make_hashable(self.an_id))
+        value = (value * 31) ^ hash(make_hashable(self.a_string))
         return value
 
     def __repr__(self):
@@ -145,7 +146,7 @@ class nested_thing(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.things)
+        value = (value * 31) ^ hash(make_hashable(self.things))
         return value
 
     def __repr__(self):

--- a/test/expected/python.tornado/variety/f_Foo.py
+++ b/test/expected/python.tornado/variety/f_Foo.py
@@ -972,9 +972,9 @@ class blah_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.num)
-        value = (value * 31) ^ hash(self.Str)
-        value = (value * 31) ^ hash(self.event)
+        value = (value * 31) ^ hash(make_hashable(self.num))
+        value = (value * 31) ^ hash(make_hashable(self.Str))
+        value = (value * 31) ^ hash(make_hashable(self.event))
         return value
 
     def __repr__(self):
@@ -1052,9 +1052,9 @@ class blah_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
-        value = (value * 31) ^ hash(self.awe)
-        value = (value * 31) ^ hash(self.api)
+        value = (value * 31) ^ hash(make_hashable(self.success))
+        value = (value * 31) ^ hash(make_hashable(self.awe))
+        value = (value * 31) ^ hash(make_hashable(self.api))
         return value
 
     def __repr__(self):
@@ -1129,8 +1129,8 @@ class oneWay_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.id)
-        value = (value * 31) ^ hash(self.req)
+        value = (value * 31) ^ hash(make_hashable(self.id))
+        value = (value * 31) ^ hash(make_hashable(self.req))
         return value
 
     def __repr__(self):
@@ -1195,8 +1195,8 @@ class bin_method_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.bin)
-        value = (value * 31) ^ hash(self.Str)
+        value = (value * 31) ^ hash(make_hashable(self.bin))
+        value = (value * 31) ^ hash(make_hashable(self.Str))
         return value
 
     def __repr__(self):
@@ -1262,8 +1262,8 @@ class bin_method_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
-        value = (value * 31) ^ hash(self.api)
+        value = (value * 31) ^ hash(make_hashable(self.success))
+        value = (value * 31) ^ hash(make_hashable(self.api))
         return value
 
     def __repr__(self):
@@ -1341,9 +1341,9 @@ class param_modifiers_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.opt_num)
-        value = (value * 31) ^ hash(self.default_num)
-        value = (value * 31) ^ hash(self.req_num)
+        value = (value * 31) ^ hash(make_hashable(self.opt_num))
+        value = (value * 31) ^ hash(make_hashable(self.default_num))
+        value = (value * 31) ^ hash(make_hashable(self.req_num))
         return value
 
     def __repr__(self):
@@ -1397,7 +1397,7 @@ class param_modifiers_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):
@@ -1478,8 +1478,8 @@ class underlying_types_test_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.list_type)
-        value = (value * 31) ^ hash(self.set_type)
+        value = (value * 31) ^ hash(make_hashable(self.list_type))
+        value = (value * 31) ^ hash(make_hashable(self.set_type))
         return value
 
     def __repr__(self):
@@ -1541,7 +1541,7 @@ class underlying_types_test_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):
@@ -1633,7 +1633,7 @@ class getThing_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):
@@ -1724,7 +1724,7 @@ class getMyInt_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):
@@ -1779,7 +1779,7 @@ class use_subdir_struct_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.a)
+        value = (value * 31) ^ hash(make_hashable(self.a))
         return value
 
     def __repr__(self):
@@ -1834,7 +1834,7 @@ class use_subdir_struct_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):

--- a/test/expected/python.tornado/variety/ttypes.py
+++ b/test/expected/python.tornado/variety/ttypes.py
@@ -16,6 +16,7 @@ import ValidTypes.constants
 import subdir_include.ttypes
 import subdir_include.constants
 
+from frugal.util import make_hashable
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol
 
@@ -113,7 +114,7 @@ class TestBase(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.base_struct)
+        value = (value * 31) ^ hash(make_hashable(self.base_struct))
         return value
 
     def __repr__(self):
@@ -167,7 +168,7 @@ class TestLowercase(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.lowercaseInt)
+        value = (value * 31) ^ hash(make_hashable(self.lowercaseInt))
         return value
 
     def __repr__(self):
@@ -237,8 +238,8 @@ class Event(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.ID)
-        value = (value * 31) ^ hash(self.Message)
+        value = (value * 31) ^ hash(make_hashable(self.ID))
+        value = (value * 31) ^ hash(make_hashable(self.Message))
         return value
 
     def __repr__(self):
@@ -580,24 +581,24 @@ class TestingDefaults(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.ID2)
-        value = (value * 31) ^ hash(self.ev1)
-        value = (value * 31) ^ hash(self.ev2)
-        value = (value * 31) ^ hash(self.ID)
-        value = (value * 31) ^ hash(self.thing)
-        value = (value * 31) ^ hash(self.thing2)
-        value = (value * 31) ^ hash(self.listfield)
-        value = (value * 31) ^ hash(self.ID3)
-        value = (value * 31) ^ hash(self.bin_field)
-        value = (value * 31) ^ hash(self.bin_field2)
-        value = (value * 31) ^ hash(self.bin_field3)
-        value = (value * 31) ^ hash(self.bin_field4)
-        value = (value * 31) ^ hash(self.list2)
-        value = (value * 31) ^ hash(self.list3)
-        value = (value * 31) ^ hash(self.list4)
-        value = (value * 31) ^ hash(self.a_map)
-        value = (value * 31) ^ hash(self.status)
-        value = (value * 31) ^ hash(self.base_status)
+        value = (value * 31) ^ hash(make_hashable(self.ID2))
+        value = (value * 31) ^ hash(make_hashable(self.ev1))
+        value = (value * 31) ^ hash(make_hashable(self.ev2))
+        value = (value * 31) ^ hash(make_hashable(self.ID))
+        value = (value * 31) ^ hash(make_hashable(self.thing))
+        value = (value * 31) ^ hash(make_hashable(self.thing2))
+        value = (value * 31) ^ hash(make_hashable(self.listfield))
+        value = (value * 31) ^ hash(make_hashable(self.ID3))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field2))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field3))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field4))
+        value = (value * 31) ^ hash(make_hashable(self.list2))
+        value = (value * 31) ^ hash(make_hashable(self.list3))
+        value = (value * 31) ^ hash(make_hashable(self.list4))
+        value = (value * 31) ^ hash(make_hashable(self.a_map))
+        value = (value * 31) ^ hash(make_hashable(self.status))
+        value = (value * 31) ^ hash(make_hashable(self.base_status))
         return value
 
     def __repr__(self):
@@ -807,16 +808,16 @@ class EventWrapper(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.ID)
-        value = (value * 31) ^ hash(self.Ev)
-        value = (value * 31) ^ hash(self.Events)
-        value = (value * 31) ^ hash(self.Events2)
-        value = (value * 31) ^ hash(self.EventMap)
-        value = (value * 31) ^ hash(self.Nums)
-        value = (value * 31) ^ hash(self.Enums)
-        value = (value * 31) ^ hash(self.aBoolField)
-        value = (value * 31) ^ hash(self.a_union)
-        value = (value * 31) ^ hash(self.typedefOfTypedef)
+        value = (value * 31) ^ hash(make_hashable(self.ID))
+        value = (value * 31) ^ hash(make_hashable(self.Ev))
+        value = (value * 31) ^ hash(make_hashable(self.Events))
+        value = (value * 31) ^ hash(make_hashable(self.Events2))
+        value = (value * 31) ^ hash(make_hashable(self.EventMap))
+        value = (value * 31) ^ hash(make_hashable(self.Nums))
+        value = (value * 31) ^ hash(make_hashable(self.Enums))
+        value = (value * 31) ^ hash(make_hashable(self.aBoolField))
+        value = (value * 31) ^ hash(make_hashable(self.a_union))
+        value = (value * 31) ^ hash(make_hashable(self.typedefOfTypedef))
         return value
 
     def __repr__(self):
@@ -950,12 +951,12 @@ class TestingUnions(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.AnID)
-        value = (value * 31) ^ hash(self.aString)
-        value = (value * 31) ^ hash(self.someotherthing)
-        value = (value * 31) ^ hash(self.AnInt16)
-        value = (value * 31) ^ hash(self.Requests)
-        value = (value * 31) ^ hash(self.bin_field_in_union)
+        value = (value * 31) ^ hash(make_hashable(self.AnID))
+        value = (value * 31) ^ hash(make_hashable(self.aString))
+        value = (value * 31) ^ hash(make_hashable(self.someotherthing))
+        value = (value * 31) ^ hash(make_hashable(self.AnInt16))
+        value = (value * 31) ^ hash(make_hashable(self.Requests))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field_in_union))
         return value
 
     def __repr__(self):
@@ -1023,8 +1024,8 @@ class AwesomeException(TException):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.ID)
-        value = (value * 31) ^ hash(self.Reason)
+        value = (value * 31) ^ hash(make_hashable(self.ID))
+        value = (value * 31) ^ hash(make_hashable(self.Reason))
         return value
 
     def __repr__(self):

--- a/test/expected/python/actual_base/f_BaseFoo.py
+++ b/test/expected/python/actual_base/f_BaseFoo.py
@@ -14,6 +14,7 @@ from frugal.exceptions import TTransportExceptionType
 from frugal.processor import FBaseProcessor
 from frugal.processor import FProcessorFunction
 from frugal.util.deprecate import deprecated
+from frugal.util import make_hashable
 from thrift.Thrift import TApplicationException
 from thrift.Thrift import TMessageType
 from thrift.transport.TTransport import TTransportException

--- a/test/expected/python/actual_base/ttypes.py
+++ b/test/expected/python/actual_base/ttypes.py
@@ -6,6 +6,7 @@
 
 from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 
+from frugal.util import make_hashable
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol
 
@@ -81,8 +82,8 @@ class thing(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.an_id)
-        value = (value * 31) ^ hash(self.a_string)
+        value = (value * 31) ^ hash(make_hashable(self.an_id))
+        value = (value * 31) ^ hash(make_hashable(self.a_string))
         return value
 
     def __repr__(self):
@@ -145,7 +146,7 @@ class nested_thing(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.things)
+        value = (value * 31) ^ hash(make_hashable(self.things))
         return value
 
     def __repr__(self):

--- a/test/expected/python/package_prefix/f_Foo.py
+++ b/test/expected/python/package_prefix/f_Foo.py
@@ -201,7 +201,7 @@ class get_thing_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.the_thing)
+        value = (value * 31) ^ hash(make_hashable(self.the_thing))
         return value
 
     def __repr__(self):
@@ -256,7 +256,7 @@ class get_thing_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):

--- a/test/expected/python/package_prefix/f_Foo.py
+++ b/test/expected/python/package_prefix/f_Foo.py
@@ -14,6 +14,7 @@ from frugal.exceptions import TTransportExceptionType
 from frugal.processor import FBaseProcessor
 from frugal.processor import FProcessorFunction
 from frugal.util.deprecate import deprecated
+from frugal.util import make_hashable
 from thrift.Thrift import TApplicationException
 from thrift.Thrift import TMessageType
 from thrift.transport.TTransport import TTransportException

--- a/test/expected/python/package_prefix/ttypes.py
+++ b/test/expected/python/package_prefix/ttypes.py
@@ -8,6 +8,7 @@ from thrift.Thrift import TType, TMessageType, TException, TApplicationException
 import generic_package_prefix.actual_base.python.ttypes
 import generic_package_prefix.actual_base.python.constants
 
+from frugal.util import make_hashable
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol
 
@@ -53,7 +54,7 @@ class new_thing(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.wrapped_thing)
+        value = (value * 31) ^ hash(make_hashable(self.wrapped_thing))
         return value
 
     def __repr__(self):

--- a/test/expected/python/variety/f_Foo.py
+++ b/test/expected/python/variety/f_Foo.py
@@ -14,6 +14,7 @@ from frugal.exceptions import TTransportExceptionType
 from frugal.processor import FBaseProcessor
 from frugal.processor import FProcessorFunction
 from frugal.util.deprecate import deprecated
+from frugal.util import make_hashable
 from thrift.Thrift import TApplicationException
 from thrift.Thrift import TMessageType
 from thrift.transport.TTransport import TTransportException

--- a/test/expected/python/variety/f_Foo.py
+++ b/test/expected/python/variety/f_Foo.py
@@ -1024,9 +1024,9 @@ class blah_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.num)
-        value = (value * 31) ^ hash(self.Str)
-        value = (value * 31) ^ hash(self.event)
+        value = (value * 31) ^ hash(make_hashable(self.num))
+        value = (value * 31) ^ hash(make_hashable(self.Str))
+        value = (value * 31) ^ hash(make_hashable(self.event))
         return value
 
     def __repr__(self):
@@ -1104,9 +1104,9 @@ class blah_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
-        value = (value * 31) ^ hash(self.awe)
-        value = (value * 31) ^ hash(self.api)
+        value = (value * 31) ^ hash(make_hashable(self.success))
+        value = (value * 31) ^ hash(make_hashable(self.awe))
+        value = (value * 31) ^ hash(make_hashable(self.api))
         return value
 
     def __repr__(self):
@@ -1181,8 +1181,8 @@ class oneWay_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.id)
-        value = (value * 31) ^ hash(self.req)
+        value = (value * 31) ^ hash(make_hashable(self.id))
+        value = (value * 31) ^ hash(make_hashable(self.req))
         return value
 
     def __repr__(self):
@@ -1247,8 +1247,8 @@ class bin_method_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.bin)
-        value = (value * 31) ^ hash(self.Str)
+        value = (value * 31) ^ hash(make_hashable(self.bin))
+        value = (value * 31) ^ hash(make_hashable(self.Str))
         return value
 
     def __repr__(self):
@@ -1314,8 +1314,8 @@ class bin_method_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
-        value = (value * 31) ^ hash(self.api)
+        value = (value * 31) ^ hash(make_hashable(self.success))
+        value = (value * 31) ^ hash(make_hashable(self.api))
         return value
 
     def __repr__(self):
@@ -1393,9 +1393,9 @@ class param_modifiers_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.opt_num)
-        value = (value * 31) ^ hash(self.default_num)
-        value = (value * 31) ^ hash(self.req_num)
+        value = (value * 31) ^ hash(make_hashable(self.opt_num))
+        value = (value * 31) ^ hash(make_hashable(self.default_num))
+        value = (value * 31) ^ hash(make_hashable(self.req_num))
         return value
 
     def __repr__(self):
@@ -1449,7 +1449,7 @@ class param_modifiers_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):
@@ -1530,8 +1530,8 @@ class underlying_types_test_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.list_type)
-        value = (value * 31) ^ hash(self.set_type)
+        value = (value * 31) ^ hash(make_hashable(self.list_type))
+        value = (value * 31) ^ hash(make_hashable(self.set_type))
         return value
 
     def __repr__(self):
@@ -1593,7 +1593,7 @@ class underlying_types_test_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):
@@ -1685,7 +1685,7 @@ class getThing_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):
@@ -1776,7 +1776,7 @@ class getMyInt_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):
@@ -1831,7 +1831,7 @@ class use_subdir_struct_args(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.a)
+        value = (value * 31) ^ hash(make_hashable(self.a))
         return value
 
     def __repr__(self):
@@ -1886,7 +1886,7 @@ class use_subdir_struct_result(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.success)
+        value = (value * 31) ^ hash(make_hashable(self.success))
         return value
 
     def __repr__(self):

--- a/test/expected/python/variety/ttypes.py
+++ b/test/expected/python/variety/ttypes.py
@@ -16,6 +16,7 @@ import ValidTypes.constants
 import subdir_include.ttypes
 import subdir_include.constants
 
+from frugal.util import make_hashable
 from thrift.transport import TTransport
 from thrift.protocol import TBinaryProtocol, TProtocol
 
@@ -113,7 +114,7 @@ class TestBase(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.base_struct)
+        value = (value * 31) ^ hash(make_hashable(self.base_struct))
         return value
 
     def __repr__(self):
@@ -167,7 +168,7 @@ class TestLowercase(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.lowercaseInt)
+        value = (value * 31) ^ hash(make_hashable(self.lowercaseInt))
         return value
 
     def __repr__(self):
@@ -237,8 +238,8 @@ class Event(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.ID)
-        value = (value * 31) ^ hash(self.Message)
+        value = (value * 31) ^ hash(make_hashable(self.ID))
+        value = (value * 31) ^ hash(make_hashable(self.Message))
         return value
 
     def __repr__(self):
@@ -580,24 +581,24 @@ class TestingDefaults(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.ID2)
-        value = (value * 31) ^ hash(self.ev1)
-        value = (value * 31) ^ hash(self.ev2)
-        value = (value * 31) ^ hash(self.ID)
-        value = (value * 31) ^ hash(self.thing)
-        value = (value * 31) ^ hash(self.thing2)
-        value = (value * 31) ^ hash(self.listfield)
-        value = (value * 31) ^ hash(self.ID3)
-        value = (value * 31) ^ hash(self.bin_field)
-        value = (value * 31) ^ hash(self.bin_field2)
-        value = (value * 31) ^ hash(self.bin_field3)
-        value = (value * 31) ^ hash(self.bin_field4)
-        value = (value * 31) ^ hash(self.list2)
-        value = (value * 31) ^ hash(self.list3)
-        value = (value * 31) ^ hash(self.list4)
-        value = (value * 31) ^ hash(self.a_map)
-        value = (value * 31) ^ hash(self.status)
-        value = (value * 31) ^ hash(self.base_status)
+        value = (value * 31) ^ hash(make_hashable(self.ID2))
+        value = (value * 31) ^ hash(make_hashable(self.ev1))
+        value = (value * 31) ^ hash(make_hashable(self.ev2))
+        value = (value * 31) ^ hash(make_hashable(self.ID))
+        value = (value * 31) ^ hash(make_hashable(self.thing))
+        value = (value * 31) ^ hash(make_hashable(self.thing2))
+        value = (value * 31) ^ hash(make_hashable(self.listfield))
+        value = (value * 31) ^ hash(make_hashable(self.ID3))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field2))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field3))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field4))
+        value = (value * 31) ^ hash(make_hashable(self.list2))
+        value = (value * 31) ^ hash(make_hashable(self.list3))
+        value = (value * 31) ^ hash(make_hashable(self.list4))
+        value = (value * 31) ^ hash(make_hashable(self.a_map))
+        value = (value * 31) ^ hash(make_hashable(self.status))
+        value = (value * 31) ^ hash(make_hashable(self.base_status))
         return value
 
     def __repr__(self):
@@ -807,16 +808,16 @@ class EventWrapper(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.ID)
-        value = (value * 31) ^ hash(self.Ev)
-        value = (value * 31) ^ hash(self.Events)
-        value = (value * 31) ^ hash(self.Events2)
-        value = (value * 31) ^ hash(self.EventMap)
-        value = (value * 31) ^ hash(self.Nums)
-        value = (value * 31) ^ hash(self.Enums)
-        value = (value * 31) ^ hash(self.aBoolField)
-        value = (value * 31) ^ hash(self.a_union)
-        value = (value * 31) ^ hash(self.typedefOfTypedef)
+        value = (value * 31) ^ hash(make_hashable(self.ID))
+        value = (value * 31) ^ hash(make_hashable(self.Ev))
+        value = (value * 31) ^ hash(make_hashable(self.Events))
+        value = (value * 31) ^ hash(make_hashable(self.Events2))
+        value = (value * 31) ^ hash(make_hashable(self.EventMap))
+        value = (value * 31) ^ hash(make_hashable(self.Nums))
+        value = (value * 31) ^ hash(make_hashable(self.Enums))
+        value = (value * 31) ^ hash(make_hashable(self.aBoolField))
+        value = (value * 31) ^ hash(make_hashable(self.a_union))
+        value = (value * 31) ^ hash(make_hashable(self.typedefOfTypedef))
         return value
 
     def __repr__(self):
@@ -950,12 +951,12 @@ class TestingUnions(object):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.AnID)
-        value = (value * 31) ^ hash(self.aString)
-        value = (value * 31) ^ hash(self.someotherthing)
-        value = (value * 31) ^ hash(self.AnInt16)
-        value = (value * 31) ^ hash(self.Requests)
-        value = (value * 31) ^ hash(self.bin_field_in_union)
+        value = (value * 31) ^ hash(make_hashable(self.AnID))
+        value = (value * 31) ^ hash(make_hashable(self.aString))
+        value = (value * 31) ^ hash(make_hashable(self.someotherthing))
+        value = (value * 31) ^ hash(make_hashable(self.AnInt16))
+        value = (value * 31) ^ hash(make_hashable(self.Requests))
+        value = (value * 31) ^ hash(make_hashable(self.bin_field_in_union))
         return value
 
     def __repr__(self):
@@ -1023,8 +1024,8 @@ class AwesomeException(TException):
 
     def __hash__(self):
         value = 17
-        value = (value * 31) ^ hash(self.ID)
-        value = (value * 31) ^ hash(self.Reason)
+        value = (value * 31) ^ hash(make_hashable(self.ID))
+        value = (value * 31) ^ hash(make_hashable(self.Reason))
         return value
 
     def __repr__(self):


### PR DESCRIPTION
Lists, sets, and maps aren't hashable in python. This converts said structures to a hashable form so the `__hash__` function should work in the generated code.

@Workiva/infre-product @Workiva/messaging-pp @sagesmith-wf @theisensanders-wf 
