### PR TITLE
java: Add FServlet

### DIFF
--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -71,6 +71,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.22</version>

--- a/lib/java/src/main/java/com/workiva/frugal/server/FServlet.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FServlet.java
@@ -24,6 +24,9 @@ import java.util.Base64;
 /**
  * Processes POST requests as Frugal requests for a processor.
  * <p>
+ * By default, the HTTP request is limited to a 64MB Frugal payload size to
+ * prevent client requests from causing the server to allocate too much memory.
+ * <p>
  * The HTTP request may include an X-Frugal-Payload-Limit header setting the size
  * limit of responses from the server.
  * <p>
@@ -37,7 +40,7 @@ import java.util.Base64;
 public class FServlet extends HttpServlet {
     private static final Logger LOGGER = LoggerFactory.getLogger(FServlet.class);
 
-    private static final int DEFAULT_MAX_REQUEST_SIZE = 1024 * 1024;
+    private static final int DEFAULT_MAX_REQUEST_SIZE = 64 * 1024 * 1024;
 
     private final FProcessor processor;
     private final FProtocolFactory inProtocolFactory;

--- a/lib/java/src/main/java/com/workiva/frugal/server/FServlet.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FServlet.java
@@ -1,0 +1,160 @@
+package com.workiva.frugal.server;
+
+import com.workiva.frugal.processor.FProcessor;
+import com.workiva.frugal.protocol.FProtocolFactory;
+import com.workiva.frugal.transport.TMemoryOutputBuffer;
+import org.apache.thrift.TException;
+import org.apache.thrift.transport.TMemoryInputTransport;
+import org.apache.thrift.transport.TTransport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Base64;
+
+/**
+ * Processes POST requests as Frugal requests for a processor.
+ * <p>
+ * The HTTP request may include an X-Frugal-Payload-Limit header setting the size
+ * limit of responses from the server.
+ * <p>
+ * The HTTP processor returns a 500 response for any runtime errors when executing
+ * a frame, a 400 response for an invalid frame, and a 413 response if the response
+ * exceeds the payload limit specified by the client.
+ * <p>
+ * Both the request and response are base64 encoded.
+ */
+@SuppressWarnings("serial")
+public class FServlet extends HttpServlet {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FServlet.class);
+
+    private static final int DEFAULT_MAX_REQUEST_SIZE = 1024 * 1024;
+
+    private final FProcessor processor;
+    private final FProtocolFactory inProtocolFactory;
+    private final FProtocolFactory outProtocolFactory;
+    private final int maxRequestSize;
+
+    /**
+     * Creates a servlet for the specified processor and protocol factory, which
+     * is used for both input and output.
+     */
+    public FServlet(FProcessor processor, FProtocolFactory protocolFactory) {
+        this(processor, protocolFactory, DEFAULT_MAX_REQUEST_SIZE);
+    }
+
+    /**
+     * Creates a servlet for the specified processor and protocol factory, which
+     * is used for both input and output.
+     *
+     * @param maxRequestSize the maximum Frugal request size in bytes
+     */
+    public FServlet(FProcessor processor, FProtocolFactory protocolFactory, int maxRequestSize) {
+        this(processor, protocolFactory, protocolFactory, maxRequestSize);
+    }
+
+    /**
+     * Creates a servlet for the specified processor and input/output protocol
+     * factories.
+     */
+    public FServlet(FProcessor processor, FProtocolFactory inProtocolFactory, FProtocolFactory outProtocolFactory) {
+        this(processor, inProtocolFactory, outProtocolFactory, DEFAULT_MAX_REQUEST_SIZE);
+    }
+
+    /**
+     * Creates a servlet for the specified processor and input/output protocol
+     * factories.
+     *
+     * @param maxRequestSize the maximum Frugal request size in bytes
+     */
+    public FServlet(
+            FProcessor processor,
+            FProtocolFactory inProtocolFactory,
+            FProtocolFactory outProtocolFactory,
+            int maxRequestSize) {
+        this.processor = processor;
+        this.inProtocolFactory = inProtocolFactory;
+        this.outProtocolFactory = outProtocolFactory;
+        this.maxRequestSize = maxRequestSize;
+    }
+
+    @Override
+    public void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        byte[] frame;
+        try (InputStream decoderIn = Base64.getDecoder().wrap(req.getInputStream());
+                DataInputStream dataIn = new DataInputStream(decoderIn)) {
+            try {
+                long size = dataIn.readInt() & 0xffff_ffffL;
+                if (size > maxRequestSize) {
+                    LOGGER.debug("Request size too large. Received: {}, Limit: {}", size, maxRequestSize);
+                    resp.setStatus(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+                    return;
+                }
+
+                frame = new byte[(int) size];
+                dataIn.readFully(frame);
+            } catch (EOFException e) {
+                LOGGER.debug("Request body too short");
+                resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                return;
+            }
+
+            if (dataIn.read() != -1) {
+                LOGGER.debug("Request body too long");
+                resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                return;
+            }
+        }
+
+        TTransport inTransport = new TMemoryInputTransport(frame);
+        TMemoryOutputBuffer outTransport = new TMemoryOutputBuffer();
+        try {
+            processor.process(inProtocolFactory.getProtocol(inTransport), outProtocolFactory.getProtocol(outTransport));
+        } catch (RuntimeException e) {
+            // Already logged by FBaseProcessor.
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return;
+        } catch (TException e) {
+            LOGGER.error("Frugal processor returned unhandled error", e);
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        byte[] data = outTransport.getWriteBytes();
+
+        int responseLimit = getResponseLimit(req);
+        if (responseLimit > 0 && outTransport.size() > responseLimit) {
+            LOGGER.debug("Response size too large for client. Received: {}, Limit: {}",
+                    outTransport.size(), responseLimit);
+            resp.setStatus(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+            return;
+        }
+
+        resp.setContentType("application/x-frugal");
+        resp.setHeader("Content-Transfer-Encoding", "base64");
+        try (OutputStream out = Base64.getEncoder().wrap(resp.getOutputStream())) {
+            out.write(data);
+        }
+    }
+
+    // Visible for testing.
+    static int getResponseLimit(HttpServletRequest req) {
+        String payloadHeader = req.getHeader("x-frugal-payload-limit");
+        int responseLimit;
+        try {
+            responseLimit = Integer.parseInt(payloadHeader);
+        } catch (NumberFormatException ignored) {
+            responseLimit = 0;
+        }
+        return responseLimit;
+    }
+}

--- a/lib/java/src/test/java/com/workiva/frugal/server/FServletTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/server/FServletTest.java
@@ -1,0 +1,276 @@
+package com.workiva.frugal.server;
+
+import com.workiva.frugal.processor.FProcessor;
+import com.workiva.frugal.protocol.FProtocolFactory;
+import org.apache.thrift.TException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * Tests for {@link FServlet}.
+ */
+public class FServletTest {
+
+    private static class ProxyServletInputStream extends ServletInputStream {
+        private final InputStream in;
+
+        ProxyServletInputStream(InputStream in) {
+            this.in = in;
+        }
+
+        @Override
+        public int read() throws IOException {
+            return in.read();
+        }
+
+        @Override
+        public boolean isFinished() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isReady() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class ProxyServletOutputStream extends ServletOutputStream {
+        private final OutputStream out;
+
+        ProxyServletOutputStream(OutputStream out) {
+            this.out = out;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            out.write(b);
+        }
+
+        @Override
+        public boolean isReady() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setWriteListener(WriteListener writeListener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private final FProcessor mockProcessor = mock(FProcessor.class);
+    private final FProtocolFactory mockProtocolFactory = mock(FProtocolFactory.class);
+    private FServlet servlet = new FServlet(mockProcessor, mockProtocolFactory);
+
+    private final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    private final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+
+    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    private final ServletOutputStream servletOut = new ProxyServletOutputStream(out);
+
+    @Before
+    public void before() throws Exception {
+        doReturn("POST").when(mockRequest).getMethod();
+        doReturn("HTTP/1.1").when(mockRequest).getProtocol();
+
+        doReturn(servletOut).when(mockResponse).getOutputStream();
+    }
+
+    @After
+    public void after() {
+        verifyNoMoreInteractions(mockResponse);
+    }
+
+    @Test
+    public final void testValidResponseLimit() {
+        doReturn("2096").when(mockRequest).getHeader("x-frugal-payload-limit");
+
+        Integer limit = FServlet.getResponseLimit(mockRequest);
+        assertThat(limit, equalTo(2096));
+    }
+
+    @Test
+    public final void testNullResponseLimit() {
+        doReturn(null).when(mockRequest).getHeader("x-frugal-payload-limit");
+
+        Integer limit = FServlet.getResponseLimit(mockRequest);
+        assertThat(limit, equalTo(0));
+    }
+
+    @Test
+    public final void testStringResponseLimit() {
+        doReturn("not-a-number").when(mockRequest).getHeader("x-frugal-payload-limit");
+
+        Integer limit = FServlet.getResponseLimit(mockRequest);
+        assertThat(limit, equalTo(0));
+    }
+
+    @Test
+    public void testGet() throws Exception {
+        doReturn("GET").when(mockRequest).getMethod();
+        doReturn("HTTP/1.1").when(mockRequest).getProtocol();
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).sendError(eq(HttpServletResponse.SC_METHOD_NOT_ALLOWED), any());
+    }
+
+    @Test
+    public void testInputEmpty() throws Exception {
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_BAD_REQUEST));
+    }
+
+    @Test
+    public void testInputTooShort() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(new byte[] { 0, 0, 0, 1 });
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_BAD_REQUEST));
+    }
+
+    @Test
+    public void testInputTooLong() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(new byte[5]);
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_BAD_REQUEST));
+    }
+
+    @Test
+    public void testDefaultRequestSize() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(new byte[] { (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff });
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE));
+    }
+
+    @Test
+    public void testRequestSize() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(new byte[] { 0, 0, 0, 2 });
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        servlet = new FServlet(mockProcessor, mockProtocolFactory, 1);
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE));
+    }
+
+    private static byte[] withLength(byte[] b) {
+        return ByteBuffer.allocate(4 + b.length)
+                .putInt(b.length)
+                .put(b)
+                .array();
+    }
+
+    @Test
+    public void testProcessorRuntimeException() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(withLength(new byte[0]));
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        doThrow(new RuntimeException("test")).when(mockProcessor).process(any(), any());
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+    }
+
+    @Test
+    public void testProcessorUnhandledException() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(withLength(new byte[0]));
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        doThrow(new TException("test")).when(mockProcessor).process(any(), any());
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+    }
+
+    @Test
+    public void testResponseTooLong() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(withLength(new byte[2]));
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        doReturn("1").when(mockRequest).getHeader("x-frugal-payload-limit");
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE));
+    }
+
+    @Test
+    public void testOk() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(withLength(new byte[0]));
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setContentType("application/x-frugal");
+        verify(mockResponse).setHeader("Content-Transfer-Encoding", "base64");
+        verify(mockResponse).getOutputStream();
+    }
+
+    @Test
+    public void testOkPayloadLimit() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(withLength(new byte[0]));
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        doReturn("4").when(mockRequest).getHeader("x-frugal-payload-limit");
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setContentType("application/x-frugal");
+        verify(mockResponse).setHeader("Content-Transfer-Encoding", "base64");
+        verify(mockResponse).getOutputStream();
+    }
+}


### PR DESCRIPTION
The existing `FNettyHttpHandler` works well, but the asynchronous nature of the Netty programming model is more difficult to use than the servlet programming model for non-Frugal use cases.  Add a servlet so that Frugal can easily be included in the same server as other servlets.

@Workiva/messaging-pp