### PR TITLE
java: Add FContext methods to remove headers

### DIFF
--- a/lib/java/src/main/java/com/workiva/frugal/FContext.java
+++ b/lib/java/src/main/java/com/workiva/frugal/FContext.java
@@ -159,6 +159,19 @@ public class FContext implements Cloneable {
     }
 
     /**
+     * Removes a request header from the FContext for the given name.
+     * The _opid header is reserved and removing it could interfere with asynchronous transports that rely upon it.
+     * Returns the same FContext to allow for call chaining.
+     *
+     * @param name header name
+     * @return FContext
+     */
+    public FContext removeRequestHeader(String name) {
+        requestHeaders.remove(name);
+        return this;
+    }
+
+    /**
      * Adds a response header to the FContext for the given name. A header is a key-value pair.
      * If a header with the name is already present on the FContext, it will be replaced.
      * The _opid header is reserved and setting it could interfere with asynchronous transports that rely upon it.
@@ -185,6 +198,19 @@ public class FContext implements Cloneable {
         for (Map.Entry<String, String> pair : headers.entrySet()) {
             addResponseHeader(pair.getKey(), pair.getValue());
         }
+        return this;
+    }
+
+    /**
+     * Removes a response header from the FContext for the given name.
+     * The _opid header is reserved and removing it could interfere with asynchronous transports that rely upon it.
+     * Returns the same FContext to allow for call chaining.
+     *
+     * @param name header name
+     * @return FContext
+     */
+    public FContext removeResponseHeader(String name) {
+        responseHeaders.remove(name);
         return this;
     }
 

--- a/lib/java/src/test/java/com/workiva/frugal/FContextTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/FContextTest.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
@@ -57,6 +58,9 @@ public class FContextTest {
         assertEquals(ctx, ctx.addRequestHeader(FContext.CID_HEADER, "123"));
         assertEquals("bar", ctx.getRequestHeader("foo"));
         assertNull(ctx.getRequestHeader("blah"));
+        assertEquals(ctx, ctx.removeRequestHeader("foo"));
+        assertNull(ctx.getRequestHeader("foo"));
+        assertFalse(ctx.getRequestHeaders().containsKey("foo"));
     }
 
     @Test
@@ -78,6 +82,9 @@ public class FContextTest {
         assertEquals(ctx, ctx.addResponseHeader(FContext.OPID_HEADER, "1"));
         assertEquals("bar", ctx.getResponseHeader("foo"));
         assertNull(ctx.getResponseHeader("blah"));
+        assertEquals(ctx, ctx.removeResponseHeader("foo"));
+        assertNull(ctx.getResponseHeader("foo"));
+        assertFalse(ctx.getResponseHeaders().containsKey("foo"));
     }
 
     @Test


### PR DESCRIPTION
It is useful to be able to clone an FContext in order to clone correlation id, tracing, etc. headers but to remove others.

@Workiva/messaging-pp 