### PR TITLE
java: Avoid comment for default requiredness

### DIFF
--- a/compiler/generator/java/generator.go
+++ b/compiler/generator/java/generator.go
@@ -916,12 +916,18 @@ func (g *Generator) generateInstanceVars(s *parser.Struct) string {
 		if field.Comment != nil {
 			contents += g.GenerateBlockComment(field.Comment, tab)
 		}
-		modifier := "required"
-		if field.Modifier == parser.Optional {
+		modifier := ""
+		if field.Modifier == parser.Required {
+			modifier = "required"
+		} else if field.Modifier == parser.Optional {
 			modifier = "optional"
 		}
-		contents += fmt.Sprintf(tab+"public %s %s; // %s\n",
-			g.getJavaTypeFromThriftType(field.Type), field.Name, modifier)
+		modifierComment := ""
+		if modifier != "" {
+			modifierComment = " // " + modifier
+		}
+		contents += fmt.Sprintf(tab+"public %s %s;%s\n",
+			g.getJavaTypeFromThriftType(field.Type), field.Name, modifierComment)
 	}
 	return contents
 }

--- a/test/expected/java/actual_base/nested_thing.java
+++ b/test/expected/java/actual_base/nested_thing.java
@@ -45,7 +45,7 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 		schemes.put(TupleScheme.class, new nested_thingTupleSchemeFactory());
 	}
 
-	public java.util.List<thing> things; // required
+	public java.util.List<thing> things;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		THINGS((short)1, "things")

--- a/test/expected/java/actual_base/thing.java
+++ b/test/expected/java/actual_base/thing.java
@@ -46,8 +46,8 @@ public class thing implements org.apache.thrift.TBase<thing, thing._Fields>, jav
 		schemes.put(TupleScheme.class, new thingTupleSchemeFactory());
 	}
 
-	public int an_id; // required
-	public String a_string; // required
+	public int an_id;
+	public String a_string;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		AN_ID((short)1, "an_id"),

--- a/test/expected/java/boxed_primitives/FFoo.java
+++ b/test/expected/java/boxed_primitives/FFoo.java
@@ -1456,9 +1456,9 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 		schemes.put(TupleScheme.class, new blah_argsTupleSchemeFactory());
 	}
 
-	public Integer num; // required
-	public String Str; // required
-	public Event event; // required
+	public Integer num;
+	public String Str;
+	public Event event;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		NUM((short)1, "num"),
@@ -2029,9 +2029,9 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 		schemes.put(TupleScheme.class, new blah_resultTupleSchemeFactory());
 	}
 
-	public Long success; // required
-	public AwesomeException awe; // required
-	public actual_base.java.api_exception api; // required
+	public Long success;
+	public AwesomeException awe;
+	public actual_base.java.api_exception api;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success"),
@@ -2606,8 +2606,8 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 		schemes.put(TupleScheme.class, new oneWay_argsTupleSchemeFactory());
 	}
 
-	public Long id; // required
-	public java.util.Map<Integer, String> req; // required
+	public Long id;
+	public java.util.Map<Integer, String> req;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		ID((short)1, "id"),
@@ -3116,8 +3116,8 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 		schemes.put(TupleScheme.class, new bin_method_argsTupleSchemeFactory());
 	}
 
-	public java.nio.ByteBuffer bin; // required
-	public String Str; // required
+	public java.nio.ByteBuffer bin;
+	public String Str;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		BIN((short)1, "bin"),
@@ -3586,8 +3586,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 		schemes.put(TupleScheme.class, new bin_method_resultTupleSchemeFactory());
 	}
 
-	public java.nio.ByteBuffer success; // required
-	public actual_base.java.api_exception api; // required
+	public java.nio.ByteBuffer success;
+	public actual_base.java.api_exception api;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success"),
@@ -4060,8 +4060,8 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 		schemes.put(TupleScheme.class, new param_modifiers_argsTupleSchemeFactory());
 	}
 
-	public Integer opt_num; // required
-	public Integer default_num; // required
+	public Integer opt_num;
+	public Integer default_num;
 	public Integer req_num; // required
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -4632,7 +4632,7 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 		schemes.put(TupleScheme.class, new param_modifiers_resultTupleSchemeFactory());
 	}
 
-	public Long success; // required
+	public Long success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")
@@ -4993,8 +4993,8 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 		schemes.put(TupleScheme.class, new underlying_types_test_argsTupleSchemeFactory());
 	}
 
-	public java.util.List<Long> list_type; // required
-	public java.util.Set<Long> set_type; // required
+	public java.util.List<Long> list_type;
+	public java.util.Set<Long> set_type;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		LIST_TYPE((short)1, "list_type"),
@@ -5538,7 +5538,7 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 		schemes.put(TupleScheme.class, new underlying_types_test_resultTupleSchemeFactory());
 	}
 
-	public java.util.List<Long> success; // required
+	public java.util.List<Long> success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")
@@ -6177,7 +6177,7 @@ public static class getThing_result implements org.apache.thrift.TBase<getThing_
 		schemes.put(TupleScheme.class, new getThing_resultTupleSchemeFactory());
 	}
 
-	public Thing success; // required
+	public Thing success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")
@@ -6776,7 +6776,7 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 		schemes.put(TupleScheme.class, new getMyInt_resultTupleSchemeFactory());
 	}
 
-	public Integer success; // required
+	public Integer success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")
@@ -7136,7 +7136,7 @@ public static class use_subdir_struct_args implements org.apache.thrift.TBase<us
 		schemes.put(TupleScheme.class, new use_subdir_struct_argsTupleSchemeFactory());
 	}
 
-	public A a; // required
+	public A a;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		A((short)1, "a")
@@ -7493,7 +7493,7 @@ public static class use_subdir_struct_result implements org.apache.thrift.TBase<
 		schemes.put(TupleScheme.class, new use_subdir_struct_resultTupleSchemeFactory());
 	}
 
-	public A success; // required
+	public A success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")

--- a/test/expected/java/boxed_primitives/TestingDefaults.java
+++ b/test/expected/java/boxed_primitives/TestingDefaults.java
@@ -63,20 +63,20 @@ public class TestingDefaults implements org.apache.thrift.TBase<TestingDefaults,
 	}
 
 	public Long ID2; // optional
-	public Event ev1; // required
-	public Event ev2; // required
-	public Long ID; // required
-	public String thing; // required
+	public Event ev1;
+	public Event ev2;
+	public Long ID;
+	public String thing;
 	public String thing2; // optional
-	public java.util.List<Integer> listfield; // required
-	public Long ID3; // required
-	public java.nio.ByteBuffer bin_field; // required
+	public java.util.List<Integer> listfield;
+	public Long ID3;
+	public java.nio.ByteBuffer bin_field;
 	public java.nio.ByteBuffer bin_field2; // optional
-	public java.nio.ByteBuffer bin_field3; // required
+	public java.nio.ByteBuffer bin_field3;
 	public java.nio.ByteBuffer bin_field4; // optional
 	public java.util.List<Integer> list2; // optional
 	public java.util.List<Integer> list3; // optional
-	public java.util.List<Integer> list4; // required
+	public java.util.List<Integer> list4;
 	public java.util.Map<String, String> a_map; // optional
 	public HealthCondition status; // required
 	public actual_base.java.base_health_condition base_status; // required

--- a/test/expected/java/variety/AwesomeException.java
+++ b/test/expected/java/variety/AwesomeException.java
@@ -49,11 +49,11 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 	/**
 	 * ID is a unique identifier for an awesome exception.
 	 */
-	public long ID; // required
+	public long ID;
 	/**
 	 * Reason contains the error message.
 	 */
-	public String Reason; // required
+	public String Reason;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		/**

--- a/test/expected/java/variety/Event.java
+++ b/test/expected/java/variety/Event.java
@@ -53,11 +53,11 @@ public class Event implements org.apache.thrift.TBase<Event, Event._Fields>, jav
 	/**
 	 * ID is a unique identifier for an event.
 	 */
-	public long ID; // required
+	public long ID;
 	/**
 	 * Message contains the event payload.
 	 */
-	public String Message; // required
+	public String Message;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		/**

--- a/test/expected/java/variety/EventWrapper.java
+++ b/test/expected/java/variety/EventWrapper.java
@@ -56,14 +56,14 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 
 	public long ID; // optional
 	public Event Ev; // required
-	public java.util.List<Event> Events; // required
-	public java.util.Set<Event> Events2; // required
-	public java.util.Map<Long, Event> EventMap; // required
-	public java.util.List<java.util.List<Integer>> Nums; // required
-	public java.util.List<ItsAnEnum> Enums; // required
-	public boolean aBoolField; // required
-	public TestingUnions a_union; // required
-	public String typedefOfTypedef; // required
+	public java.util.List<Event> Events;
+	public java.util.Set<Event> Events2;
+	public java.util.Map<Long, Event> EventMap;
+	public java.util.List<java.util.List<Integer>> Nums;
+	public java.util.List<ItsAnEnum> Enums;
+	public boolean aBoolField;
+	public TestingUnions a_union;
+	public String typedefOfTypedef;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		ID((short)1, "ID"),

--- a/test/expected/java/variety/FFoo.java
+++ b/test/expected/java/variety/FFoo.java
@@ -1456,9 +1456,9 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 		schemes.put(TupleScheme.class, new blah_argsTupleSchemeFactory());
 	}
 
-	public int num; // required
-	public String Str; // required
-	public Event event; // required
+	public int num;
+	public String Str;
+	public Event event;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		NUM((short)1, "num"),
@@ -2022,9 +2022,9 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 		schemes.put(TupleScheme.class, new blah_resultTupleSchemeFactory());
 	}
 
-	public long success; // required
-	public AwesomeException awe; // required
-	public actual_base.java.api_exception api; // required
+	public long success;
+	public AwesomeException awe;
+	public actual_base.java.api_exception api;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success"),
@@ -2592,8 +2592,8 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 		schemes.put(TupleScheme.class, new oneWay_argsTupleSchemeFactory());
 	}
 
-	public long id; // required
-	public java.util.Map<Integer, String> req; // required
+	public long id;
+	public java.util.Map<Integer, String> req;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		ID((short)1, "id"),
@@ -3084,8 +3084,8 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 		schemes.put(TupleScheme.class, new bin_method_argsTupleSchemeFactory());
 	}
 
-	public java.nio.ByteBuffer bin; // required
-	public String Str; // required
+	public java.nio.ByteBuffer bin;
+	public String Str;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		BIN((short)1, "bin"),
@@ -3554,8 +3554,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 		schemes.put(TupleScheme.class, new bin_method_resultTupleSchemeFactory());
 	}
 
-	public java.nio.ByteBuffer success; // required
-	public actual_base.java.api_exception api; // required
+	public java.nio.ByteBuffer success;
+	public actual_base.java.api_exception api;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success"),
@@ -4028,8 +4028,8 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 		schemes.put(TupleScheme.class, new param_modifiers_argsTupleSchemeFactory());
 	}
 
-	public int opt_num; // required
-	public int default_num; // required
+	public int opt_num;
+	public int default_num;
 	public int req_num; // required
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -4573,7 +4573,7 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 		schemes.put(TupleScheme.class, new param_modifiers_resultTupleSchemeFactory());
 	}
 
-	public long success; // required
+	public long success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")
@@ -4927,8 +4927,8 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 		schemes.put(TupleScheme.class, new underlying_types_test_argsTupleSchemeFactory());
 	}
 
-	public java.util.List<Long> list_type; // required
-	public java.util.Set<Long> set_type; // required
+	public java.util.List<Long> list_type;
+	public java.util.Set<Long> set_type;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		LIST_TYPE((short)1, "list_type"),
@@ -5460,7 +5460,7 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 		schemes.put(TupleScheme.class, new underlying_types_test_resultTupleSchemeFactory());
 	}
 
-	public java.util.List<Long> success; // required
+	public java.util.List<Long> success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")
@@ -6093,7 +6093,7 @@ public static class getThing_result implements org.apache.thrift.TBase<getThing_
 		schemes.put(TupleScheme.class, new getThing_resultTupleSchemeFactory());
 	}
 
-	public Thing success; // required
+	public Thing success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")
@@ -6692,7 +6692,7 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 		schemes.put(TupleScheme.class, new getMyInt_resultTupleSchemeFactory());
 	}
 
-	public int success; // required
+	public int success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")
@@ -7045,7 +7045,7 @@ public static class use_subdir_struct_args implements org.apache.thrift.TBase<us
 		schemes.put(TupleScheme.class, new use_subdir_struct_argsTupleSchemeFactory());
 	}
 
-	public A a; // required
+	public A a;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		A((short)1, "a")
@@ -7402,7 +7402,7 @@ public static class use_subdir_struct_result implements org.apache.thrift.TBase<
 		schemes.put(TupleScheme.class, new use_subdir_struct_resultTupleSchemeFactory());
 	}
 
-	public A success; // required
+	public A success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")

--- a/test/expected/java/variety/TestBase.java
+++ b/test/expected/java/variety/TestBase.java
@@ -45,7 +45,7 @@ public class TestBase implements org.apache.thrift.TBase<TestBase, TestBase._Fie
 		schemes.put(TupleScheme.class, new TestBaseTupleSchemeFactory());
 	}
 
-	public actual_base.java.thing base_struct; // required
+	public actual_base.java.thing base_struct;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		BASE_STRUCT((short)1, "base_struct")

--- a/test/expected/java/variety/TestLowercase.java
+++ b/test/expected/java/variety/TestLowercase.java
@@ -45,7 +45,7 @@ public class TestLowercase implements org.apache.thrift.TBase<TestLowercase, Tes
 		schemes.put(TupleScheme.class, new TestLowercaseTupleSchemeFactory());
 	}
 
-	public int lowercaseInt; // required
+	public int lowercaseInt;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		LOWERCASE_INT((short)1, "lowercaseInt")

--- a/test/expected/java/variety/TestingDefaults.java
+++ b/test/expected/java/variety/TestingDefaults.java
@@ -63,20 +63,20 @@ public class TestingDefaults implements org.apache.thrift.TBase<TestingDefaults,
 	}
 
 	public long ID2; // optional
-	public Event ev1; // required
-	public Event ev2; // required
-	public long ID; // required
-	public String thing; // required
+	public Event ev1;
+	public Event ev2;
+	public long ID;
+	public String thing;
 	public String thing2; // optional
-	public java.util.List<Integer> listfield; // required
-	public long ID3; // required
-	public java.nio.ByteBuffer bin_field; // required
+	public java.util.List<Integer> listfield;
+	public long ID3;
+	public java.nio.ByteBuffer bin_field;
 	public java.nio.ByteBuffer bin_field2; // optional
-	public java.nio.ByteBuffer bin_field3; // required
+	public java.nio.ByteBuffer bin_field3;
 	public java.nio.ByteBuffer bin_field4; // optional
 	public java.util.List<Integer> list2; // optional
 	public java.util.List<Integer> list3; // optional
-	public java.util.List<Integer> list4; // required
+	public java.util.List<Integer> list4;
 	public java.util.Map<String, String> a_map; // optional
 	public HealthCondition status; // required
 	public actual_base.java.base_health_condition base_status; // required

--- a/test/expected/java/variety_async/FFoo.java
+++ b/test/expected/java/variety_async/FFoo.java
@@ -1539,9 +1539,9 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 		schemes.put(TupleScheme.class, new blah_argsTupleSchemeFactory());
 	}
 
-	public int num; // required
-	public String Str; // required
-	public Event event; // required
+	public int num;
+	public String Str;
+	public Event event;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		NUM((short)1, "num"),
@@ -2105,9 +2105,9 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 		schemes.put(TupleScheme.class, new blah_resultTupleSchemeFactory());
 	}
 
-	public long success; // required
-	public AwesomeException awe; // required
-	public actual_base.java.api_exception api; // required
+	public long success;
+	public AwesomeException awe;
+	public actual_base.java.api_exception api;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success"),
@@ -2675,8 +2675,8 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 		schemes.put(TupleScheme.class, new oneWay_argsTupleSchemeFactory());
 	}
 
-	public long id; // required
-	public java.util.Map<Integer, String> req; // required
+	public long id;
+	public java.util.Map<Integer, String> req;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		ID((short)1, "id"),
@@ -3167,8 +3167,8 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 		schemes.put(TupleScheme.class, new bin_method_argsTupleSchemeFactory());
 	}
 
-	public java.nio.ByteBuffer bin; // required
-	public String Str; // required
+	public java.nio.ByteBuffer bin;
+	public String Str;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		BIN((short)1, "bin"),
@@ -3637,8 +3637,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 		schemes.put(TupleScheme.class, new bin_method_resultTupleSchemeFactory());
 	}
 
-	public java.nio.ByteBuffer success; // required
-	public actual_base.java.api_exception api; // required
+	public java.nio.ByteBuffer success;
+	public actual_base.java.api_exception api;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success"),
@@ -4111,8 +4111,8 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 		schemes.put(TupleScheme.class, new param_modifiers_argsTupleSchemeFactory());
 	}
 
-	public int opt_num; // required
-	public int default_num; // required
+	public int opt_num;
+	public int default_num;
 	public int req_num; // required
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -4656,7 +4656,7 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 		schemes.put(TupleScheme.class, new param_modifiers_resultTupleSchemeFactory());
 	}
 
-	public long success; // required
+	public long success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")
@@ -5010,8 +5010,8 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 		schemes.put(TupleScheme.class, new underlying_types_test_argsTupleSchemeFactory());
 	}
 
-	public java.util.List<Long> list_type; // required
-	public java.util.Set<Long> set_type; // required
+	public java.util.List<Long> list_type;
+	public java.util.Set<Long> set_type;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		LIST_TYPE((short)1, "list_type"),
@@ -5543,7 +5543,7 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 		schemes.put(TupleScheme.class, new underlying_types_test_resultTupleSchemeFactory());
 	}
 
-	public java.util.List<Long> success; // required
+	public java.util.List<Long> success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")
@@ -6176,7 +6176,7 @@ public static class getThing_result implements org.apache.thrift.TBase<getThing_
 		schemes.put(TupleScheme.class, new getThing_resultTupleSchemeFactory());
 	}
 
-	public Thing success; // required
+	public Thing success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")
@@ -6775,7 +6775,7 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 		schemes.put(TupleScheme.class, new getMyInt_resultTupleSchemeFactory());
 	}
 
-	public int success; // required
+	public int success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")
@@ -7128,7 +7128,7 @@ public static class use_subdir_struct_args implements org.apache.thrift.TBase<us
 		schemes.put(TupleScheme.class, new use_subdir_struct_argsTupleSchemeFactory());
 	}
 
-	public A a; // required
+	public A a;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		A((short)1, "a")
@@ -7485,7 +7485,7 @@ public static class use_subdir_struct_result implements org.apache.thrift.TBase<
 		schemes.put(TupleScheme.class, new use_subdir_struct_resultTupleSchemeFactory());
 	}
 
-	public A success; // required
+	public A success;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		SUCCESS((short)0, "success")


### PR DESCRIPTION
It is confusing to output a `// required` comment for fields that have default requiredness.

@Workiva/messaging-pp 