### PR TITLE
Support deprecated annotation for fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Some common annotations are listed below
 | Annotation    | Values        | Allowed Places | Description
 | ------------- | ------------- | -------------- | -----------
 | vendor        | Optional location | Namespaces, Includes | See [vendoring includes](#vendoring-includes)
-| deprecated    | Optional description | Service methods | Marks a method as deprecated (if supported by the language) and logs a warning if the method is called.
+| deprecated    | Optional description | Service methods, Struct/union fields | Marks a method or field as deprecated (if supported by the language, or in a comment otherwise), and logs a warning if a deprecated method is called.
 
 ### Vendoring Includes
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Some common annotations are listed below
 | Annotation    | Values        | Allowed Places | Description
 | ------------- | ------------- | -------------- | -----------
 | vendor        | Optional location | Namespaces, Includes | See [vendoring includes](#vendoring-includes)
-| deprecated    | Optional description | Service methods, Struct/union fields | Marks a method or field as deprecated (if supported by the language, or in a comment otherwise), and logs a warning if a deprecated method is called.
+| deprecated    | Optional description | Service methods, Struct/union/exception fields | Marks a method or field as deprecated (if supported by the language, or in a comment otherwise), and logs a warning if a deprecated method is called.
 
 ### Vendoring Includes
 

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1511,14 +1511,14 @@ func (g *Generator) GenerateService(file *os.File, s *parser.Service) error {
 func (g *Generator) generateCommentWithDeprecated(comment []string, indent string, anns parser.Annotations) string {
 	contents := ""
 	if comment != nil {
-		contents += g.GenerateInlineComment(comment, tab+"/")
+		contents += g.GenerateInlineComment(comment, indent+"/")
 	}
 
 	if deprecationValue, deprecated := anns.Deprecated(); deprecated {
 		if deprecationValue != "" {
-			contents += g.GenerateInlineComment([]string{"Deprecated: " + deprecationValue}, tab+"/")
+			contents += g.GenerateInlineComment([]string{"Deprecated: " + deprecationValue}, indent+"/")
 		}
-		contents += tab + "@deprecated\n"
+		contents += indent + "@deprecated\n"
 	}
 
 	return contents

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -651,9 +651,7 @@ func (g *Generator) generateStruct(s *parser.Struct) string {
 
 	// Fields
 	for _, field := range s.Fields {
-		if field.Comment != nil {
-			contents += g.GenerateInlineComment(field.Comment, tab+"/")
-		}
+		contents += g.generateCommentWithDeprecated(field.Comment, tab, field.Annotations)
 		contents += fmt.Sprintf(tab+"%s _%s%s;\n",
 			g.getDartTypeFromThriftType(field.Type), toFieldName(field.Name), g.generateInitValue(field))
 		contents += fmt.Sprintf(tab+"static const int %s = %d;\n", strings.ToUpper(field.Name), field.ID)
@@ -730,13 +728,9 @@ func (g *Generator) generateFieldMethods(s *parser.Struct) string {
 		fName := toFieldName(field.Name)
 		titleName := strings.Title(field.Name)
 
-		if field.Comment != nil {
-			contents += g.GenerateInlineComment(field.Comment, tab+"/")
-		}
+		contents += g.generateCommentWithDeprecated(field.Comment, tab, field.Annotations)
 		contents += fmt.Sprintf(tab+"%s get %s => this._%s;\n\n", dartType, fName, fName)
-		if field.Comment != nil {
-			contents += g.GenerateInlineComment(field.Comment, tab+"/")
-		}
+		contents += g.generateCommentWithDeprecated(field.Comment, tab, field.Annotations)
 		contents += fmt.Sprintf(tab+"set %s(%s %s) {\n", fName, dartType, fName)
 		contents += fmt.Sprintf(tabtab+"this._%s = %s;\n", fName, fName)
 		if dartPrimitive {
@@ -744,6 +738,9 @@ func (g *Generator) generateFieldMethods(s *parser.Struct) string {
 		}
 		contents += tab + "}\n\n"
 
+		if field.Annotations.IsDeprecated() {
+			contents += tab + "@deprecated"
+		}
 		if dartPrimitive {
 			contents += fmt.Sprintf(tab+"bool isSet%s() => this.__isset_%s;\n\n", titleName, fName)
 			contents += fmt.Sprintf(tab+"unset%s() {\n", titleName)
@@ -1511,6 +1508,22 @@ func (g *Generator) GenerateService(file *os.File, s *parser.Service) error {
 	return err
 }
 
+func (g *Generator) generateCommentWithDeprecated(comment []string, indent string, anns parser.Annotations) string {
+	contents := ""
+	if comment != nil {
+		contents += g.GenerateInlineComment(comment, tab+"/")
+	}
+
+	if deprecationValue, deprecated := anns.Deprecated(); deprecated {
+		if deprecationValue != "" {
+			contents += g.GenerateInlineComment([]string{"Deprecated: " + deprecationValue}, tab+"/")
+		}
+		contents += tab + "@deprecated\n"
+	}
+
+	return contents
+}
+
 func (g *Generator) generateInterface(service *parser.Service) string {
 	contents := ""
 	if service.Comment != nil {
@@ -1524,17 +1537,7 @@ func (g *Generator) generateInterface(service *parser.Service) string {
 	}
 	for _, method := range service.Methods {
 		contents += "\n"
-		if method.Comment != nil {
-			contents += g.GenerateInlineComment(method.Comment, tab+"/")
-		}
-
-		if deprecationValue, deprecated := method.Annotations.Deprecated(); deprecated {
-			if deprecationValue != "" {
-				contents += g.GenerateInlineComment([]string{"Deprecated: " + deprecationValue}, tab+"/")
-			}
-			contents += tab + "@deprecated\n"
-		}
-
+		contents += g.generateCommentWithDeprecated(method.Comment, tab, method.Annotations)
 		contents += fmt.Sprintf(tab+"Future%s %s(frugal.FContext ctx%s);\n",
 			g.generateReturnArg(method), parser.LowercaseFirstLetter(method.Name), g.generateInputArgs(method.Arguments))
 	}
@@ -1605,25 +1608,13 @@ func (g *Generator) generateClient(service *parser.Service) string {
 
 func (g *Generator) generateClientMethod(service *parser.Service, method *parser.Method) string {
 	nameLower := parser.LowercaseFirstLetter(method.Name)
-	contents := ""
-
-	if method.Comment != nil {
-		contents += g.GenerateInlineComment(method.Comment, tab+"/")
-	}
-
-	deprecationValue, deprecated := method.Annotations.Deprecated()
-	if deprecated {
-		if deprecationValue != "" {
-			contents += g.GenerateInlineComment([]string{"Deprecated: " + deprecationValue}, tab+"/")
-		}
-		contents += tab + "@deprecated\n"
-	}
+	contents := g.generateCommentWithDeprecated(method.Comment, tab, method.Annotations)
 
 	// Generate wrapper method
 	contents += fmt.Sprintf(tab+"Future%s %s(frugal.FContext ctx%s) {\n",
 		g.generateReturnArg(method), nameLower, g.generateInputArgs(method.Arguments))
 
-	if deprecated {
+	if method.Annotations.IsDeprecated() {
 		contents += fmt.Sprintf(tabtab+"_frugalLog.warning(\"Call to deprecated function '%s.%s'\");\n", service.Name, nameLower)
 	}
 

--- a/compiler/generator/golang/generator.go
+++ b/compiler/generator/golang/generator.go
@@ -445,7 +445,7 @@ func (g *Generator) generateStruct(s *parser.Struct, serviceName string) string 
 func (g *Generator) generateCommentWithDeprecated(comment []string, indent string, anns parser.Annotations) string {
 	contents := ""
 	if comment != nil {
-		contents += g.GenerateInlineComment(comment, "\t")
+		contents += g.GenerateInlineComment(comment, indent)
 	}
 
 	deprecationValue, deprecated := anns.Deprecated()

--- a/compiler/generator/golang/generator.go
+++ b/compiler/generator/golang/generator.go
@@ -205,7 +205,7 @@ func (g *Generator) GenerateConstantsContents(constants []*parser.Constant) erro
 
 // quote creates a Go string literal for a string.
 func (g *Generator) quote(s string) string {
-	return strconv.Quote(s);
+	return strconv.Quote(s)
 }
 
 // generateConstantValue recursively generates the string representation of
@@ -442,6 +442,24 @@ func (g *Generator) generateStruct(s *parser.Struct, serviceName string) string 
 	return contents
 }
 
+func (g *Generator) generateCommentWithDeprecated(comment []string, indent string, anns parser.Annotations) string {
+	contents := ""
+	if comment != nil {
+		contents += g.GenerateInlineComment(comment, "\t")
+	}
+
+	deprecationValue, deprecated := anns.Deprecated()
+	if deprecated && deprecationValue != "" {
+		if deprecationValue == "" {
+			contents += indent + "// Deprecated\n"
+		} else {
+			contents += fmt.Sprintf("%s// Deprecated: %s\n", indent, deprecationValue)
+		}
+	}
+
+	return contents
+}
+
 func (g *Generator) generateStructDeclaration(s *parser.Struct, sName string) string {
 	contents := ""
 	if s.Comment != nil {
@@ -455,9 +473,7 @@ func (g *Generator) generateStructDeclaration(s *parser.Struct, sName string) st
 		fName := title(field.Name)
 		// All fields in a union are marked optional by default
 
-		if field.Comment != nil {
-			contents += g.GenerateInlineComment(field.Comment, "\t")
-		}
+		contents += g.generateCommentWithDeprecated(field.Comment, "\t", field.Annotations)
 
 		// Use the actual field name for annotations because the serialized
 		// name needs to be the same for all languages
@@ -1518,14 +1534,7 @@ func (g *Generator) generateServiceInterface(service *parser.Service) string {
 		contents += fmt.Sprintf("\t%s\n\n", g.getServiceExtendsName(service))
 	}
 	for _, method := range service.Methods {
-		if method.Comment != nil {
-			contents += g.GenerateInlineComment(method.Comment, "\t")
-		}
-
-		if _, ok := method.Annotations.Deprecated(); ok {
-			contents += "\t// Deprecated\n"
-		}
-
+		contents += g.generateCommentWithDeprecated(method.Comment, "\t", method.Annotations)
 		contents += fmt.Sprintf("\t%s(ctx frugal.FContext%s) %s\n",
 			snakeToCamel(method.Name), g.generateInterfaceArgs(method.Arguments),
 			g.generateReturnArgs(method))

--- a/compiler/generator/html/module_template.go
+++ b/compiler/generator/html/module_template.go
@@ -168,7 +168,7 @@ const moduleTemplate = `
 						<td>{{ .ID }}</td>
 						<td>{{ .Name }}</td>
 						<td><code>{{ .Type | displayType }}</code></td>
-						<td>{{ range .Comment }}{{ . }}<br />{{ end }}</td>
+						<td>{{ range .Comment }}{{ . }}<br />{{ end }}{{ if .Annotations.IsDeprecated }}Deprecated{{ if .Annotations.DeprecationValue }}: {{ .Annotations.DeprecationValue }}{{ end }}{{ end }}</td>
 						<td>{{ .Modifier.String | lowercase }}</td>
 						<td>{{ if .Default }}<code>{{ .Default | formatValue }}</code>{{ end }}</td>
 					</tr>

--- a/compiler/generator/java/generator.go
+++ b/compiler/generator/java/generator.go
@@ -1314,6 +1314,9 @@ func (g *Generator) generateSetField(structName string, field *parser.Field) str
 func (g *Generator) generateUnsetField(s *parser.Struct, field *parser.Field) string {
 	contents := ""
 
+	if field.Annotations.IsDeprecated() {
+		contents += tab + "@Deprecated\n"
+	}
 	contents += fmt.Sprintf(tab+"public void unset%s() {\n", strings.Title(field.Name))
 	if g.isJavaPrimitive(field.Type) {
 		isSetType, _ := g.getIsSetType(s)

--- a/compiler/generator/java/generator.go
+++ b/compiler/generator/java/generator.go
@@ -289,7 +289,7 @@ func (g *Generator) generateEnumConstFromValue(t *parser.Type, value int) string
 // quote creates a Java string literal for a string.
 func (g *Generator) quote(s string) string {
 	// For now, just use Go quoting rules.
-	return strconv.Quote(s);
+	return strconv.Quote(s)
 }
 
 func (g *Generator) generateConstantValueRec(t *parser.Type, value interface{}) (string, string) {
@@ -543,6 +543,7 @@ func (g *Generator) generateUnionFieldConstructors(union *parser.Struct) string 
 	contents := ""
 
 	for _, field := range union.Fields {
+		contents += g.generateCommentWithDeprecated(field.Comment, tab, field.Annotations)
 		contents += fmt.Sprintf(tab+"public static %s %s(%s value) {\n",
 			union.Name, field.Name, g.getJavaTypeFromThriftType(field.Type))
 		contents += fmt.Sprintf(tabtab+"%s x = new %s();\n", union.Name, union.Name)
@@ -710,6 +711,9 @@ func (g *Generator) generateUnionGetSetFields(union *parser.Struct) string {
 		javaType := g.getJavaTypeFromThriftType(field.Type)
 
 		// get
+		if field.Annotations.IsDeprecated() {
+			contents += tab + "@Deprecated\n"
+		}
 		contents += fmt.Sprintf(tab+"public %s get%s() {\n", javaType, titleName)
 		contents += fmt.Sprintf(tabtab+"if (getSetField() == _Fields.%s) {\n", constantName)
 		contents += fmt.Sprintf(tabtabtab+"return (%s)getFieldValue();\n", containerType(javaType))
@@ -719,6 +723,9 @@ func (g *Generator) generateUnionGetSetFields(union *parser.Struct) string {
 		contents += tab + "}\n\n"
 
 		// set
+		if field.Annotations.IsDeprecated() {
+			contents += tab + "@Deprecated\n"
+		}
 		contents += fmt.Sprintf(tab+"public void set%s(%s value) {\n", titleName, javaType)
 		if !g.isJavaPrimitive(field.Type) {
 			contents += tabtab + "if (value == null) throw new NullPointerException();\n"
@@ -735,6 +742,9 @@ func (g *Generator) generateUnionIsSetFields(union *parser.Struct) string {
 	contents := ""
 
 	for _, field := range union.Fields {
+		if field.Annotations.IsDeprecated() {
+			contents += tab + "@Deprecated\n"
+		}
 		contents += fmt.Sprintf(tab+"public boolean isSet%s() {\n", strings.Title(field.Name))
 		contents += fmt.Sprintf(tabtab+"return setField_ == _Fields.%s;\n", toConstantName(field.Name))
 		contents += tab + "}\n\n"
@@ -919,9 +929,7 @@ func (g *Generator) generateSchemeMap(s *parser.Struct) string {
 func (g *Generator) generateInstanceVars(s *parser.Struct) string {
 	contents := ""
 	for _, field := range s.Fields {
-		if field.Comment != nil {
-			contents += g.GenerateBlockComment(field.Comment, tab)
-		}
+		contents += g.generateCommentWithDeprecated(field.Comment, tab, field.Annotations)
 		modifier := ""
 		if field.Modifier == parser.Required {
 			modifier = "required"
@@ -1150,6 +1158,9 @@ func (g *Generator) generateClear(s *parser.Struct) string {
 
 func (g *Generator) generateContainerGetSize(field *parser.Field) string {
 	contents := ""
+	if field.Annotations.IsDeprecated() {
+		contents += tab + "@Deprecated\n"
+	}
 	contents += fmt.Sprintf(tab+"public int get%sSize() {\n", strings.Title(field.Name))
 	contents += fmt.Sprintf(tabtab+"return (this.%s == null) ? 0 : this.%s.size();\n", field.Name, field.Name)
 	contents += fmt.Sprintf(tab + "}\n\n")
@@ -1165,6 +1176,9 @@ func (g *Generator) generateContainerIterator(field *parser.Field) string {
 	}
 
 	contents := ""
+	if field.Annotations.IsDeprecated() {
+		contents += tab + "@Deprecated\n"
+	}
 	contents += fmt.Sprintf(tab+"public java.util.Iterator<%s> get%sIterator() {\n",
 		containerType(g.getJavaTypeFromThriftType(underlyingType.ValueType)), strings.Title(field.Name))
 	contents += fmt.Sprintf(tabtab+"return (this.%s == null) ? null : this.%s.iterator();\n", field.Name, field.Name)
@@ -1178,6 +1192,9 @@ func (g *Generator) generateContainerAddTo(field *parser.Field) string {
 	fieldTitle := strings.Title(field.Name)
 
 	contents := ""
+	if field.Annotations.IsDeprecated() {
+		contents += tab + "@Deprecated\n"
+	}
 
 	if underlyingType.Name == "list" || underlyingType.Name == "set" {
 		contents += fmt.Sprintf(tab+"public void addTo%s(%s elem) {\n", fieldTitle, valType)
@@ -1228,6 +1245,9 @@ func (g *Generator) generateGetField(field *parser.Field) string {
 	}
 
 	accessPrefix := g.getAccessorPrefix(field.Type)
+	if field.Annotations.IsDeprecated() {
+		contents += tab + "@Deprecated\n"
+	}
 	contents += fmt.Sprintf(tab+"public %s %s%s() {\n", returnType, accessPrefix, fieldTitle)
 	if underlyingType.Name == "binary" {
 		contents += fmt.Sprintf(tabtab+"set%s(org.apache.thrift.TBaseHelper.rightSize(%s));\n",
@@ -1255,6 +1275,9 @@ func (g *Generator) generateSetField(structName string, field *parser.Field) str
 
 	if underlyingType.Name == "binary" {
 		// Special additional binary set
+		if field.Annotations.IsDeprecated() {
+			contents += tab + "@Deprecated\n"
+		}
 		contents += fmt.Sprintf(tab+"public %s set%s(byte[] %s) {\n", structName, fieldTitle, field.Name)
 		contents += fmt.Sprintf(tabtab+"this.%s = %s == null ? (java.nio.ByteBuffer)null : java.nio.ByteBuffer.wrap(Arrays.copyOf(%s, %s.length));\n",
 			field.Name, field.Name, field.Name, field.Name)
@@ -1264,6 +1287,9 @@ func (g *Generator) generateSetField(structName string, field *parser.Field) str
 
 	if field.Comment != nil {
 		contents += g.GenerateBlockComment(field.Comment, tab)
+	}
+	if field.Annotations.IsDeprecated() {
+		contents += tab + "@Deprecated\n"
 	}
 	contents += fmt.Sprintf(tab+"public %s set%s(%s %s) {\n",
 		structName, fieldTitle, g.getJavaTypeFromThriftType(field.Type), field.Name)
@@ -1314,6 +1340,9 @@ func (g *Generator) getIsSetID(fieldName string) string {
 func (g *Generator) generateIsSetField(s *parser.Struct, field *parser.Field) string {
 	contents := ""
 	contents += fmt.Sprintf(tab+"/** Returns true if field %s is set (has been assigned a value) and false otherwise */\n", field.Name)
+	if field.Annotations.IsDeprecated() {
+		contents += tab + "@Deprecated\n"
+	}
 	contents += fmt.Sprintf(tab+"public boolean isSet%s() {\n", strings.Title(field.Name))
 	if g.isJavaPrimitive(field.Type) {
 		isSetType, _ := g.getIsSetType(s)
@@ -1335,6 +1364,9 @@ func (g *Generator) generateIsSetField(s *parser.Struct, field *parser.Field) st
 
 func (g *Generator) generateSetIsSetField(s *parser.Struct, field *parser.Field) string {
 	contents := ""
+	if field.Annotations.IsDeprecated() {
+		contents += tab + "@Deprecated\n"
+	}
 	contents += fmt.Sprintf(tab+"public void set%sIsSet(boolean value) {\n", strings.Title(field.Name))
 	if g.isJavaPrimitive(field.Type) {
 		isSetType, _ := g.getIsSetType(s)
@@ -2657,6 +2689,27 @@ func (g *Generator) GenerateService(file *os.File, s *parser.Service) error {
 	return err
 }
 
+func (g *Generator) generateCommentWithDeprecated(comment []string, indent string, anns parser.Annotations) string {
+	fullComment := []string{}
+	if comment != nil {
+		fullComment = append(fullComment, comment...)
+	}
+
+	deprecationValue, deprecated := anns.Deprecated()
+	if deprecated && deprecationValue != "" {
+		fullComment = append(fullComment, fmt.Sprintf("@deprecated %s", deprecationValue))
+	}
+
+	contents := ""
+	if len(fullComment) != 0 {
+		contents += g.GenerateBlockComment(fullComment, indent)
+	}
+	if deprecated {
+		contents += indent + "@Deprecated\n"
+	}
+	return contents
+}
+
 func (g *Generator) generateServiceInterface(service *parser.Service) string {
 	contents := ""
 	if service.Comment != nil {
@@ -2669,24 +2722,7 @@ func (g *Generator) generateServiceInterface(service *parser.Service) string {
 		contents += tab + "public interface Iface {\n\n"
 	}
 	for _, method := range service.Methods {
-		comment := []string{}
-		if method.Comment != nil {
-			comment = append(comment, method.Comment...)
-		}
-
-		deprecationValue, deprecated := method.Annotations.Deprecated()
-		if deprecated && deprecationValue != "" {
-			comment = append(comment, fmt.Sprintf("@deprecated %s", deprecationValue))
-		}
-
-		if len(comment) != 0 {
-			contents += g.GenerateBlockComment(comment, tabtab)
-		}
-
-		if deprecated {
-			contents += tabtab + "@Deprecated\n"
-		}
-
+		contents += g.generateCommentWithDeprecated(method.Comment, tabtab, method.Annotations)
 		contents += fmt.Sprintf(tabtab+"public %s %s(FContext ctx%s) %s;\n\n",
 			g.generateReturnValue(method), method.Name, g.generateArgs(method.Arguments, false), g.generateExceptions(method.Exceptions))
 	}

--- a/compiler/generator/python/generator.go
+++ b/compiler/generator/python/generator.go
@@ -189,7 +189,7 @@ func (g *Generator) GenerateConstantsContents(constants []*parser.Constant) erro
 // quote creates a Python string literal for a string.
 func (g *Generator) quote(s string) string {
 	// For now, just use Go quoting rules.
-	return strconv.Quote(s);
+	return strconv.Quote(s)
 }
 
 func (g *Generator) generateConstantValue(t *parser.Type, value interface{}, ind string) (parser.IdentifierType, string) {
@@ -460,9 +460,24 @@ func (g *Generator) generateClassDocstring(s *parser.Struct) string {
 			if len(field.Comment) > 0 {
 				line = fmt.Sprintf("%s: %s", line, field.Comment[0])
 				lines = append(lines, line)
-				lines = append(lines, field.Comment[1:]...)
+
+				remaining := make([]string, len(field.Comment)-1)
+				copy(remaining, field.Comment[1:])
+				for i, value := range remaining {
+					remaining[i] = "   " + value
+				}
+				lines = append(lines, remaining...)
 			} else {
 				lines = append(lines, line)
+			}
+
+			deprecationValue, deprecated := field.Annotations.Deprecated()
+			if deprecated {
+				if deprecationValue != "" {
+					lines = append(lines, fmt.Sprintf("   Deprecated: %s", deprecationValue))
+				} else {
+					lines = append(lines, "   Deprecated")
+				}
 			}
 		}
 	}

--- a/compiler/parser/types.go
+++ b/compiler/parser/types.go
@@ -479,6 +479,18 @@ func (a Annotations) Deprecated() (string, bool) {
 	return a.Get(DeprecatedAnnotation)
 }
 
+// IsDeprecated returns true if the "deprecated" annotation is present.
+func (a Annotations) IsDeprecated() bool {
+	_, d := a.Deprecated()
+	return d
+}
+
+// DeprecationValue returns the value of the "deprecated" annotation.
+func (a Annotations) DeprecationValue() string {
+	v, _ := a.Deprecated()
+	return v
+}
+
 func getImports(t *Type) []string {
 	list := []string{}
 	switch t.Name {

--- a/test/expected/dart/actual_base/f_nested_thing.dart
+++ b/test/expected/dart/actual_base/f_nested_thing.dart
@@ -73,12 +73,12 @@ class nested_thing implements thrift.TBase {
       switch(field.id) {
         case THINGS:
           if(field.type == thrift.TType.LIST) {
-            thrift.TList elem77 = iprot.readListBegin();
+            thrift.TList elem81 = iprot.readListBegin();
             things = new List<t_actual_base_dart.thing>();
-            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
-              t_actual_base_dart.thing elem78 = new t_actual_base_dart.thing();
-              elem78.read(iprot);
-              things.add(elem78);
+            for(int elem83 = 0; elem83 < elem81.length; ++elem83) {
+              t_actual_base_dart.thing elem82 = new t_actual_base_dart.thing();
+              elem82.read(iprot);
+              things.add(elem82);
             }
             iprot.readListEnd();
           } else {
@@ -104,8 +104,8 @@ class nested_thing implements thrift.TBase {
     if(this.things != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
       oprot.writeListBegin(new thrift.TList(thrift.TType.STRUCT, things.length));
-      for(var elem80 in things) {
-        elem80.write(oprot);
+      for(var elem84 in things) {
+        elem84.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/test/expected/dart/variety/f_awesome_exception.dart
+++ b/test/expected/dart/variety/f_awesome_exception.dart
@@ -14,6 +14,7 @@ class AwesomeException extends Error implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("AwesomeException");
   static final thrift.TField _ID_FIELD_DESC = new thrift.TField("ID", thrift.TType.I64, 1);
   static final thrift.TField _REASON_FIELD_DESC = new thrift.TField("Reason", thrift.TType.STRING, 2);
+  static final thrift.TField _DEPR_FIELD_DESC = new thrift.TField("depr", thrift.TType.BOOL, 3);
 
   /// ID is a unique identifier for an awesome exception.
   int _iD = 0;
@@ -21,8 +22,13 @@ class AwesomeException extends Error implements thrift.TBase {
   /// Reason contains the error message.
   String _reason;
   static const int REASON = 2;
+  /// Deprecated: use something else
+  @deprecated
+  bool _depr = false;
+  static const int DEPR = 3;
 
   bool __isset_iD = false;
+  bool __isset_depr = false;
 
   AwesomeException() {
   }
@@ -56,12 +62,31 @@ class AwesomeException extends Error implements thrift.TBase {
     this.reason = null;
   }
 
+  /// Deprecated: use something else
+  @deprecated
+  bool get depr => this._depr;
+
+  /// Deprecated: use something else
+  @deprecated
+  set depr(bool depr) {
+    this._depr = depr;
+    this.__isset_depr = true;
+  }
+
+  @deprecated  bool isSetDepr() => this.__isset_depr;
+
+  unsetDepr() {
+    this.__isset_depr = false;
+  }
+
   getFieldValue(int fieldID) {
     switch (fieldID) {
       case ID:
         return this.iD;
       case REASON:
         return this.reason;
+      case DEPR:
+        return this.depr;
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
     }
@@ -85,6 +110,14 @@ class AwesomeException extends Error implements thrift.TBase {
         }
         break;
 
+      case DEPR:
+        if(value == null) {
+          unsetDepr();
+        } else {
+          this.depr = value as bool;
+        }
+        break;
+
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
     }
@@ -97,6 +130,8 @@ class AwesomeException extends Error implements thrift.TBase {
         return isSetID();
       case REASON:
         return isSetReason();
+      case DEPR:
+        return isSetDepr();
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
     }
@@ -126,6 +161,14 @@ class AwesomeException extends Error implements thrift.TBase {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
+        case DEPR:
+          if(field.type == thrift.TType.BOOL) {
+            depr = iprot.readBool();
+            this.__isset_depr = true;
+          } else {
+            thrift.TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
         default:
           thrift.TProtocolUtil.skip(iprot, field.type);
           break;
@@ -150,6 +193,9 @@ class AwesomeException extends Error implements thrift.TBase {
       oprot.writeString(reason);
       oprot.writeFieldEnd();
     }
+    oprot.writeFieldBegin(_DEPR_FIELD_DESC);
+    oprot.writeBool(depr);
+    oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
   }
@@ -168,6 +214,10 @@ class AwesomeException extends Error implements thrift.TBase {
       ret.write(this.reason);
     }
 
+    ret.write(", ");
+    ret.write("depr:");
+    ret.write(this.depr);
+
     ret.write(")");
 
     return ret.toString();
@@ -179,16 +229,19 @@ class AwesomeException extends Error implements thrift.TBase {
     }
     AwesomeException other = o as AwesomeException;
     return this.iD == other.iD
-      && this.reason == other.reason;
+      && this.reason == other.reason
+      && this.depr == other.depr;
   }
 
   AwesomeException clone({
     int iD: null,
     String reason: null,
+    bool depr: null,
   }) {
     return new AwesomeException()
       ..iD = iD ?? this.iD
-      ..reason = reason ?? this.reason;
+      ..reason = reason ?? this.reason
+      ..depr = depr ?? this.depr;
   }
 
   validate() {

--- a/test/expected/dart/variety/f_event_wrapper.dart
+++ b/test/expected/dart/variety/f_event_wrapper.dart
@@ -22,6 +22,9 @@ class EventWrapper implements thrift.TBase {
   static final thrift.TField _A_BOOL_FIELD_FIELD_DESC = new thrift.TField("aBoolField", thrift.TType.BOOL, 8);
   static final thrift.TField _A_UNION_FIELD_DESC = new thrift.TField("a_union", thrift.TType.STRUCT, 9);
   static final thrift.TField _TYPEDEF_OF_TYPEDEF_FIELD_DESC = new thrift.TField("typedefOfTypedef", thrift.TType.STRING, 10);
+  static final thrift.TField _DEPR_FIELD_DESC = new thrift.TField("depr", thrift.TType.BOOL, 11);
+  static final thrift.TField _DEPR_BINARY_FIELD_DESC = new thrift.TField("deprBinary", thrift.TType.STRING, 12);
+  static final thrift.TField _DEPR_LIST_FIELD_DESC = new thrift.TField("deprList", thrift.TType.LIST, 13);
 
   int _iD;
   static const int ID = 1;
@@ -43,9 +46,24 @@ class EventWrapper implements thrift.TBase {
   static const int A_UNION = 9;
   String _typedefOfTypedef;
   static const int TYPEDEFOFTYPEDEF = 10;
+  /// This is a docstring comment for a deprecated field that has been spread
+  /// across two lines.
+  /// Deprecated: use something else
+  @deprecated
+  bool _depr = false;
+  static const int DEPR = 11;
+  /// Deprecated: use something else
+  @deprecated
+  Uint8List _deprBinary;
+  static const int DEPRBINARY = 12;
+  /// Deprecated: use something else
+  @deprecated
+  List<bool> _deprList;
+  static const int DEPRLIST = 13;
 
   bool __isset_iD = false;
   bool __isset_aBoolField = false;
+  bool __isset_depr = false;
 
   EventWrapper() {
   }
@@ -172,6 +190,59 @@ class EventWrapper implements thrift.TBase {
     this.typedefOfTypedef = null;
   }
 
+  /// This is a docstring comment for a deprecated field that has been spread
+  /// across two lines.
+  /// Deprecated: use something else
+  @deprecated
+  bool get depr => this._depr;
+
+  /// This is a docstring comment for a deprecated field that has been spread
+  /// across two lines.
+  /// Deprecated: use something else
+  @deprecated
+  set depr(bool depr) {
+    this._depr = depr;
+    this.__isset_depr = true;
+  }
+
+  @deprecated  bool isSetDepr() => this.__isset_depr;
+
+  unsetDepr() {
+    this.__isset_depr = false;
+  }
+
+  /// Deprecated: use something else
+  @deprecated
+  Uint8List get deprBinary => this._deprBinary;
+
+  /// Deprecated: use something else
+  @deprecated
+  set deprBinary(Uint8List deprBinary) {
+    this._deprBinary = deprBinary;
+  }
+
+  @deprecated  bool isSetDeprBinary() => this.deprBinary != null;
+
+  unsetDeprBinary() {
+    this.deprBinary = null;
+  }
+
+  /// Deprecated: use something else
+  @deprecated
+  List<bool> get deprList => this._deprList;
+
+  /// Deprecated: use something else
+  @deprecated
+  set deprList(List<bool> deprList) {
+    this._deprList = deprList;
+  }
+
+  @deprecated  bool isSetDeprList() => this.deprList != null;
+
+  unsetDeprList() {
+    this.deprList = null;
+  }
+
   getFieldValue(int fieldID) {
     switch (fieldID) {
       case ID:
@@ -194,6 +265,12 @@ class EventWrapper implements thrift.TBase {
         return this.a_union;
       case TYPEDEFOFTYPEDEF:
         return this.typedefOfTypedef;
+      case DEPR:
+        return this.depr;
+      case DEPRBINARY:
+        return this.deprBinary;
+      case DEPRLIST:
+        return this.deprList;
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
     }
@@ -281,6 +358,30 @@ class EventWrapper implements thrift.TBase {
         }
         break;
 
+      case DEPR:
+        if(value == null) {
+          unsetDepr();
+        } else {
+          this.depr = value as bool;
+        }
+        break;
+
+      case DEPRBINARY:
+        if(value == null) {
+          unsetDeprBinary();
+        } else {
+          this.deprBinary = value as Uint8List;
+        }
+        break;
+
+      case DEPRLIST:
+        if(value == null) {
+          unsetDeprList();
+        } else {
+          this.deprList = value as List<bool>;
+        }
+        break;
+
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
     }
@@ -309,6 +410,12 @@ class EventWrapper implements thrift.TBase {
         return isSetA_union();
       case TYPEDEFOFTYPEDEF:
         return isSetTypedefOfTypedef();
+      case DEPR:
+        return isSetDepr();
+      case DEPRBINARY:
+        return isSetDeprBinary();
+      case DEPRLIST:
+        return isSetDeprList();
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
     }
@@ -437,6 +544,34 @@ class EventWrapper implements thrift.TBase {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
+        case DEPR:
+          if(field.type == thrift.TType.BOOL) {
+            depr = iprot.readBool();
+            this.__isset_depr = true;
+          } else {
+            thrift.TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
+        case DEPRBINARY:
+          if(field.type == thrift.TType.STRING) {
+            deprBinary = iprot.readBinary();
+          } else {
+            thrift.TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
+        case DEPRLIST:
+          if(field.type == thrift.TType.LIST) {
+            thrift.TList elem40 = iprot.readListBegin();
+            deprList = new List<bool>();
+            for(int elem42 = 0; elem42 < elem40.length; ++elem42) {
+              bool elem41 = iprot.readBool();
+              deprList.add(elem41);
+            }
+            iprot.readListEnd();
+          } else {
+            thrift.TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
         default:
           thrift.TProtocolUtil.skip(iprot, field.type);
           break;
@@ -466,8 +601,8 @@ class EventWrapper implements thrift.TBase {
     if(this.events != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
       oprot.writeListBegin(new thrift.TList(thrift.TType.STRUCT, events.length));
-      for(var elem40 in events) {
-        elem40.write(oprot);
+      for(var elem43 in events) {
+        elem43.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
@@ -475,8 +610,8 @@ class EventWrapper implements thrift.TBase {
     if(this.events2 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
       oprot.writeSetBegin(new thrift.TSet(thrift.TType.STRUCT, events2.length));
-      for(var elem41 in events2) {
-        elem41.write(oprot);
+      for(var elem44 in events2) {
+        elem44.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -484,9 +619,9 @@ class EventWrapper implements thrift.TBase {
     if(this.eventMap != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
       oprot.writeMapBegin(new thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, eventMap.length));
-      for(var elem42 in eventMap.keys) {
-        oprot.writeI64(elem42);
-        eventMap[elem42].write(oprot);
+      for(var elem45 in eventMap.keys) {
+        oprot.writeI64(elem45);
+        eventMap[elem45].write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -494,10 +629,10 @@ class EventWrapper implements thrift.TBase {
     if(this.nums != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
       oprot.writeListBegin(new thrift.TList(thrift.TType.LIST, nums.length));
-      for(var elem43 in nums) {
-        oprot.writeListBegin(new thrift.TList(thrift.TType.I32, elem43.length));
-        for(var elem44 in elem43) {
-          oprot.writeI32(elem44);
+      for(var elem46 in nums) {
+        oprot.writeListBegin(new thrift.TList(thrift.TType.I32, elem46.length));
+        for(var elem47 in elem46) {
+          oprot.writeI32(elem47);
         }
         oprot.writeListEnd();
       }
@@ -507,8 +642,8 @@ class EventWrapper implements thrift.TBase {
     if(this.enums != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
       oprot.writeListBegin(new thrift.TList(thrift.TType.I32, enums.length));
-      for(var elem45 in enums) {
-        oprot.writeI32(elem45);
+      for(var elem48 in enums) {
+        oprot.writeI32(elem48);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
@@ -524,6 +659,23 @@ class EventWrapper implements thrift.TBase {
     if(this.typedefOfTypedef != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
       oprot.writeString(typedefOfTypedef);
+      oprot.writeFieldEnd();
+    }
+    oprot.writeFieldBegin(_DEPR_FIELD_DESC);
+    oprot.writeBool(depr);
+    oprot.writeFieldEnd();
+    if(this.deprBinary != null) {
+      oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
+      oprot.writeBinary(deprBinary);
+      oprot.writeFieldEnd();
+    }
+    if(this.deprList != null) {
+      oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
+      oprot.writeListBegin(new thrift.TList(thrift.TType.BOOL, deprList.length));
+      for(var elem49 in deprList) {
+        oprot.writeBool(elem49);
+      }
+      oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -606,6 +758,26 @@ class EventWrapper implements thrift.TBase {
       ret.write(this.typedefOfTypedef);
     }
 
+    ret.write(", ");
+    ret.write("depr:");
+    ret.write(this.depr);
+
+    ret.write(", ");
+    ret.write("deprBinary:");
+    if(this.deprBinary == null) {
+      ret.write("null");
+    } else {
+      ret.write("BINARY");
+    }
+
+    ret.write(", ");
+    ret.write("deprList:");
+    if(this.deprList == null) {
+      ret.write("null");
+    } else {
+      ret.write(this.deprList);
+    }
+
     ret.write(")");
 
     return ret.toString();
@@ -625,7 +797,10 @@ class EventWrapper implements thrift.TBase {
       && this.enums == other.enums
       && this.aBoolField == other.aBoolField
       && this.a_union == other.a_union
-      && this.typedefOfTypedef == other.typedefOfTypedef;
+      && this.typedefOfTypedef == other.typedefOfTypedef
+      && this.depr == other.depr
+      && this.deprBinary == other.deprBinary
+      && this.deprList == other.deprList;
   }
 
   EventWrapper clone({
@@ -639,6 +814,9 @@ class EventWrapper implements thrift.TBase {
     bool aBoolField: null,
     t_variety.TestingUnions a_union: null,
     String typedefOfTypedef: null,
+    bool depr: null,
+    Uint8List deprBinary: null,
+    List<bool> deprList: null,
   }) {
     return new EventWrapper()
       ..iD = iD ?? this.iD
@@ -650,7 +828,10 @@ class EventWrapper implements thrift.TBase {
       ..enums = enums ?? this.enums
       ..aBoolField = aBoolField ?? this.aBoolField
       ..a_union = a_union ?? this.a_union
-      ..typedefOfTypedef = typedefOfTypedef ?? this.typedefOfTypedef;
+      ..typedefOfTypedef = typedefOfTypedef ?? this.typedefOfTypedef
+      ..depr = depr ?? this.depr
+      ..deprBinary = deprBinary ?? this.deprBinary
+      ..deprList = deprList ?? this.deprList;
   }
 
   validate() {

--- a/test/expected/dart/variety/f_events_scope.dart
+++ b/test/expected/dart/variety/f_events_scope.dart
@@ -117,11 +117,11 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(new thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem68 in req) {
-      oprot.writeMapBegin(new thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem68.length));
-      for(var elem69 in elem68.keys) {
-        oprot.writeI64(elem69);
-        elem68[elem69].write(oprot);
+    for(var elem72 in req) {
+      oprot.writeMapBegin(new thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem72.length));
+      for(var elem73 in elem72.keys) {
+        oprot.writeI64(elem73);
+        elem72[elem73].write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -254,19 +254,19 @@ class EventsSubscriber {
         throw new thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem70 = iprot.readListBegin();
+      thrift.TList elem74 = iprot.readListBegin();
       List<Map<int, t_variety.Event>> req = new List<Map<int, t_variety.Event>>();
-      for(int elem76 = 0; elem76 < elem70.length; ++elem76) {
-        thrift.TMap elem72 = iprot.readMapBegin();
-        Map<int, t_variety.Event> elem71 = new Map<int, t_variety.Event>();
-        for(int elem74 = 0; elem74 < elem72.length; ++elem74) {
-          int elem75 = iprot.readI64();
-          t_variety.Event elem73 = new t_variety.Event();
-          elem73.read(iprot);
-          elem71[elem75] = elem73;
+      for(int elem80 = 0; elem80 < elem74.length; ++elem80) {
+        thrift.TMap elem76 = iprot.readMapBegin();
+        Map<int, t_variety.Event> elem75 = new Map<int, t_variety.Event>();
+        for(int elem78 = 0; elem78 < elem76.length; ++elem78) {
+          int elem79 = iprot.readI64();
+          t_variety.Event elem77 = new t_variety.Event();
+          elem77.read(iprot);
+          elem75[elem79] = elem77;
         }
         iprot.readMapEnd();
-        req.add(elem71);
+        req.add(elem75);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -1148,12 +1148,12 @@ class oneWay_args implements thrift.TBase {
           break;
         case REQ:
           if(field.type == thrift.TType.MAP) {
-            thrift.TMap elem51 = iprot.readMapBegin();
+            thrift.TMap elem55 = iprot.readMapBegin();
             req = new Map<int, String>();
-            for(int elem53 = 0; elem53 < elem51.length; ++elem53) {
-              int elem54 = iprot.readI32();
-              String elem52 = iprot.readString();
-              req[elem54] = elem52;
+            for(int elem57 = 0; elem57 < elem55.length; ++elem57) {
+              int elem58 = iprot.readI32();
+              String elem56 = iprot.readString();
+              req[elem58] = elem56;
             }
             iprot.readMapEnd();
           } else {
@@ -1182,9 +1182,9 @@ class oneWay_args implements thrift.TBase {
     if(this.req != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
       oprot.writeMapBegin(new thrift.TMap(thrift.TType.I32, thrift.TType.STRING, req.length));
-      for(var elem55 in req.keys) {
-        oprot.writeI32(elem55);
-        oprot.writeString(req[elem55]);
+      for(var elem59 in req.keys) {
+        oprot.writeI32(elem59);
+        oprot.writeString(req[elem59]);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -2062,11 +2062,11 @@ class underlying_types_test_args implements thrift.TBase {
       switch(field.id) {
         case LIST_TYPE:
           if(field.type == thrift.TType.LIST) {
-            thrift.TList elem56 = iprot.readListBegin();
+            thrift.TList elem60 = iprot.readListBegin();
             list_type = new List<int>();
-            for(int elem58 = 0; elem58 < elem56.length; ++elem58) {
-              int elem57 = iprot.readI64();
-              list_type.add(elem57);
+            for(int elem62 = 0; elem62 < elem60.length; ++elem62) {
+              int elem61 = iprot.readI64();
+              list_type.add(elem61);
             }
             iprot.readListEnd();
           } else {
@@ -2075,11 +2075,11 @@ class underlying_types_test_args implements thrift.TBase {
           break;
         case SET_TYPE:
           if(field.type == thrift.TType.SET) {
-            thrift.TSet elem59 = iprot.readSetBegin();
+            thrift.TSet elem63 = iprot.readSetBegin();
             set_type = new Set<int>();
-            for(int elem61 = 0; elem61 < elem59.length; ++elem61) {
-              int elem60 = iprot.readI64();
-              set_type.add(elem60);
+            for(int elem65 = 0; elem65 < elem63.length; ++elem65) {
+              int elem64 = iprot.readI64();
+              set_type.add(elem64);
             }
             iprot.readSetEnd();
           } else {
@@ -2105,8 +2105,8 @@ class underlying_types_test_args implements thrift.TBase {
     if(this.list_type != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
       oprot.writeListBegin(new thrift.TList(thrift.TType.I64, list_type.length));
-      for(var elem62 in list_type) {
-        oprot.writeI64(elem62);
+      for(var elem66 in list_type) {
+        oprot.writeI64(elem66);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
@@ -2114,8 +2114,8 @@ class underlying_types_test_args implements thrift.TBase {
     if(this.set_type != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
       oprot.writeSetBegin(new thrift.TSet(thrift.TType.I64, set_type.length));
-      for(var elem63 in set_type) {
-        oprot.writeI64(elem63);
+      for(var elem67 in set_type) {
+        oprot.writeI64(elem67);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -2238,11 +2238,11 @@ class underlying_types_test_result implements thrift.TBase {
       switch(field.id) {
         case SUCCESS:
           if(field.type == thrift.TType.LIST) {
-            thrift.TList elem64 = iprot.readListBegin();
+            thrift.TList elem68 = iprot.readListBegin();
             success = new List<int>();
-            for(int elem66 = 0; elem66 < elem64.length; ++elem66) {
-              int elem65 = iprot.readI64();
-              success.add(elem65);
+            for(int elem70 = 0; elem70 < elem68.length; ++elem70) {
+              int elem69 = iprot.readI64();
+              success.add(elem69);
             }
             iprot.readListEnd();
           } else {
@@ -2268,8 +2268,8 @@ class underlying_types_test_result implements thrift.TBase {
     if(isSetSuccess() && this.success != null) {
       oprot.writeFieldBegin(_SUCCESS_FIELD_DESC);
       oprot.writeListBegin(new thrift.TList(thrift.TType.I64, success.length));
-      for(var elem67 in success) {
-        oprot.writeI64(elem67);
+      for(var elem71 in success) {
+        oprot.writeI64(elem71);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/test/expected/dart/variety/f_testing_unions.dart
+++ b/test/expected/dart/variety/f_testing_unions.dart
@@ -18,6 +18,7 @@ class TestingUnions implements thrift.TBase {
   static final thrift.TField _AN_INT16_FIELD_DESC = new thrift.TField("AnInt16", thrift.TType.I16, 4);
   static final thrift.TField _REQUESTS_FIELD_DESC = new thrift.TField("Requests", thrift.TType.MAP, 5);
   static final thrift.TField _BIN_FIELD_IN_UNION_FIELD_DESC = new thrift.TField("bin_field_in_union", thrift.TType.STRING, 6);
+  static final thrift.TField _DEPR_FIELD_DESC = new thrift.TField("depr", thrift.TType.BOOL, 7);
 
   int _anID;
   static const int ANID = 1;
@@ -31,10 +32,15 @@ class TestingUnions implements thrift.TBase {
   static const int REQUESTS = 5;
   Uint8List _bin_field_in_union;
   static const int BIN_FIELD_IN_UNION = 6;
+  /// Deprecated: use something else
+  @deprecated
+  bool _depr;
+  static const int DEPR = 7;
 
   bool __isset_anID = false;
   bool __isset_someotherthing = false;
   bool __isset_anInt16 = false;
+  bool __isset_depr = false;
 
   TestingUnions() {
   }
@@ -114,6 +120,23 @@ class TestingUnions implements thrift.TBase {
     this.bin_field_in_union = null;
   }
 
+  /// Deprecated: use something else
+  @deprecated
+  bool get depr => this._depr;
+
+  /// Deprecated: use something else
+  @deprecated
+  set depr(bool depr) {
+    this._depr = depr;
+    this.__isset_depr = true;
+  }
+
+  @deprecated  bool isSetDepr() => this.__isset_depr;
+
+  unsetDepr() {
+    this.__isset_depr = false;
+  }
+
   getFieldValue(int fieldID) {
     switch (fieldID) {
       case ANID:
@@ -128,6 +151,8 @@ class TestingUnions implements thrift.TBase {
         return this.requests;
       case BIN_FIELD_IN_UNION:
         return this.bin_field_in_union;
+      case DEPR:
+        return this.depr;
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
     }
@@ -183,6 +208,14 @@ class TestingUnions implements thrift.TBase {
         }
         break;
 
+      case DEPR:
+        if(value == null) {
+          unsetDepr();
+        } else {
+          this.depr = value as bool;
+        }
+        break;
+
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
     }
@@ -203,6 +236,8 @@ class TestingUnions implements thrift.TBase {
         return isSetRequests();
       case BIN_FIELD_IN_UNION:
         return isSetBin_field_in_union();
+      case DEPR:
+        return isSetDepr();
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
     }
@@ -250,12 +285,12 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if(field.type == thrift.TType.MAP) {
-            thrift.TMap elem46 = iprot.readMapBegin();
+            thrift.TMap elem50 = iprot.readMapBegin();
             requests = new Map<int, String>();
-            for(int elem48 = 0; elem48 < elem46.length; ++elem48) {
-              int elem49 = iprot.readI32();
-              String elem47 = iprot.readString();
-              requests[elem49] = elem47;
+            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
+              int elem53 = iprot.readI32();
+              String elem51 = iprot.readString();
+              requests[elem53] = elem51;
             }
             iprot.readMapEnd();
           } else {
@@ -265,6 +300,14 @@ class TestingUnions implements thrift.TBase {
         case BIN_FIELD_IN_UNION:
           if(field.type == thrift.TType.STRING) {
             bin_field_in_union = iprot.readBinary();
+          } else {
+            thrift.TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
+        case DEPR:
+          if(field.type == thrift.TType.BOOL) {
+            depr = iprot.readBool();
+            this.__isset_depr = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -308,9 +351,9 @@ class TestingUnions implements thrift.TBase {
     if(isSetRequests() && this.requests != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
       oprot.writeMapBegin(new thrift.TMap(thrift.TType.I32, thrift.TType.STRING, requests.length));
-      for(var elem50 in requests.keys) {
-        oprot.writeI32(elem50);
-        oprot.writeString(requests[elem50]);
+      for(var elem54 in requests.keys) {
+        oprot.writeI32(elem54);
+        oprot.writeString(requests[elem54]);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -318,6 +361,11 @@ class TestingUnions implements thrift.TBase {
     if(isSetBin_field_in_union() && this.bin_field_in_union != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
       oprot.writeBinary(bin_field_in_union);
+      oprot.writeFieldEnd();
+    }
+    if(isSetDepr()) {
+      oprot.writeFieldBegin(_DEPR_FIELD_DESC);
+      oprot.writeBool(depr);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -374,6 +422,12 @@ class TestingUnions implements thrift.TBase {
       }
     }
 
+    if(isSetDepr()) {
+      ret.write(", ");
+      ret.write("depr:");
+      ret.write(this.depr);
+    }
+
     ret.write(")");
 
     return ret.toString();
@@ -389,7 +443,8 @@ class TestingUnions implements thrift.TBase {
       && this.someotherthing == other.someotherthing
       && this.anInt16 == other.anInt16
       && this.requests == other.requests
-      && this.bin_field_in_union == other.bin_field_in_union;
+      && this.bin_field_in_union == other.bin_field_in_union
+      && this.depr == other.depr;
   }
 
   TestingUnions clone({
@@ -399,6 +454,7 @@ class TestingUnions implements thrift.TBase {
     int anInt16: null,
     Map<int, String> requests: null,
     Uint8List bin_field_in_union: null,
+    bool depr: null,
   }) {
     return new TestingUnions()
       ..anID = anID ?? this.anID
@@ -406,7 +462,8 @@ class TestingUnions implements thrift.TBase {
       ..someotherthing = someotherthing ?? this.someotherthing
       ..anInt16 = anInt16 ?? this.anInt16
       ..requests = requests ?? this.requests
-      ..bin_field_in_union = bin_field_in_union ?? this.bin_field_in_union;
+      ..bin_field_in_union = bin_field_in_union ?? this.bin_field_in_union
+      ..depr = depr ?? this.depr;
   }
 
   validate() {
@@ -428,6 +485,9 @@ class TestingUnions implements thrift.TBase {
       setFields++;
     }
     if(isSetBin_field_in_union()) {
+      setFields++;
+    }
+    if(isSetDepr()) {
       setFields++;
     }
     if(setFields != 1) {

--- a/test/expected/go/actual_base/f_types.txt
+++ b/test/expected/go/actual_base/f_types.txt
@@ -266,11 +266,11 @@ func (p *NestedThing) ReadField1(iprot thrift.TProtocol) error {
 	}
 	p.Things = make([]*Thing, 0, size)
 	for i := 0; i < size; i++ {
-		elem23 := NewThing()
-		if err := elem23.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem23), err)
+		elem24 := NewThing()
+		if err := elem24.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem24), err)
 		}
-		p.Things = append(p.Things, elem23)
+		p.Things = append(p.Things, elem24)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/go/variety/f_events_scope.txt
+++ b/test/expected/go/variety/f_events_scope.txt
@@ -447,25 +447,25 @@ func (l *eventsSubscriber) recvSomeList(op string, pf *frugal.FProtocolFactory, 
 			if err != nil {
 				return thrift.PrependError("error reading map begin: ", err)
 			}
-			elem20 := make(map[ID]*Event, size)
+			elem21 := make(map[ID]*Event, size)
 			for i := 0; i < size; i++ {
-				var elem21 ID
+				var elem22 ID
 				if v, err := iprot.ReadI64(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := ID(v)
-					elem21 = temp
+					elem22 = temp
 				}
-				elem22 := NewEvent()
-				if err := elem22.Read(iprot); err != nil {
-					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem22), err)
+				elem23 := NewEvent()
+				if err := elem23.Read(iprot); err != nil {
+					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem23), err)
 				}
-				(elem20)[elem21] = elem22
+				(elem21)[elem22] = elem23
 			}
 			if err := iprot.ReadMapEnd(); err != nil {
 				return thrift.PrependError("error reading map end: ", err)
 			}
-			req = append(req, elem20)
+			req = append(req, elem21)
 		}
 		if err := iprot.ReadListEnd(); err != nil {
 			return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/go/variety/f_foo_service.txt
+++ b/test/expected/go/variety/f_foo_service.txt
@@ -28,7 +28,7 @@ type FFoo interface {
 	golang.FBaseFoo
 
 	// Ping the server.
-	// Deprecated
+	// Deprecated: don't use this; use "something else"
 	Ping(ctx frugal.FContext) (err error)
 	// Blah the server.
 	Blah(ctx frugal.FContext, num int32, Str string, event *Event) (r int64, err error)
@@ -2076,20 +2076,20 @@ func (p *FooOneWayArgs) ReadField2(iprot thrift.TProtocol) error {
 	}
 	p.Req = make(Request, size)
 	for i := 0; i < size; i++ {
-		var elem15 Int
+		var elem16 Int
 		if v, err := iprot.ReadI32(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := Int(v)
-			elem15 = temp
+			elem16 = temp
 		}
-		var elem16 string
+		var elem17 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			elem16 = v
+			elem17 = v
 		}
-		(p.Req)[elem15] = elem16
+		(p.Req)[elem16] = elem17
 	}
 	if err := iprot.ReadMapEnd(); err != nil {
 		return thrift.PrependError("error reading map end: ", err)
@@ -2752,14 +2752,14 @@ func (p *FooUnderlyingTypesTestArgs) ReadField1(iprot thrift.TProtocol) error {
 	}
 	p.ListType = make([]ID, 0, size)
 	for i := 0; i < size; i++ {
-		var elem17 ID
+		var elem18 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem17 = temp
+			elem18 = temp
 		}
-		p.ListType = append(p.ListType, elem17)
+		p.ListType = append(p.ListType, elem18)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -2774,14 +2774,14 @@ func (p *FooUnderlyingTypesTestArgs) ReadField2(iprot thrift.TProtocol) error {
 	}
 	p.SetType = make(map[ID]bool, size)
 	for i := 0; i < size; i++ {
-		var elem18 ID
+		var elem19 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem18 = temp
+			elem19 = temp
 		}
-		(p.SetType)[elem18] = true
+		(p.SetType)[elem19] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -2915,14 +2915,14 @@ func (p *FooUnderlyingTypesTestResult) ReadField0(iprot thrift.TProtocol) error 
 	}
 	p.Success = make([]ID, 0, size)
 	for i := 0; i < size; i++ {
-		var elem19 ID
+		var elem20 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem19 = temp
+			elem20 = temp
 		}
-		p.Success = append(p.Success, elem19)
+		p.Success = append(p.Success, elem20)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/go/variety/f_types.txt
+++ b/test/expected/go/variety/f_types.txt
@@ -2610,6 +2610,8 @@ type AwesomeException struct {
 	ID ID `thrift:"ID,1" db:"ID" json:"ID"`
 	// Reason contains the error message.
 	Reason string `thrift:"Reason,2" db:"Reason" json:"Reason"`
+	// Deprecated: use something else
+	Depr bool `thrift:"depr,3" db:"depr" json:"depr"`
 }
 
 func NewAwesomeException() *AwesomeException {
@@ -2622,6 +2624,10 @@ func (p *AwesomeException) GetID() ID {
 
 func (p *AwesomeException) GetReason() string {
 	return p.Reason
+}
+
+func (p *AwesomeException) GetDepr() bool {
+	return p.Depr
 }
 
 func (p *AwesomeException) Read(iprot thrift.TProtocol) error {
@@ -2644,6 +2650,10 @@ func (p *AwesomeException) Read(iprot thrift.TProtocol) error {
 			}
 		case 2:
 			if err := p.ReadField2(iprot); err != nil {
+				return err
+			}
+		case 3:
+			if err := p.ReadField3(iprot); err != nil {
 				return err
 			}
 		default:
@@ -2680,6 +2690,15 @@ func (p *AwesomeException) ReadField2(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *AwesomeException) ReadField3(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBool(); err != nil {
+		return thrift.PrependError("error reading field 3: ", err)
+	} else {
+		p.Depr = v
+	}
+	return nil
+}
+
 func (p *AwesomeException) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("AwesomeException"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -2688,6 +2707,9 @@ func (p *AwesomeException) Write(oprot thrift.TProtocol) error {
 		return err
 	}
 	if err := p.writeField2(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField3(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -2721,6 +2743,19 @@ func (p *AwesomeException) writeField2(oprot thrift.TProtocol) error {
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write field end error 2:Reason: ", p), err)
+	}
+	return nil
+}
+
+func (p *AwesomeException) writeField3(oprot thrift.TProtocol) error {
+	if err := oprot.WriteFieldBegin("depr", thrift.BOOL, 3); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 3:depr: ", p), err)
+	}
+	if err := oprot.WriteBool(bool(p.Depr)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.depr (3) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 3:depr: ", p), err)
 	}
 	return nil
 }

--- a/test/expected/go/variety/f_types.txt
+++ b/test/expected/go/variety/f_types.txt
@@ -1503,6 +1503,14 @@ type EventWrapper struct {
 	ABoolField       bool            `thrift:"aBoolField,8" db:"aBoolField" json:"aBoolField"`
 	AUnion           *TestingUnions  `thrift:"a_union,9" db:"a_union" json:"a_union"`
 	TypedefOfTypedef T2String        `thrift:"typedefOfTypedef,10" db:"typedefOfTypedef" json:"typedefOfTypedef"`
+	// This is a docstring comment for a deprecated field that has been spread
+	// across two lines.
+	// Deprecated: use something else
+	Depr bool `thrift:"depr,11" db:"depr" json:"depr"`
+	// Deprecated: use something else
+	DeprBinary []byte `thrift:"deprBinary,12" db:"deprBinary" json:"deprBinary"`
+	// Deprecated: use something else
+	DeprList []bool `thrift:"deprList,13" db:"deprList" json:"deprList"`
 }
 
 func NewEventWrapper() *EventWrapper {
@@ -1576,6 +1584,18 @@ func (p *EventWrapper) GetTypedefOfTypedef() T2String {
 	return p.TypedefOfTypedef
 }
 
+func (p *EventWrapper) GetDepr() bool {
+	return p.Depr
+}
+
+func (p *EventWrapper) GetDeprBinary() []byte {
+	return p.DeprBinary
+}
+
+func (p *EventWrapper) GetDeprList() []bool {
+	return p.DeprList
+}
+
 func (p *EventWrapper) Read(iprot thrift.TProtocol) error {
 	if _, err := iprot.ReadStructBegin(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
@@ -1631,6 +1651,18 @@ func (p *EventWrapper) Read(iprot thrift.TProtocol) error {
 			}
 		case 10:
 			if err := p.ReadField10(iprot); err != nil {
+				return err
+			}
+		case 11:
+			if err := p.ReadField11(iprot); err != nil {
+				return err
+			}
+		case 12:
+			if err := p.ReadField12(iprot); err != nil {
+				return err
+			}
+		case 13:
+			if err := p.ReadField13(iprot); err != nil {
 				return err
 			}
 		default:
@@ -1815,6 +1847,45 @@ func (p *EventWrapper) ReadField10(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *EventWrapper) ReadField11(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBool(); err != nil {
+		return thrift.PrependError("error reading field 11: ", err)
+	} else {
+		p.Depr = v
+	}
+	return nil
+}
+
+func (p *EventWrapper) ReadField12(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBinary(); err != nil {
+		return thrift.PrependError("error reading field 12: ", err)
+	} else {
+		p.DeprBinary = v
+	}
+	return nil
+}
+
+func (p *EventWrapper) ReadField13(iprot thrift.TProtocol) error {
+	_, size, err := iprot.ReadListBegin()
+	if err != nil {
+		return thrift.PrependError("error reading list begin: ", err)
+	}
+	p.DeprList = make([]bool, 0, size)
+	for i := 0; i < size; i++ {
+		var elem13 bool
+		if v, err := iprot.ReadBool(); err != nil {
+			return thrift.PrependError("error reading field 0: ", err)
+		} else {
+			elem13 = v
+		}
+		p.DeprList = append(p.DeprList, elem13)
+	}
+	if err := iprot.ReadListEnd(); err != nil {
+		return thrift.PrependError("error reading list end: ", err)
+	}
+	return nil
+}
+
 func (p *EventWrapper) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("EventWrapper"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -1847,6 +1918,15 @@ func (p *EventWrapper) Write(oprot thrift.TProtocol) error {
 		return err
 	}
 	if err := p.writeField10(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField11(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField12(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField13(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -2041,6 +2121,53 @@ func (p *EventWrapper) writeField10(oprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *EventWrapper) writeField11(oprot thrift.TProtocol) error {
+	if err := oprot.WriteFieldBegin("depr", thrift.BOOL, 11); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 11:depr: ", p), err)
+	}
+	if err := oprot.WriteBool(bool(p.Depr)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.depr (11) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 11:depr: ", p), err)
+	}
+	return nil
+}
+
+func (p *EventWrapper) writeField12(oprot thrift.TProtocol) error {
+	if err := oprot.WriteFieldBegin("deprBinary", thrift.STRING, 12); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 12:deprBinary: ", p), err)
+	}
+	if err := oprot.WriteBinary([]byte(p.DeprBinary)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.deprBinary (12) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 12:deprBinary: ", p), err)
+	}
+	return nil
+}
+
+func (p *EventWrapper) writeField13(oprot thrift.TProtocol) error {
+	if err := oprot.WriteFieldBegin("deprList", thrift.LIST, 13); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 13:deprList: ", p), err)
+	}
+	if err := oprot.WriteListBegin(thrift.BOOL, len(p.DeprList)); err != nil {
+		return thrift.PrependError("error writing list begin: ", err)
+	}
+	for _, v := range p.DeprList {
+		if err := oprot.WriteBool(bool(v)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+		}
+	}
+	if err := oprot.WriteListEnd(); err != nil {
+		return thrift.PrependError("error writing list end: ", err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 13:deprList: ", p), err)
+	}
+	return nil
+}
+
 func (p *EventWrapper) String() string {
 	if p == nil {
 		return "<nil>"
@@ -2055,6 +2182,8 @@ type TestingUnions struct {
 	AnInt16         *int16  `thrift:"AnInt16,4" db:"AnInt16" json:"AnInt16,omitempty"`
 	Requests        Request `thrift:"Requests,5" db:"Requests" json:"Requests,omitempty"`
 	BinFieldInUnion []byte  `thrift:"bin_field_in_union,6" db:"bin_field_in_union" json:"bin_field_in_union,omitempty"`
+	// Deprecated: use something else
+	Depr *bool `thrift:"depr,7" db:"depr" json:"depr,omitempty"`
 }
 
 func NewTestingUnions() *TestingUnions {
@@ -2133,6 +2262,19 @@ func (p *TestingUnions) GetBinFieldInUnion() []byte {
 	return p.BinFieldInUnion
 }
 
+var TestingUnions_Depr_DEFAULT bool
+
+func (p *TestingUnions) IsSetDepr() bool {
+	return p.Depr != nil
+}
+
+func (p *TestingUnions) GetDepr() bool {
+	if !p.IsSetDepr() {
+		return TestingUnions_Depr_DEFAULT
+	}
+	return *p.Depr
+}
+
 func (p *TestingUnions) CountSetFieldsTestingUnions() int {
 	count := 0
 	if p.IsSetAnID() {
@@ -2151,6 +2293,9 @@ func (p *TestingUnions) CountSetFieldsTestingUnions() int {
 		count++
 	}
 	if p.IsSetBinFieldInUnion() {
+		count++
+	}
+	if p.IsSetDepr() {
 		count++
 	}
 	return count
@@ -2192,6 +2337,10 @@ func (p *TestingUnions) Read(iprot thrift.TProtocol) error {
 			}
 		case 6:
 			if err := p.ReadField6(iprot); err != nil {
+				return err
+			}
+		case 7:
+			if err := p.ReadField7(iprot); err != nil {
 				return err
 			}
 		default:
@@ -2257,20 +2406,20 @@ func (p *TestingUnions) ReadField5(iprot thrift.TProtocol) error {
 	}
 	p.Requests = make(Request, size)
 	for i := 0; i < size; i++ {
-		var elem13 Int
+		var elem14 Int
 		if v, err := iprot.ReadI32(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := Int(v)
-			elem13 = temp
+			elem14 = temp
 		}
-		var elem14 string
+		var elem15 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			elem14 = v
+			elem15 = v
 		}
-		(p.Requests)[elem13] = elem14
+		(p.Requests)[elem14] = elem15
 	}
 	if err := iprot.ReadMapEnd(); err != nil {
 		return thrift.PrependError("error reading map end: ", err)
@@ -2283,6 +2432,15 @@ func (p *TestingUnions) ReadField6(iprot thrift.TProtocol) error {
 		return thrift.PrependError("error reading field 6: ", err)
 	} else {
 		p.BinFieldInUnion = v
+	}
+	return nil
+}
+
+func (p *TestingUnions) ReadField7(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadBool(); err != nil {
+		return thrift.PrependError("error reading field 7: ", err)
+	} else {
+		p.Depr = &v
 	}
 	return nil
 }
@@ -2310,6 +2468,9 @@ func (p *TestingUnions) Write(oprot thrift.TProtocol) error {
 		return err
 	}
 	if err := p.writeField6(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField7(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -2417,6 +2578,21 @@ func (p *TestingUnions) writeField6(oprot thrift.TProtocol) error {
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T write field end error 6:bin_field_in_union: ", p), err)
+		}
+	}
+	return nil
+}
+
+func (p *TestingUnions) writeField7(oprot thrift.TProtocol) error {
+	if p.IsSetDepr() {
+		if err := oprot.WriteFieldBegin("depr", thrift.BOOL, 7); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 7:depr: ", p), err)
+		}
+		if err := oprot.WriteBool(bool(*p.Depr)); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T.depr (7) field write error: ", p), err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 7:depr: ", p), err)
 		}
 	}
 	return nil

--- a/test/expected/go/variety_async/f_foo_service.txt
+++ b/test/expected/go/variety_async/f_foo_service.txt
@@ -28,7 +28,7 @@ type FFoo interface {
 	golang.FBaseFoo
 
 	// Ping the server.
-	// Deprecated
+	// Deprecated: don't use this; use "something else"
 	Ping(ctx frugal.FContext) (err error)
 	// Blah the server.
 	Blah(ctx frugal.FContext, num int32, Str string, event *Event) (r int64, err error)
@@ -2193,20 +2193,20 @@ func (p *FooOneWayArgs) ReadField2(iprot thrift.TProtocol) error {
 	}
 	p.Req = make(Request, size)
 	for i := 0; i < size; i++ {
-		var elem15 Int
+		var elem16 Int
 		if v, err := iprot.ReadI32(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := Int(v)
-			elem15 = temp
+			elem16 = temp
 		}
-		var elem16 string
+		var elem17 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			elem16 = v
+			elem17 = v
 		}
-		(p.Req)[elem15] = elem16
+		(p.Req)[elem16] = elem17
 	}
 	if err := iprot.ReadMapEnd(); err != nil {
 		return thrift.PrependError("error reading map end: ", err)
@@ -2869,14 +2869,14 @@ func (p *FooUnderlyingTypesTestArgs) ReadField1(iprot thrift.TProtocol) error {
 	}
 	p.ListType = make([]ID, 0, size)
 	for i := 0; i < size; i++ {
-		var elem17 ID
+		var elem18 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem17 = temp
+			elem18 = temp
 		}
-		p.ListType = append(p.ListType, elem17)
+		p.ListType = append(p.ListType, elem18)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -2891,14 +2891,14 @@ func (p *FooUnderlyingTypesTestArgs) ReadField2(iprot thrift.TProtocol) error {
 	}
 	p.SetType = make(map[ID]bool, size)
 	for i := 0; i < size; i++ {
-		var elem18 ID
+		var elem19 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem18 = temp
+			elem19 = temp
 		}
-		(p.SetType)[elem18] = true
+		(p.SetType)[elem19] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -3032,14 +3032,14 @@ func (p *FooUnderlyingTypesTestResult) ReadField0(iprot thrift.TProtocol) error 
 	}
 	p.Success = make([]ID, 0, size)
 	for i := 0; i < size; i++ {
-		var elem19 ID
+		var elem20 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem19 = temp
+			elem20 = temp
 		}
-		p.Success = append(p.Success, elem19)
+		p.Success = append(p.Success, elem20)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/html/standalone/variety.html
+++ b/test/expected/html/standalone/variety.html
@@ -1002,6 +1002,33 @@ code { line-height: 20px; }
 						<td></td>
 					</tr>
 					
+					<tr>
+						<td>11</td>
+						<td>depr</td>
+						<td><code>bool</code></td>
+						<td>This is a docstring comment for a deprecated field that has been spread<br />across two lines.<br />Deprecated: use something else</td>
+						<td>default</td>
+						<td></td>
+					</tr>
+					
+					<tr>
+						<td>12</td>
+						<td>deprBinary</td>
+						<td><code>binary</code></td>
+						<td>Deprecated: use something else</td>
+						<td>default</td>
+						<td></td>
+					</tr>
+					
+					<tr>
+						<td>13</td>
+						<td>deprList</td>
+						<td><code>list&lt;bool&gt;</code></td>
+						<td>Deprecated: use something else</td>
+						<td>default</td>
+						<td></td>
+					</tr>
+					
 				</table>
 				<br />
 				
@@ -1104,6 +1131,15 @@ code { line-height: 20px; }
 						<td>bin_field_in_union</td>
 						<td><code>binary</code></td>
 						<td></td>
+						<td>optional</td>
+						<td></td>
+					</tr>
+					
+					<tr>
+						<td>7</td>
+						<td>depr</td>
+						<td><code>bool</code></td>
+						<td>Deprecated: use something else</td>
 						<td>optional</td>
 						<td></td>
 					</tr>

--- a/test/expected/html/standalone/variety.html
+++ b/test/expected/html/standalone/variety.html
@@ -1064,6 +1064,15 @@ code { line-height: 20px; }
 						<td></td>
 					</tr>
 					
+					<tr>
+						<td>3</td>
+						<td>depr</td>
+						<td><code>bool</code></td>
+						<td>Deprecated: use something else</td>
+						<td>default</td>
+						<td></td>
+					</tr>
+					
 				</table>
 				<br />
 				

--- a/test/expected/html/variety.html
+++ b/test/expected/html/variety.html
@@ -817,6 +817,33 @@
 						<td></td>
 					</tr>
 					
+					<tr>
+						<td>11</td>
+						<td>depr</td>
+						<td><code>bool</code></td>
+						<td>This is a docstring comment for a deprecated field that has been spread<br />across two lines.<br />Deprecated: use something else</td>
+						<td>default</td>
+						<td></td>
+					</tr>
+					
+					<tr>
+						<td>12</td>
+						<td>deprBinary</td>
+						<td><code>binary</code></td>
+						<td>Deprecated: use something else</td>
+						<td>default</td>
+						<td></td>
+					</tr>
+					
+					<tr>
+						<td>13</td>
+						<td>deprList</td>
+						<td><code>list&lt;bool&gt;</code></td>
+						<td>Deprecated: use something else</td>
+						<td>default</td>
+						<td></td>
+					</tr>
+					
 				</table>
 				<br />
 				
@@ -919,6 +946,15 @@
 						<td>bin_field_in_union</td>
 						<td><code>binary</code></td>
 						<td></td>
+						<td>optional</td>
+						<td></td>
+					</tr>
+					
+					<tr>
+						<td>7</td>
+						<td>depr</td>
+						<td><code>bool</code></td>
+						<td>Deprecated: use something else</td>
 						<td>optional</td>
 						<td></td>
 					</tr>

--- a/test/expected/html/variety.html
+++ b/test/expected/html/variety.html
@@ -879,6 +879,15 @@
 						<td></td>
 					</tr>
 					
+					<tr>
+						<td>3</td>
+						<td>depr</td>
+						<td><code>bool</code></td>
+						<td>Deprecated: use something else</td>
+						<td>default</td>
+						<td></td>
+					</tr>
+					
 				</table>
 				<br />
 				

--- a/test/expected/java/actual_base/nested_thing.java
+++ b/test/expected/java/actual_base/nested_thing.java
@@ -121,9 +121,9 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 	public nested_thing(nested_thing other) {
 		if (other.isSetThings()) {
 			this.things = new ArrayList<thing>(other.things.size());
-			for (thing elem313 : other.things) {
-				thing elem314 = new thing(elem313);
-				this.things.add(elem314);
+			for (thing elem315 : other.things) {
+				thing elem316 = new thing(elem315);
+				this.things.add(elem316);
 			}
 		}
 	}
@@ -339,12 +339,12 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 				switch (schemeField.id) {
 					case 1: // THINGS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem315 = iprot.readListBegin();
-							struct.things = new ArrayList<thing>(elem315.size);
-							for (int elem316 = 0; elem316 < elem315.size; ++elem316) {
-								thing elem317 = new thing();
-								elem317.read(iprot);
-								struct.things.add(elem317);
+							org.apache.thrift.protocol.TList elem317 = iprot.readListBegin();
+							struct.things = new ArrayList<thing>(elem317.size);
+							for (int elem318 = 0; elem318 < elem317.size; ++elem318) {
+								thing elem319 = new thing();
+								elem319.read(iprot);
+								struct.things.add(elem319);
 							}
 							iprot.readListEnd();
 							struct.setThingsIsSet(true);
@@ -370,8 +370,8 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 			if (struct.things != null) {
 				oprot.writeFieldBegin(THINGS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.things.size()));
-				for (thing elem318 : struct.things) {
-					elem318.write(oprot);
+				for (thing elem320 : struct.things) {
+					elem320.write(oprot);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -400,8 +400,8 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetThings()) {
 				oprot.writeI32(struct.things.size());
-				for (thing elem319 : struct.things) {
-					elem319.write(oprot);
+				for (thing elem321 : struct.things) {
+					elem321.write(oprot);
 				}
 			}
 		}
@@ -411,12 +411,12 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(1);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem320 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-				struct.things = new ArrayList<thing>(elem320.size);
-				for (int elem321 = 0; elem321 < elem320.size; ++elem321) {
-					thing elem322 = new thing();
-					elem322.read(iprot);
-					struct.things.add(elem322);
+				org.apache.thrift.protocol.TList elem322 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+				struct.things = new ArrayList<thing>(elem322.size);
+				for (int elem323 = 0; elem323 < elem322.size; ++elem323) {
+					thing elem324 = new thing();
+					elem324.read(iprot);
+					struct.things.add(elem324);
 				}
 				struct.setThingsIsSet(true);
 			}

--- a/test/expected/java/actual_base/nested_thing.java
+++ b/test/expected/java/actual_base/nested_thing.java
@@ -121,9 +121,9 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 	public nested_thing(nested_thing other) {
 		if (other.isSetThings()) {
 			this.things = new ArrayList<thing>(other.things.size());
-			for (thing elem295 : other.things) {
-				thing elem296 = new thing(elem295);
-				this.things.add(elem296);
+			for (thing elem313 : other.things) {
+				thing elem314 = new thing(elem313);
+				this.things.add(elem314);
 			}
 		}
 	}
@@ -339,12 +339,12 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 				switch (schemeField.id) {
 					case 1: // THINGS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem297 = iprot.readListBegin();
-							struct.things = new ArrayList<thing>(elem297.size);
-							for (int elem298 = 0; elem298 < elem297.size; ++elem298) {
-								thing elem299 = new thing();
-								elem299.read(iprot);
-								struct.things.add(elem299);
+							org.apache.thrift.protocol.TList elem315 = iprot.readListBegin();
+							struct.things = new ArrayList<thing>(elem315.size);
+							for (int elem316 = 0; elem316 < elem315.size; ++elem316) {
+								thing elem317 = new thing();
+								elem317.read(iprot);
+								struct.things.add(elem317);
 							}
 							iprot.readListEnd();
 							struct.setThingsIsSet(true);
@@ -370,8 +370,8 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 			if (struct.things != null) {
 				oprot.writeFieldBegin(THINGS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.things.size()));
-				for (thing elem300 : struct.things) {
-					elem300.write(oprot);
+				for (thing elem318 : struct.things) {
+					elem318.write(oprot);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -400,8 +400,8 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetThings()) {
 				oprot.writeI32(struct.things.size());
-				for (thing elem301 : struct.things) {
-					elem301.write(oprot);
+				for (thing elem319 : struct.things) {
+					elem319.write(oprot);
 				}
 			}
 		}
@@ -411,12 +411,12 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(1);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem302 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-				struct.things = new ArrayList<thing>(elem302.size);
-				for (int elem303 = 0; elem303 < elem302.size; ++elem303) {
-					thing elem304 = new thing();
-					elem304.read(iprot);
-					struct.things.add(elem304);
+				org.apache.thrift.protocol.TList elem320 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+				struct.things = new ArrayList<thing>(elem320.size);
+				for (int elem321 = 0; elem321 < elem320.size; ++elem321) {
+					thing elem322 = new thing();
+					elem322.read(iprot);
+					struct.things.add(elem322);
 				}
 				struct.setThingsIsSet(true);
 			}

--- a/test/expected/java/actual_base/thing.java
+++ b/test/expected/java/actual_base/thing.java
@@ -430,13 +430,13 @@ public class thing implements org.apache.thrift.TBase<thing, thing._Fields>, jav
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(AN_ID_FIELD_DESC);
-			int elem309 = struct.an_id;
-			oprot.writeI32(elem309);
+			int elem311 = struct.an_id;
+			oprot.writeI32(elem311);
 			oprot.writeFieldEnd();
 			if (struct.a_string != null) {
 				oprot.writeFieldBegin(A_STRING_FIELD_DESC);
-				String elem310 = struct.a_string;
-				oprot.writeString(elem310);
+				String elem312 = struct.a_string;
+				oprot.writeString(elem312);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -465,12 +465,12 @@ public class thing implements org.apache.thrift.TBase<thing, thing._Fields>, jav
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetAn_id()) {
-				int elem311 = struct.an_id;
-				oprot.writeI32(elem311);
+				int elem313 = struct.an_id;
+				oprot.writeI32(elem313);
 			}
 			if (struct.isSetA_string()) {
-				String elem312 = struct.a_string;
-				oprot.writeString(elem312);
+				String elem314 = struct.a_string;
+				oprot.writeString(elem314);
 			}
 		}
 

--- a/test/expected/java/actual_base/thing.java
+++ b/test/expected/java/actual_base/thing.java
@@ -430,13 +430,13 @@ public class thing implements org.apache.thrift.TBase<thing, thing._Fields>, jav
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(AN_ID_FIELD_DESC);
-			int elem291 = struct.an_id;
-			oprot.writeI32(elem291);
+			int elem309 = struct.an_id;
+			oprot.writeI32(elem309);
 			oprot.writeFieldEnd();
 			if (struct.a_string != null) {
 				oprot.writeFieldBegin(A_STRING_FIELD_DESC);
-				String elem292 = struct.a_string;
-				oprot.writeString(elem292);
+				String elem310 = struct.a_string;
+				oprot.writeString(elem310);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -465,12 +465,12 @@ public class thing implements org.apache.thrift.TBase<thing, thing._Fields>, jav
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetAn_id()) {
-				int elem293 = struct.an_id;
-				oprot.writeI32(elem293);
+				int elem311 = struct.an_id;
+				oprot.writeI32(elem311);
 			}
 			if (struct.isSetA_string()) {
-				String elem294 = struct.a_string;
-				oprot.writeString(elem294);
+				String elem312 = struct.a_string;
+				oprot.writeString(elem312);
 			}
 		}
 

--- a/test/expected/java/boxed_primitives/FFoo.java
+++ b/test/expected/java/boxed_primitives/FFoo.java
@@ -1933,16 +1933,16 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(NUM_FIELD_DESC);
-			Integer elem196 = struct.num;
-			if (elem196 == null) {
-				elem196 = 0;
+			Integer elem214 = struct.num;
+			if (elem214 == null) {
+				elem214 = 0;
 			}
-			oprot.writeI32(elem196);
+			oprot.writeI32(elem214);
 			oprot.writeFieldEnd();
 			if (struct.Str != null) {
 				oprot.writeFieldBegin(STR_FIELD_DESC);
-				String elem197 = struct.Str;
-				oprot.writeString(elem197);
+				String elem215 = struct.Str;
+				oprot.writeString(elem215);
 				oprot.writeFieldEnd();
 			}
 			if (struct.event != null) {
@@ -1979,15 +1979,15 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetNum()) {
-				Integer elem198 = struct.num;
-				if (elem198 == null) {
-					elem198 = 0;
+				Integer elem216 = struct.num;
+				if (elem216 == null) {
+					elem216 = 0;
 				}
-				oprot.writeI32(elem198);
+				oprot.writeI32(elem216);
 			}
 			if (struct.isSetStr()) {
-				String elem199 = struct.Str;
-				oprot.writeString(elem199);
+				String elem217 = struct.Str;
+				oprot.writeString(elem217);
 			}
 			if (struct.isSetEvent()) {
 				struct.event.write(oprot);
@@ -2511,11 +2511,11 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				Long elem200 = struct.success;
-				if (elem200 == null) {
-					elem200 = 0L;
+				Long elem218 = struct.success;
+				if (elem218 == null) {
+					elem218 = 0L;
 				}
-				oprot.writeI64(elem200);
+				oprot.writeI64(elem218);
 				oprot.writeFieldEnd();
 			}
 			if (struct.awe != null) {
@@ -2557,11 +2557,11 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetSuccess()) {
-				Long elem201 = struct.success;
-				if (elem201 == null) {
-					elem201 = 0L;
+				Long elem219 = struct.success;
+				if (elem219 == null) {
+					elem219 = 0L;
 				}
-				oprot.writeI64(elem201);
+				oprot.writeI64(elem219);
 			}
 			if (struct.isSetAwe()) {
 				struct.awe.write(oprot);
@@ -2691,10 +2691,10 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 		}
 		if (other.isSetReq()) {
 			this.req = new HashMap<Integer,String>(other.req.size());
-			for (Map.Entry<Integer, String> elem202 : other.req.entrySet()) {
-				Integer elem204 = elem202.getKey();
-				String elem203 = elem202.getValue();
-				this.req.put(elem204, elem203);
+			for (Map.Entry<Integer, String> elem220 : other.req.entrySet()) {
+				Integer elem222 = elem220.getKey();
+				String elem221 = elem220.getValue();
+				this.req.put(elem222, elem221);
 			}
 		}
 	}
@@ -2985,12 +2985,12 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 						break;
 					case 2: // REQ
 						if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
-							org.apache.thrift.protocol.TMap elem205 = iprot.readMapBegin();
-							struct.req = new HashMap<Integer,String>(2*elem205.size);
-							for (int elem206 = 0; elem206 < elem205.size; ++elem206) {
-								Integer elem208 = iprot.readI32();
-								String elem207 = iprot.readString();
-								struct.req.put(elem208, elem207);
+							org.apache.thrift.protocol.TMap elem223 = iprot.readMapBegin();
+							struct.req = new HashMap<Integer,String>(2*elem223.size);
+							for (int elem224 = 0; elem224 < elem223.size; ++elem224) {
+								Integer elem226 = iprot.readI32();
+								String elem225 = iprot.readString();
+								struct.req.put(elem226, elem225);
 							}
 							iprot.readMapEnd();
 							struct.setReqIsSet(true);
@@ -3014,23 +3014,23 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(ID_FIELD_DESC);
-			Long elem209 = struct.id;
-			if (elem209 == null) {
-				elem209 = 0L;
+			Long elem227 = struct.id;
+			if (elem227 == null) {
+				elem227 = 0L;
 			}
-			oprot.writeI64(elem209);
+			oprot.writeI64(elem227);
 			oprot.writeFieldEnd();
 			if (struct.req != null) {
 				oprot.writeFieldBegin(REQ_FIELD_DESC);
 				oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, struct.req.size()));
-				for (Map.Entry<Integer, String> elem210 : struct.req.entrySet()) {
-					Integer elem211 = elem210.getKey();
-					if (elem211 == null) {
-						elem211 = 0;
+				for (Map.Entry<Integer, String> elem228 : struct.req.entrySet()) {
+					Integer elem229 = elem228.getKey();
+					if (elem229 == null) {
+						elem229 = 0;
 					}
-					oprot.writeI32(elem211);
-					String elem212 = elem210.getValue();
-					oprot.writeString(elem212);
+					oprot.writeI32(elem229);
+					String elem230 = elem228.getValue();
+					oprot.writeString(elem230);
 				}
 				oprot.writeMapEnd();
 				oprot.writeFieldEnd();
@@ -3061,22 +3061,22 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetId()) {
-				Long elem213 = struct.id;
-				if (elem213 == null) {
-					elem213 = 0L;
+				Long elem231 = struct.id;
+				if (elem231 == null) {
+					elem231 = 0L;
 				}
-				oprot.writeI64(elem213);
+				oprot.writeI64(elem231);
 			}
 			if (struct.isSetReq()) {
 				oprot.writeI32(struct.req.size());
-				for (Map.Entry<Integer, String> elem214 : struct.req.entrySet()) {
-					Integer elem215 = elem214.getKey();
-					if (elem215 == null) {
-						elem215 = 0;
+				for (Map.Entry<Integer, String> elem232 : struct.req.entrySet()) {
+					Integer elem233 = elem232.getKey();
+					if (elem233 == null) {
+						elem233 = 0;
 					}
-					oprot.writeI32(elem215);
-					String elem216 = elem214.getValue();
-					oprot.writeString(elem216);
+					oprot.writeI32(elem233);
+					String elem234 = elem232.getValue();
+					oprot.writeString(elem234);
 				}
 			}
 		}
@@ -3090,12 +3090,12 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 				struct.setIdIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TMap elem217 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-				struct.req = new HashMap<Integer,String>(2*elem217.size);
-				for (int elem218 = 0; elem218 < elem217.size; ++elem218) {
-					Integer elem220 = iprot.readI32();
-					String elem219 = iprot.readString();
-					struct.req.put(elem220, elem219);
+				org.apache.thrift.protocol.TMap elem235 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+				struct.req = new HashMap<Integer,String>(2*elem235.size);
+				for (int elem236 = 0; elem236 < elem235.size; ++elem236) {
+					Integer elem238 = iprot.readI32();
+					String elem237 = iprot.readString();
+					struct.req.put(elem238, elem237);
 				}
 				struct.setReqIsSet(true);
 			}
@@ -3512,14 +3512,14 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.bin != null) {
 				oprot.writeFieldBegin(BIN_FIELD_DESC);
-				java.nio.ByteBuffer elem221 = struct.bin;
-				oprot.writeBinary(elem221);
+				java.nio.ByteBuffer elem239 = struct.bin;
+				oprot.writeBinary(elem239);
 				oprot.writeFieldEnd();
 			}
 			if (struct.Str != null) {
 				oprot.writeFieldBegin(STR_FIELD_DESC);
-				String elem222 = struct.Str;
-				oprot.writeString(elem222);
+				String elem240 = struct.Str;
+				oprot.writeString(elem240);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -3548,12 +3548,12 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetBin()) {
-				java.nio.ByteBuffer elem223 = struct.bin;
-				oprot.writeBinary(elem223);
+				java.nio.ByteBuffer elem241 = struct.bin;
+				oprot.writeBinary(elem241);
 			}
 			if (struct.isSetStr()) {
-				String elem224 = struct.Str;
-				oprot.writeString(elem224);
+				String elem242 = struct.Str;
+				oprot.writeString(elem242);
 			}
 		}
 
@@ -3986,8 +3986,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.success != null) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				java.nio.ByteBuffer elem225 = struct.success;
-				oprot.writeBinary(elem225);
+				java.nio.ByteBuffer elem243 = struct.success;
+				oprot.writeBinary(elem243);
 				oprot.writeFieldEnd();
 			}
 			if (struct.api != null) {
@@ -4021,8 +4021,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetSuccess()) {
-				java.nio.ByteBuffer elem226 = struct.success;
-				oprot.writeBinary(elem226);
+				java.nio.ByteBuffer elem244 = struct.success;
+				oprot.writeBinary(elem244);
 			}
 			if (struct.isSetApi()) {
 				struct.api.write(oprot);
@@ -4536,25 +4536,25 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(OPT_NUM_FIELD_DESC);
-			Integer elem227 = struct.opt_num;
-			if (elem227 == null) {
-				elem227 = 0;
+			Integer elem245 = struct.opt_num;
+			if (elem245 == null) {
+				elem245 = 0;
 			}
-			oprot.writeI32(elem227);
+			oprot.writeI32(elem245);
 			oprot.writeFieldEnd();
 			oprot.writeFieldBegin(DEFAULT_NUM_FIELD_DESC);
-			Integer elem228 = struct.default_num;
-			if (elem228 == null) {
-				elem228 = 0;
+			Integer elem246 = struct.default_num;
+			if (elem246 == null) {
+				elem246 = 0;
 			}
-			oprot.writeI32(elem228);
+			oprot.writeI32(elem246);
 			oprot.writeFieldEnd();
 			oprot.writeFieldBegin(REQ_NUM_FIELD_DESC);
-			Integer elem229 = struct.req_num;
-			if (elem229 == null) {
-				elem229 = 0;
+			Integer elem247 = struct.req_num;
+			if (elem247 == null) {
+				elem247 = 0;
 			}
-			oprot.writeI32(elem229);
+			oprot.writeI32(elem247);
 			oprot.writeFieldEnd();
 			oprot.writeFieldStop();
 			oprot.writeStructEnd();
@@ -4573,11 +4573,11 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 		@Override
 		public void write(org.apache.thrift.protocol.TProtocol prot, param_modifiers_args struct) throws org.apache.thrift.TException {
 			TTupleProtocol oprot = (TTupleProtocol) prot;
-			Integer elem230 = struct.req_num;
-			if (elem230 == null) {
-				elem230 = 0;
+			Integer elem248 = struct.req_num;
+			if (elem248 == null) {
+				elem248 = 0;
 			}
-			oprot.writeI32(elem230);
+			oprot.writeI32(elem248);
 			BitSet optionals = new BitSet();
 			if (struct.isSetOpt_num()) {
 				optionals.set(0);
@@ -4587,18 +4587,18 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetOpt_num()) {
-				Integer elem231 = struct.opt_num;
-				if (elem231 == null) {
-					elem231 = 0;
+				Integer elem249 = struct.opt_num;
+				if (elem249 == null) {
+					elem249 = 0;
 				}
-				oprot.writeI32(elem231);
+				oprot.writeI32(elem249);
 			}
 			if (struct.isSetDefault_num()) {
-				Integer elem232 = struct.default_num;
-				if (elem232 == null) {
-					elem232 = 0;
+				Integer elem250 = struct.default_num;
+				if (elem250 == null) {
+					elem250 = 0;
 				}
-				oprot.writeI32(elem232);
+				oprot.writeI32(elem250);
 			}
 		}
 
@@ -4930,11 +4930,11 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				Long elem233 = struct.success;
-				if (elem233 == null) {
-					elem233 = 0L;
+				Long elem251 = struct.success;
+				if (elem251 == null) {
+					elem251 = 0L;
 				}
-				oprot.writeI64(elem233);
+				oprot.writeI64(elem251);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -4960,11 +4960,11 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 			}
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
-				Long elem234 = struct.success;
-				if (elem234 == null) {
-					elem234 = 0L;
+				Long elem252 = struct.success;
+				if (elem252 == null) {
+					elem252 = 0L;
 				}
-				oprot.writeI64(elem234);
+				oprot.writeI64(elem252);
 			}
 		}
 
@@ -5075,16 +5075,16 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 	public underlying_types_test_args(underlying_types_test_args other) {
 		if (other.isSetList_type()) {
 			this.list_type = new ArrayList<Long>(other.list_type.size());
-			for (Long elem235 : other.list_type) {
-				Long elem236 = elem235;
-				this.list_type.add(elem236);
+			for (Long elem253 : other.list_type) {
+				Long elem254 = elem253;
+				this.list_type.add(elem254);
 			}
 		}
 		if (other.isSetSet_type()) {
 			this.set_type = new HashSet<Long>(other.set_type.size());
-			for (Long elem237 : other.set_type) {
-				Long elem238 = elem237;
-				this.set_type.add(elem238);
+			for (Long elem255 : other.set_type) {
+				Long elem256 = elem255;
+				this.set_type.add(elem256);
 			}
 		}
 	}
@@ -5386,11 +5386,11 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 				switch (schemeField.id) {
 					case 1: // LIST_TYPE
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem239 = iprot.readListBegin();
-							struct.list_type = new ArrayList<Long>(elem239.size);
-							for (int elem240 = 0; elem240 < elem239.size; ++elem240) {
-								Long elem241 = iprot.readI64();
-								struct.list_type.add(elem241);
+							org.apache.thrift.protocol.TList elem257 = iprot.readListBegin();
+							struct.list_type = new ArrayList<Long>(elem257.size);
+							for (int elem258 = 0; elem258 < elem257.size; ++elem258) {
+								Long elem259 = iprot.readI64();
+								struct.list_type.add(elem259);
 							}
 							iprot.readListEnd();
 							struct.setList_typeIsSet(true);
@@ -5400,11 +5400,11 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 						break;
 					case 2: // SET_TYPE
 						if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
-							org.apache.thrift.protocol.TSet elem242 = iprot.readSetBegin();
-							struct.set_type = new HashSet<Long>(2*elem242.size);
-							for (int elem243 = 0; elem243 < elem242.size; ++elem243) {
-								Long elem244 = iprot.readI64();
-								struct.set_type.add(elem244);
+							org.apache.thrift.protocol.TSet elem260 = iprot.readSetBegin();
+							struct.set_type = new HashSet<Long>(2*elem260.size);
+							for (int elem261 = 0; elem261 < elem260.size; ++elem261) {
+								Long elem262 = iprot.readI64();
+								struct.set_type.add(elem262);
 							}
 							iprot.readSetEnd();
 							struct.setSet_typeIsSet(true);
@@ -5430,12 +5430,12 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			if (struct.list_type != null) {
 				oprot.writeFieldBegin(LIST_TYPE_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.list_type.size()));
-				for (Long elem245 : struct.list_type) {
-					Long elem246 = elem245;
-					if (elem246 == null) {
-						elem246 = 0L;
+				for (Long elem263 : struct.list_type) {
+					Long elem264 = elem263;
+					if (elem264 == null) {
+						elem264 = 0L;
 					}
-					oprot.writeI64(elem246);
+					oprot.writeI64(elem264);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -5443,12 +5443,12 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			if (struct.set_type != null) {
 				oprot.writeFieldBegin(SET_TYPE_FIELD_DESC);
 				oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, struct.set_type.size()));
-				for (Long elem247 : struct.set_type) {
-					Long elem248 = elem247;
-					if (elem248 == null) {
-						elem248 = 0L;
+				for (Long elem265 : struct.set_type) {
+					Long elem266 = elem265;
+					if (elem266 == null) {
+						elem266 = 0L;
 					}
-					oprot.writeI64(elem248);
+					oprot.writeI64(elem266);
 				}
 				oprot.writeSetEnd();
 				oprot.writeFieldEnd();
@@ -5480,22 +5480,22 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetList_type()) {
 				oprot.writeI32(struct.list_type.size());
-				for (Long elem249 : struct.list_type) {
-					Long elem250 = elem249;
-					if (elem250 == null) {
-						elem250 = 0L;
+				for (Long elem267 : struct.list_type) {
+					Long elem268 = elem267;
+					if (elem268 == null) {
+						elem268 = 0L;
 					}
-					oprot.writeI64(elem250);
+					oprot.writeI64(elem268);
 				}
 			}
 			if (struct.isSetSet_type()) {
 				oprot.writeI32(struct.set_type.size());
-				for (Long elem251 : struct.set_type) {
-					Long elem252 = elem251;
-					if (elem252 == null) {
-						elem252 = 0L;
+				for (Long elem269 : struct.set_type) {
+					Long elem270 = elem269;
+					if (elem270 == null) {
+						elem270 = 0L;
 					}
-					oprot.writeI64(elem252);
+					oprot.writeI64(elem270);
 				}
 			}
 		}
@@ -5505,20 +5505,20 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(2);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem253 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.list_type = new ArrayList<Long>(elem253.size);
-				for (int elem254 = 0; elem254 < elem253.size; ++elem254) {
-					Long elem255 = iprot.readI64();
-					struct.list_type.add(elem255);
+				org.apache.thrift.protocol.TList elem271 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.list_type = new ArrayList<Long>(elem271.size);
+				for (int elem272 = 0; elem272 < elem271.size; ++elem272) {
+					Long elem273 = iprot.readI64();
+					struct.list_type.add(elem273);
 				}
 				struct.setList_typeIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TSet elem256 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.set_type = new HashSet<Long>(2*elem256.size);
-				for (int elem257 = 0; elem257 < elem256.size; ++elem257) {
-					Long elem258 = iprot.readI64();
-					struct.set_type.add(elem258);
+				org.apache.thrift.protocol.TSet elem274 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.set_type = new HashSet<Long>(2*elem274.size);
+				for (int elem275 = 0; elem275 < elem274.size; ++elem275) {
+					Long elem276 = iprot.readI64();
+					struct.set_type.add(elem276);
 				}
 				struct.setSet_typeIsSet(true);
 			}
@@ -5614,9 +5614,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 	public underlying_types_test_result(underlying_types_test_result other) {
 		if (other.isSetSuccess()) {
 			this.success = new ArrayList<Long>(other.success.size());
-			for (Long elem259 : other.success) {
-				Long elem260 = elem259;
-				this.success.add(elem260);
+			for (Long elem277 : other.success) {
+				Long elem278 = elem277;
+				this.success.add(elem278);
 			}
 		}
 	}
@@ -5832,11 +5832,11 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 				switch (schemeField.id) {
 					case 0: // SUCCESS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem261 = iprot.readListBegin();
-							struct.success = new ArrayList<Long>(elem261.size);
-							for (int elem262 = 0; elem262 < elem261.size; ++elem262) {
-								Long elem263 = iprot.readI64();
-								struct.success.add(elem263);
+							org.apache.thrift.protocol.TList elem279 = iprot.readListBegin();
+							struct.success = new ArrayList<Long>(elem279.size);
+							for (int elem280 = 0; elem280 < elem279.size; ++elem280) {
+								Long elem281 = iprot.readI64();
+								struct.success.add(elem281);
 							}
 							iprot.readListEnd();
 							struct.setSuccessIsSet(true);
@@ -5862,12 +5862,12 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			if (struct.success != null) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.success.size()));
-				for (Long elem264 : struct.success) {
-					Long elem265 = elem264;
-					if (elem265 == null) {
-						elem265 = 0L;
+				for (Long elem282 : struct.success) {
+					Long elem283 = elem282;
+					if (elem283 == null) {
+						elem283 = 0L;
 					}
-					oprot.writeI64(elem265);
+					oprot.writeI64(elem283);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -5896,12 +5896,12 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
 				oprot.writeI32(struct.success.size());
-				for (Long elem266 : struct.success) {
-					Long elem267 = elem266;
-					if (elem267 == null) {
-						elem267 = 0L;
+				for (Long elem284 : struct.success) {
+					Long elem285 = elem284;
+					if (elem285 == null) {
+						elem285 = 0L;
 					}
-					oprot.writeI64(elem267);
+					oprot.writeI64(elem285);
 				}
 			}
 		}
@@ -5911,11 +5911,11 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(1);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem268 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.success = new ArrayList<Long>(elem268.size);
-				for (int elem269 = 0; elem269 < elem268.size; ++elem269) {
-					Long elem270 = iprot.readI64();
-					struct.success.add(elem270);
+				org.apache.thrift.protocol.TList elem286 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.success = new ArrayList<Long>(elem286.size);
+				for (int elem287 = 0; elem287 < elem286.size; ++elem287) {
+					Long elem288 = iprot.readI64();
+					struct.success.add(elem288);
 				}
 				struct.setSuccessIsSet(true);
 			}
@@ -7074,11 +7074,11 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				Integer elem271 = struct.success;
-				if (elem271 == null) {
-					elem271 = 0;
+				Integer elem289 = struct.success;
+				if (elem289 == null) {
+					elem289 = 0;
 				}
-				oprot.writeI32(elem271);
+				oprot.writeI32(elem289);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -7104,11 +7104,11 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 			}
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
-				Integer elem272 = struct.success;
-				if (elem272 == null) {
-					elem272 = 0;
+				Integer elem290 = struct.success;
+				if (elem290 == null) {
+					elem290 = 0;
 				}
-				oprot.writeI32(elem272);
+				oprot.writeI32(elem290);
 			}
 		}
 

--- a/test/expected/java/boxed_primitives/FFoo.java
+++ b/test/expected/java/boxed_primitives/FFoo.java
@@ -1933,16 +1933,16 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(NUM_FIELD_DESC);
-			Integer elem214 = struct.num;
-			if (elem214 == null) {
-				elem214 = 0;
+			Integer elem216 = struct.num;
+			if (elem216 == null) {
+				elem216 = 0;
 			}
-			oprot.writeI32(elem214);
+			oprot.writeI32(elem216);
 			oprot.writeFieldEnd();
 			if (struct.Str != null) {
 				oprot.writeFieldBegin(STR_FIELD_DESC);
-				String elem215 = struct.Str;
-				oprot.writeString(elem215);
+				String elem217 = struct.Str;
+				oprot.writeString(elem217);
 				oprot.writeFieldEnd();
 			}
 			if (struct.event != null) {
@@ -1979,15 +1979,15 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetNum()) {
-				Integer elem216 = struct.num;
-				if (elem216 == null) {
-					elem216 = 0;
+				Integer elem218 = struct.num;
+				if (elem218 == null) {
+					elem218 = 0;
 				}
-				oprot.writeI32(elem216);
+				oprot.writeI32(elem218);
 			}
 			if (struct.isSetStr()) {
-				String elem217 = struct.Str;
-				oprot.writeString(elem217);
+				String elem219 = struct.Str;
+				oprot.writeString(elem219);
 			}
 			if (struct.isSetEvent()) {
 				struct.event.write(oprot);
@@ -2511,11 +2511,11 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				Long elem218 = struct.success;
-				if (elem218 == null) {
-					elem218 = 0L;
+				Long elem220 = struct.success;
+				if (elem220 == null) {
+					elem220 = 0L;
 				}
-				oprot.writeI64(elem218);
+				oprot.writeI64(elem220);
 				oprot.writeFieldEnd();
 			}
 			if (struct.awe != null) {
@@ -2557,11 +2557,11 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetSuccess()) {
-				Long elem219 = struct.success;
-				if (elem219 == null) {
-					elem219 = 0L;
+				Long elem221 = struct.success;
+				if (elem221 == null) {
+					elem221 = 0L;
 				}
-				oprot.writeI64(elem219);
+				oprot.writeI64(elem221);
 			}
 			if (struct.isSetAwe()) {
 				struct.awe.write(oprot);
@@ -2691,10 +2691,10 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 		}
 		if (other.isSetReq()) {
 			this.req = new HashMap<Integer,String>(other.req.size());
-			for (Map.Entry<Integer, String> elem220 : other.req.entrySet()) {
-				Integer elem222 = elem220.getKey();
-				String elem221 = elem220.getValue();
-				this.req.put(elem222, elem221);
+			for (Map.Entry<Integer, String> elem222 : other.req.entrySet()) {
+				Integer elem224 = elem222.getKey();
+				String elem223 = elem222.getValue();
+				this.req.put(elem224, elem223);
 			}
 		}
 	}
@@ -2985,12 +2985,12 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 						break;
 					case 2: // REQ
 						if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
-							org.apache.thrift.protocol.TMap elem223 = iprot.readMapBegin();
-							struct.req = new HashMap<Integer,String>(2*elem223.size);
-							for (int elem224 = 0; elem224 < elem223.size; ++elem224) {
-								Integer elem226 = iprot.readI32();
-								String elem225 = iprot.readString();
-								struct.req.put(elem226, elem225);
+							org.apache.thrift.protocol.TMap elem225 = iprot.readMapBegin();
+							struct.req = new HashMap<Integer,String>(2*elem225.size);
+							for (int elem226 = 0; elem226 < elem225.size; ++elem226) {
+								Integer elem228 = iprot.readI32();
+								String elem227 = iprot.readString();
+								struct.req.put(elem228, elem227);
 							}
 							iprot.readMapEnd();
 							struct.setReqIsSet(true);
@@ -3014,23 +3014,23 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(ID_FIELD_DESC);
-			Long elem227 = struct.id;
-			if (elem227 == null) {
-				elem227 = 0L;
+			Long elem229 = struct.id;
+			if (elem229 == null) {
+				elem229 = 0L;
 			}
-			oprot.writeI64(elem227);
+			oprot.writeI64(elem229);
 			oprot.writeFieldEnd();
 			if (struct.req != null) {
 				oprot.writeFieldBegin(REQ_FIELD_DESC);
 				oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, struct.req.size()));
-				for (Map.Entry<Integer, String> elem228 : struct.req.entrySet()) {
-					Integer elem229 = elem228.getKey();
-					if (elem229 == null) {
-						elem229 = 0;
+				for (Map.Entry<Integer, String> elem230 : struct.req.entrySet()) {
+					Integer elem231 = elem230.getKey();
+					if (elem231 == null) {
+						elem231 = 0;
 					}
-					oprot.writeI32(elem229);
-					String elem230 = elem228.getValue();
-					oprot.writeString(elem230);
+					oprot.writeI32(elem231);
+					String elem232 = elem230.getValue();
+					oprot.writeString(elem232);
 				}
 				oprot.writeMapEnd();
 				oprot.writeFieldEnd();
@@ -3061,22 +3061,22 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetId()) {
-				Long elem231 = struct.id;
-				if (elem231 == null) {
-					elem231 = 0L;
+				Long elem233 = struct.id;
+				if (elem233 == null) {
+					elem233 = 0L;
 				}
-				oprot.writeI64(elem231);
+				oprot.writeI64(elem233);
 			}
 			if (struct.isSetReq()) {
 				oprot.writeI32(struct.req.size());
-				for (Map.Entry<Integer, String> elem232 : struct.req.entrySet()) {
-					Integer elem233 = elem232.getKey();
-					if (elem233 == null) {
-						elem233 = 0;
+				for (Map.Entry<Integer, String> elem234 : struct.req.entrySet()) {
+					Integer elem235 = elem234.getKey();
+					if (elem235 == null) {
+						elem235 = 0;
 					}
-					oprot.writeI32(elem233);
-					String elem234 = elem232.getValue();
-					oprot.writeString(elem234);
+					oprot.writeI32(elem235);
+					String elem236 = elem234.getValue();
+					oprot.writeString(elem236);
 				}
 			}
 		}
@@ -3090,12 +3090,12 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 				struct.setIdIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TMap elem235 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-				struct.req = new HashMap<Integer,String>(2*elem235.size);
-				for (int elem236 = 0; elem236 < elem235.size; ++elem236) {
-					Integer elem238 = iprot.readI32();
-					String elem237 = iprot.readString();
-					struct.req.put(elem238, elem237);
+				org.apache.thrift.protocol.TMap elem237 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+				struct.req = new HashMap<Integer,String>(2*elem237.size);
+				for (int elem238 = 0; elem238 < elem237.size; ++elem238) {
+					Integer elem240 = iprot.readI32();
+					String elem239 = iprot.readString();
+					struct.req.put(elem240, elem239);
 				}
 				struct.setReqIsSet(true);
 			}
@@ -3512,14 +3512,14 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.bin != null) {
 				oprot.writeFieldBegin(BIN_FIELD_DESC);
-				java.nio.ByteBuffer elem239 = struct.bin;
-				oprot.writeBinary(elem239);
+				java.nio.ByteBuffer elem241 = struct.bin;
+				oprot.writeBinary(elem241);
 				oprot.writeFieldEnd();
 			}
 			if (struct.Str != null) {
 				oprot.writeFieldBegin(STR_FIELD_DESC);
-				String elem240 = struct.Str;
-				oprot.writeString(elem240);
+				String elem242 = struct.Str;
+				oprot.writeString(elem242);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -3548,12 +3548,12 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetBin()) {
-				java.nio.ByteBuffer elem241 = struct.bin;
-				oprot.writeBinary(elem241);
+				java.nio.ByteBuffer elem243 = struct.bin;
+				oprot.writeBinary(elem243);
 			}
 			if (struct.isSetStr()) {
-				String elem242 = struct.Str;
-				oprot.writeString(elem242);
+				String elem244 = struct.Str;
+				oprot.writeString(elem244);
 			}
 		}
 
@@ -3986,8 +3986,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.success != null) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				java.nio.ByteBuffer elem243 = struct.success;
-				oprot.writeBinary(elem243);
+				java.nio.ByteBuffer elem245 = struct.success;
+				oprot.writeBinary(elem245);
 				oprot.writeFieldEnd();
 			}
 			if (struct.api != null) {
@@ -4021,8 +4021,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetSuccess()) {
-				java.nio.ByteBuffer elem244 = struct.success;
-				oprot.writeBinary(elem244);
+				java.nio.ByteBuffer elem246 = struct.success;
+				oprot.writeBinary(elem246);
 			}
 			if (struct.isSetApi()) {
 				struct.api.write(oprot);
@@ -4536,25 +4536,25 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(OPT_NUM_FIELD_DESC);
-			Integer elem245 = struct.opt_num;
-			if (elem245 == null) {
-				elem245 = 0;
-			}
-			oprot.writeI32(elem245);
-			oprot.writeFieldEnd();
-			oprot.writeFieldBegin(DEFAULT_NUM_FIELD_DESC);
-			Integer elem246 = struct.default_num;
-			if (elem246 == null) {
-				elem246 = 0;
-			}
-			oprot.writeI32(elem246);
-			oprot.writeFieldEnd();
-			oprot.writeFieldBegin(REQ_NUM_FIELD_DESC);
-			Integer elem247 = struct.req_num;
+			Integer elem247 = struct.opt_num;
 			if (elem247 == null) {
 				elem247 = 0;
 			}
 			oprot.writeI32(elem247);
+			oprot.writeFieldEnd();
+			oprot.writeFieldBegin(DEFAULT_NUM_FIELD_DESC);
+			Integer elem248 = struct.default_num;
+			if (elem248 == null) {
+				elem248 = 0;
+			}
+			oprot.writeI32(elem248);
+			oprot.writeFieldEnd();
+			oprot.writeFieldBegin(REQ_NUM_FIELD_DESC);
+			Integer elem249 = struct.req_num;
+			if (elem249 == null) {
+				elem249 = 0;
+			}
+			oprot.writeI32(elem249);
 			oprot.writeFieldEnd();
 			oprot.writeFieldStop();
 			oprot.writeStructEnd();
@@ -4573,11 +4573,11 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 		@Override
 		public void write(org.apache.thrift.protocol.TProtocol prot, param_modifiers_args struct) throws org.apache.thrift.TException {
 			TTupleProtocol oprot = (TTupleProtocol) prot;
-			Integer elem248 = struct.req_num;
-			if (elem248 == null) {
-				elem248 = 0;
+			Integer elem250 = struct.req_num;
+			if (elem250 == null) {
+				elem250 = 0;
 			}
-			oprot.writeI32(elem248);
+			oprot.writeI32(elem250);
 			BitSet optionals = new BitSet();
 			if (struct.isSetOpt_num()) {
 				optionals.set(0);
@@ -4587,18 +4587,18 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetOpt_num()) {
-				Integer elem249 = struct.opt_num;
-				if (elem249 == null) {
-					elem249 = 0;
+				Integer elem251 = struct.opt_num;
+				if (elem251 == null) {
+					elem251 = 0;
 				}
-				oprot.writeI32(elem249);
+				oprot.writeI32(elem251);
 			}
 			if (struct.isSetDefault_num()) {
-				Integer elem250 = struct.default_num;
-				if (elem250 == null) {
-					elem250 = 0;
+				Integer elem252 = struct.default_num;
+				if (elem252 == null) {
+					elem252 = 0;
 				}
-				oprot.writeI32(elem250);
+				oprot.writeI32(elem252);
 			}
 		}
 
@@ -4930,11 +4930,11 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				Long elem251 = struct.success;
-				if (elem251 == null) {
-					elem251 = 0L;
+				Long elem253 = struct.success;
+				if (elem253 == null) {
+					elem253 = 0L;
 				}
-				oprot.writeI64(elem251);
+				oprot.writeI64(elem253);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -4960,11 +4960,11 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 			}
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
-				Long elem252 = struct.success;
-				if (elem252 == null) {
-					elem252 = 0L;
+				Long elem254 = struct.success;
+				if (elem254 == null) {
+					elem254 = 0L;
 				}
-				oprot.writeI64(elem252);
+				oprot.writeI64(elem254);
 			}
 		}
 
@@ -5075,16 +5075,16 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 	public underlying_types_test_args(underlying_types_test_args other) {
 		if (other.isSetList_type()) {
 			this.list_type = new ArrayList<Long>(other.list_type.size());
-			for (Long elem253 : other.list_type) {
-				Long elem254 = elem253;
-				this.list_type.add(elem254);
+			for (Long elem255 : other.list_type) {
+				Long elem256 = elem255;
+				this.list_type.add(elem256);
 			}
 		}
 		if (other.isSetSet_type()) {
 			this.set_type = new HashSet<Long>(other.set_type.size());
-			for (Long elem255 : other.set_type) {
-				Long elem256 = elem255;
-				this.set_type.add(elem256);
+			for (Long elem257 : other.set_type) {
+				Long elem258 = elem257;
+				this.set_type.add(elem258);
 			}
 		}
 	}
@@ -5386,11 +5386,11 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 				switch (schemeField.id) {
 					case 1: // LIST_TYPE
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem257 = iprot.readListBegin();
-							struct.list_type = new ArrayList<Long>(elem257.size);
-							for (int elem258 = 0; elem258 < elem257.size; ++elem258) {
-								Long elem259 = iprot.readI64();
-								struct.list_type.add(elem259);
+							org.apache.thrift.protocol.TList elem259 = iprot.readListBegin();
+							struct.list_type = new ArrayList<Long>(elem259.size);
+							for (int elem260 = 0; elem260 < elem259.size; ++elem260) {
+								Long elem261 = iprot.readI64();
+								struct.list_type.add(elem261);
 							}
 							iprot.readListEnd();
 							struct.setList_typeIsSet(true);
@@ -5400,11 +5400,11 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 						break;
 					case 2: // SET_TYPE
 						if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
-							org.apache.thrift.protocol.TSet elem260 = iprot.readSetBegin();
-							struct.set_type = new HashSet<Long>(2*elem260.size);
-							for (int elem261 = 0; elem261 < elem260.size; ++elem261) {
-								Long elem262 = iprot.readI64();
-								struct.set_type.add(elem262);
+							org.apache.thrift.protocol.TSet elem262 = iprot.readSetBegin();
+							struct.set_type = new HashSet<Long>(2*elem262.size);
+							for (int elem263 = 0; elem263 < elem262.size; ++elem263) {
+								Long elem264 = iprot.readI64();
+								struct.set_type.add(elem264);
 							}
 							iprot.readSetEnd();
 							struct.setSet_typeIsSet(true);
@@ -5430,12 +5430,12 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			if (struct.list_type != null) {
 				oprot.writeFieldBegin(LIST_TYPE_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.list_type.size()));
-				for (Long elem263 : struct.list_type) {
-					Long elem264 = elem263;
-					if (elem264 == null) {
-						elem264 = 0L;
+				for (Long elem265 : struct.list_type) {
+					Long elem266 = elem265;
+					if (elem266 == null) {
+						elem266 = 0L;
 					}
-					oprot.writeI64(elem264);
+					oprot.writeI64(elem266);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -5443,12 +5443,12 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			if (struct.set_type != null) {
 				oprot.writeFieldBegin(SET_TYPE_FIELD_DESC);
 				oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, struct.set_type.size()));
-				for (Long elem265 : struct.set_type) {
-					Long elem266 = elem265;
-					if (elem266 == null) {
-						elem266 = 0L;
+				for (Long elem267 : struct.set_type) {
+					Long elem268 = elem267;
+					if (elem268 == null) {
+						elem268 = 0L;
 					}
-					oprot.writeI64(elem266);
+					oprot.writeI64(elem268);
 				}
 				oprot.writeSetEnd();
 				oprot.writeFieldEnd();
@@ -5480,22 +5480,22 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetList_type()) {
 				oprot.writeI32(struct.list_type.size());
-				for (Long elem267 : struct.list_type) {
-					Long elem268 = elem267;
-					if (elem268 == null) {
-						elem268 = 0L;
-					}
-					oprot.writeI64(elem268);
-				}
-			}
-			if (struct.isSetSet_type()) {
-				oprot.writeI32(struct.set_type.size());
-				for (Long elem269 : struct.set_type) {
+				for (Long elem269 : struct.list_type) {
 					Long elem270 = elem269;
 					if (elem270 == null) {
 						elem270 = 0L;
 					}
 					oprot.writeI64(elem270);
+				}
+			}
+			if (struct.isSetSet_type()) {
+				oprot.writeI32(struct.set_type.size());
+				for (Long elem271 : struct.set_type) {
+					Long elem272 = elem271;
+					if (elem272 == null) {
+						elem272 = 0L;
+					}
+					oprot.writeI64(elem272);
 				}
 			}
 		}
@@ -5505,20 +5505,20 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(2);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem271 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.list_type = new ArrayList<Long>(elem271.size);
-				for (int elem272 = 0; elem272 < elem271.size; ++elem272) {
-					Long elem273 = iprot.readI64();
-					struct.list_type.add(elem273);
+				org.apache.thrift.protocol.TList elem273 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.list_type = new ArrayList<Long>(elem273.size);
+				for (int elem274 = 0; elem274 < elem273.size; ++elem274) {
+					Long elem275 = iprot.readI64();
+					struct.list_type.add(elem275);
 				}
 				struct.setList_typeIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TSet elem274 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.set_type = new HashSet<Long>(2*elem274.size);
-				for (int elem275 = 0; elem275 < elem274.size; ++elem275) {
-					Long elem276 = iprot.readI64();
-					struct.set_type.add(elem276);
+				org.apache.thrift.protocol.TSet elem276 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.set_type = new HashSet<Long>(2*elem276.size);
+				for (int elem277 = 0; elem277 < elem276.size; ++elem277) {
+					Long elem278 = iprot.readI64();
+					struct.set_type.add(elem278);
 				}
 				struct.setSet_typeIsSet(true);
 			}
@@ -5614,9 +5614,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 	public underlying_types_test_result(underlying_types_test_result other) {
 		if (other.isSetSuccess()) {
 			this.success = new ArrayList<Long>(other.success.size());
-			for (Long elem277 : other.success) {
-				Long elem278 = elem277;
-				this.success.add(elem278);
+			for (Long elem279 : other.success) {
+				Long elem280 = elem279;
+				this.success.add(elem280);
 			}
 		}
 	}
@@ -5832,11 +5832,11 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 				switch (schemeField.id) {
 					case 0: // SUCCESS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem279 = iprot.readListBegin();
-							struct.success = new ArrayList<Long>(elem279.size);
-							for (int elem280 = 0; elem280 < elem279.size; ++elem280) {
-								Long elem281 = iprot.readI64();
-								struct.success.add(elem281);
+							org.apache.thrift.protocol.TList elem281 = iprot.readListBegin();
+							struct.success = new ArrayList<Long>(elem281.size);
+							for (int elem282 = 0; elem282 < elem281.size; ++elem282) {
+								Long elem283 = iprot.readI64();
+								struct.success.add(elem283);
 							}
 							iprot.readListEnd();
 							struct.setSuccessIsSet(true);
@@ -5862,12 +5862,12 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			if (struct.success != null) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.success.size()));
-				for (Long elem282 : struct.success) {
-					Long elem283 = elem282;
-					if (elem283 == null) {
-						elem283 = 0L;
+				for (Long elem284 : struct.success) {
+					Long elem285 = elem284;
+					if (elem285 == null) {
+						elem285 = 0L;
 					}
-					oprot.writeI64(elem283);
+					oprot.writeI64(elem285);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -5896,12 +5896,12 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
 				oprot.writeI32(struct.success.size());
-				for (Long elem284 : struct.success) {
-					Long elem285 = elem284;
-					if (elem285 == null) {
-						elem285 = 0L;
+				for (Long elem286 : struct.success) {
+					Long elem287 = elem286;
+					if (elem287 == null) {
+						elem287 = 0L;
 					}
-					oprot.writeI64(elem285);
+					oprot.writeI64(elem287);
 				}
 			}
 		}
@@ -5911,11 +5911,11 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(1);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem286 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.success = new ArrayList<Long>(elem286.size);
-				for (int elem287 = 0; elem287 < elem286.size; ++elem287) {
-					Long elem288 = iprot.readI64();
-					struct.success.add(elem288);
+				org.apache.thrift.protocol.TList elem288 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.success = new ArrayList<Long>(elem288.size);
+				for (int elem289 = 0; elem289 < elem288.size; ++elem289) {
+					Long elem290 = iprot.readI64();
+					struct.success.add(elem290);
 				}
 				struct.setSuccessIsSet(true);
 			}
@@ -7074,11 +7074,11 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				Integer elem289 = struct.success;
-				if (elem289 == null) {
-					elem289 = 0;
+				Integer elem291 = struct.success;
+				if (elem291 == null) {
+					elem291 = 0;
 				}
-				oprot.writeI32(elem289);
+				oprot.writeI32(elem291);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -7104,11 +7104,11 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 			}
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
-				Integer elem290 = struct.success;
-				if (elem290 == null) {
-					elem290 = 0;
+				Integer elem292 = struct.success;
+				if (elem292 == null) {
+					elem292 = 0;
 				}
-				oprot.writeI32(elem290);
+				oprot.writeI32(elem292);
 			}
 		}
 

--- a/test/expected/java/variety/AwesomeException.java
+++ b/test/expected/java/variety/AwesomeException.java
@@ -454,13 +454,13 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(ID_FIELD_DESC);
-			long elem192 = struct.ID;
-			oprot.writeI64(elem192);
+			long elem210 = struct.ID;
+			oprot.writeI64(elem210);
 			oprot.writeFieldEnd();
 			if (struct.Reason != null) {
 				oprot.writeFieldBegin(REASON_FIELD_DESC);
-				String elem193 = struct.Reason;
-				oprot.writeString(elem193);
+				String elem211 = struct.Reason;
+				oprot.writeString(elem211);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -489,12 +489,12 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetID()) {
-				long elem194 = struct.ID;
-				oprot.writeI64(elem194);
+				long elem212 = struct.ID;
+				oprot.writeI64(elem212);
 			}
 			if (struct.isSetReason()) {
-				String elem195 = struct.Reason;
-				oprot.writeString(elem195);
+				String elem213 = struct.Reason;
+				oprot.writeString(elem213);
 			}
 		}
 

--- a/test/expected/java/variety/AwesomeException.java
+++ b/test/expected/java/variety/AwesomeException.java
@@ -39,6 +39,7 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 
 	private static final org.apache.thrift.protocol.TField ID_FIELD_DESC = new org.apache.thrift.protocol.TField("ID", org.apache.thrift.protocol.TType.I64, (short)1);
 	private static final org.apache.thrift.protocol.TField REASON_FIELD_DESC = new org.apache.thrift.protocol.TField("Reason", org.apache.thrift.protocol.TType.STRING, (short)2);
+	private static final org.apache.thrift.protocol.TField DEPR_FIELD_DESC = new org.apache.thrift.protocol.TField("depr", org.apache.thrift.protocol.TType.BOOL, (short)3);
 
 	private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
 	static {
@@ -54,6 +55,11 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 	 * Reason contains the error message.
 	 */
 	public String Reason;
+	/**
+	 * @deprecated use something else
+	 */
+	@Deprecated
+	public boolean depr;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		/**
@@ -63,7 +69,8 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 		/**
 		 * Reason contains the error message.
 		 */
-		REASON((short)2, "Reason")
+		REASON((short)2, "Reason"),
+		DEPR((short)3, "depr")
 ;
 
 		private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
@@ -83,6 +90,8 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 					return ID;
 				case 2: // REASON
 					return REASON;
+				case 3: // DEPR
+					return DEPR;
 				default:
 					return null;
 			}
@@ -124,17 +133,21 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 
 	// isset id assignments
 	private static final int __ID_ISSET_ID = 0;
+	private static final int __DEPR_ISSET_ID = 1;
 	private byte __isset_bitfield = 0;
 	public AwesomeException() {
 	}
 
 	public AwesomeException(
 		long ID,
-		String Reason) {
+		String Reason,
+		boolean depr) {
 		this();
 		this.ID = ID;
 		setIDIsSet(true);
 		this.Reason = Reason;
+		this.depr = depr;
+		setDeprIsSet(true);
 	}
 
 	/**
@@ -146,6 +159,7 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 		if (other.isSetReason()) {
 			this.Reason = other.Reason;
 		}
+		this.depr = other.depr;
 	}
 
 	public AwesomeException deepCopy() {
@@ -158,6 +172,9 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 		this.ID = 0L;
 
 		this.Reason = null;
+
+		setDeprIsSet(false);
+		this.depr = false;
 
 	}
 
@@ -220,6 +237,33 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 		}
 	}
 
+	@Deprecated
+	public boolean isDepr() {
+		return this.depr;
+	}
+
+	@Deprecated
+	public AwesomeException setDepr(boolean depr) {
+		this.depr = depr;
+		setDeprIsSet(true);
+		return this;
+	}
+
+	public void unsetDepr() {
+		__isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __DEPR_ISSET_ID);
+	}
+
+	/** Returns true if field depr is set (has been assigned a value) and false otherwise */
+	@Deprecated
+	public boolean isSetDepr() {
+		return EncodingUtils.testBit(__isset_bitfield, __DEPR_ISSET_ID);
+	}
+
+	@Deprecated
+	public void setDeprIsSet(boolean value) {
+		__isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __DEPR_ISSET_ID, value);
+	}
+
 	public void setFieldValue(_Fields field, Object value) {
 		switch (field) {
 		case ID:
@@ -238,6 +282,14 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 			}
 			break;
 
+		case DEPR:
+			if (value == null) {
+				unsetDepr();
+			} else {
+				setDepr((Boolean)value);
+			}
+			break;
+
 		}
 	}
 
@@ -248,6 +300,9 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 
 		case REASON:
 			return getReason();
+
+		case DEPR:
+			return isDepr();
 
 		}
 		throw new IllegalStateException();
@@ -264,6 +319,8 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 			return isSetID();
 		case REASON:
 			return isSetReason();
+		case DEPR:
+			return isSetDepr();
 		}
 		throw new IllegalStateException();
 	}
@@ -299,6 +356,15 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 				return false;
 		}
 
+		boolean this_present_depr = true;
+		boolean that_present_depr = true;
+		if (this_present_depr || that_present_depr) {
+			if (!(this_present_depr && that_present_depr))
+				return false;
+			if (this.depr != that.depr)
+				return false;
+		}
+
 		return true;
 	}
 
@@ -315,6 +381,11 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 		list.add(present_Reason);
 		if (present_Reason)
 			list.add(Reason);
+
+		boolean present_depr = true;
+		list.add(present_depr);
+		if (present_depr)
+			list.add(depr);
 
 		return list.hashCode();
 	}
@@ -343,6 +414,16 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 		}
 		if (isSetReason()) {
 			lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.Reason, other.Reason);
+			if (lastComparison != 0) {
+				return lastComparison;
+			}
+		}
+		lastComparison = Boolean.valueOf(isSetDepr()).compareTo(other.isSetDepr());
+		if (lastComparison != 0) {
+			return lastComparison;
+		}
+		if (isSetDepr()) {
+			lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.depr, other.depr);
 			if (lastComparison != 0) {
 				return lastComparison;
 			}
@@ -377,6 +458,10 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 		} else {
 			sb.append(this.Reason);
 		}
+		first = false;
+		if (!first) sb.append(", ");
+		sb.append("depr:");
+		sb.append(this.depr);
 		first = false;
 		sb.append(")");
 		return sb.toString();
@@ -438,6 +523,14 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 							org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
 						}
 						break;
+					case 3: // DEPR
+						if (schemeField.type == org.apache.thrift.protocol.TType.BOOL) {
+							struct.depr = iprot.readBool();
+							struct.setDeprIsSet(true);
+						} else {
+							org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+						}
+						break;
 					default:
 						org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
 				}
@@ -463,6 +556,10 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 				oprot.writeString(elem211);
 				oprot.writeFieldEnd();
 			}
+			oprot.writeFieldBegin(DEPR_FIELD_DESC);
+			boolean elem212 = struct.depr;
+			oprot.writeBool(elem212);
+			oprot.writeFieldEnd();
 			oprot.writeFieldStop();
 			oprot.writeStructEnd();
 		}
@@ -487,21 +584,28 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 			if (struct.isSetReason()) {
 				optionals.set(1);
 			}
-			oprot.writeBitSet(optionals, 2);
+			if (struct.isSetDepr()) {
+				optionals.set(2);
+			}
+			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetID()) {
-				long elem212 = struct.ID;
-				oprot.writeI64(elem212);
+				long elem213 = struct.ID;
+				oprot.writeI64(elem213);
 			}
 			if (struct.isSetReason()) {
-				String elem213 = struct.Reason;
-				oprot.writeString(elem213);
+				String elem214 = struct.Reason;
+				oprot.writeString(elem214);
+			}
+			if (struct.isSetDepr()) {
+				boolean elem215 = struct.depr;
+				oprot.writeBool(elem215);
 			}
 		}
 
 		@Override
 		public void read(org.apache.thrift.protocol.TProtocol prot, AwesomeException struct) throws org.apache.thrift.TException {
 			TTupleProtocol iprot = (TTupleProtocol) prot;
-			BitSet incoming = iprot.readBitSet(2);
+			BitSet incoming = iprot.readBitSet(3);
 			if (incoming.get(0)) {
 				struct.ID = iprot.readI64();
 				struct.setIDIsSet(true);
@@ -509,6 +613,10 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 			if (incoming.get(1)) {
 				struct.Reason = iprot.readString();
 				struct.setReasonIsSet(true);
+			}
+			if (incoming.get(2)) {
+				struct.depr = iprot.readBool();
+				struct.setDeprIsSet(true);
 			}
 		}
 

--- a/test/expected/java/variety/AwesomeException.java
+++ b/test/expected/java/variety/AwesomeException.java
@@ -249,6 +249,7 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 		return this;
 	}
 
+	@Deprecated
 	public void unsetDepr() {
 		__isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __DEPR_ISSET_ID);
 	}

--- a/test/expected/java/variety/EventWrapper.java
+++ b/test/expected/java/variety/EventWrapper.java
@@ -47,6 +47,9 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 	private static final org.apache.thrift.protocol.TField A_BOOL_FIELD_FIELD_DESC = new org.apache.thrift.protocol.TField("aBoolField", org.apache.thrift.protocol.TType.BOOL, (short)8);
 	private static final org.apache.thrift.protocol.TField A_UNION_FIELD_DESC = new org.apache.thrift.protocol.TField("a_union", org.apache.thrift.protocol.TType.STRUCT, (short)9);
 	private static final org.apache.thrift.protocol.TField TYPEDEF_OF_TYPEDEF_FIELD_DESC = new org.apache.thrift.protocol.TField("typedefOfTypedef", org.apache.thrift.protocol.TType.STRING, (short)10);
+	private static final org.apache.thrift.protocol.TField DEPR_FIELD_DESC = new org.apache.thrift.protocol.TField("depr", org.apache.thrift.protocol.TType.BOOL, (short)11);
+	private static final org.apache.thrift.protocol.TField DEPR_BINARY_FIELD_DESC = new org.apache.thrift.protocol.TField("deprBinary", org.apache.thrift.protocol.TType.STRING, (short)12);
+	private static final org.apache.thrift.protocol.TField DEPR_LIST_FIELD_DESC = new org.apache.thrift.protocol.TField("deprList", org.apache.thrift.protocol.TType.LIST, (short)13);
 
 	private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
 	static {
@@ -64,6 +67,23 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 	public boolean aBoolField;
 	public TestingUnions a_union;
 	public String typedefOfTypedef;
+	/**
+	 * This is a docstring comment for a deprecated field that has been spread
+	 * across two lines.
+	 * @deprecated use something else
+	 */
+	@Deprecated
+	public boolean depr;
+	/**
+	 * @deprecated use something else
+	 */
+	@Deprecated
+	public java.nio.ByteBuffer deprBinary;
+	/**
+	 * @deprecated use something else
+	 */
+	@Deprecated
+	public java.util.List<Boolean> deprList;
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		ID((short)1, "ID"),
@@ -75,7 +95,14 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		ENUMS((short)7, "Enums"),
 		A_BOOL_FIELD((short)8, "aBoolField"),
 		A_UNION((short)9, "a_union"),
-		TYPEDEF_OF_TYPEDEF((short)10, "typedefOfTypedef")
+		TYPEDEF_OF_TYPEDEF((short)10, "typedefOfTypedef"),
+		/**
+		 * This is a docstring comment for a deprecated field that has been spread
+		 * across two lines.
+		 */
+		DEPR((short)11, "depr"),
+		DEPR_BINARY((short)12, "deprBinary"),
+		DEPR_LIST((short)13, "deprList")
 ;
 
 		private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
@@ -111,6 +138,12 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 					return A_UNION;
 				case 10: // TYPEDEF_OF_TYPEDEF
 					return TYPEDEF_OF_TYPEDEF;
+				case 11: // DEPR
+					return DEPR;
+				case 12: // DEPR_BINARY
+					return DEPR_BINARY;
+				case 13: // DEPR_LIST
+					return DEPR_LIST;
 				default:
 					return null;
 			}
@@ -153,6 +186,7 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 	// isset id assignments
 	private static final int __ID_ISSET_ID = 0;
 	private static final int __ABOOLFIELD_ISSET_ID = 1;
+	private static final int __DEPR_ISSET_ID = 2;
 	private byte __isset_bitfield = 0;
 	public EventWrapper() {
 	}
@@ -166,7 +200,10 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		java.util.List<ItsAnEnum> Enums,
 		boolean aBoolField,
 		TestingUnions a_union,
-		String typedefOfTypedef) {
+		String typedefOfTypedef,
+		boolean depr,
+		java.nio.ByteBuffer deprBinary,
+		java.util.List<Boolean> deprList) {
 		this();
 		this.Ev = Ev;
 		this.Events = Events;
@@ -178,6 +215,10 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		setABoolFieldIsSet(true);
 		this.a_union = a_union;
 		this.typedefOfTypedef = typedefOfTypedef;
+		this.depr = depr;
+		setDeprIsSet(true);
+		this.deprBinary = org.apache.thrift.TBaseHelper.copyBinary(deprBinary);
+		this.deprList = deprList;
 	}
 
 	/**
@@ -236,6 +277,17 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		if (other.isSetTypedefOfTypedef()) {
 			this.typedefOfTypedef = other.typedefOfTypedef;
 		}
+		this.depr = other.depr;
+		if (other.isSetDeprBinary()) {
+			this.deprBinary = org.apache.thrift.TBaseHelper.copyBinary(other.deprBinary);
+		}
+		if (other.isSetDeprList()) {
+			this.deprList = new ArrayList<Boolean>(other.deprList.size());
+			for (boolean elem106 : other.deprList) {
+				boolean elem107 = elem106;
+				this.deprList.add(elem107);
+			}
+		}
 	}
 
 	public EventWrapper deepCopy() {
@@ -265,6 +317,13 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		this.a_union = null;
 
 		this.typedefOfTypedef = null;
+
+		setDeprIsSet(false);
+		this.depr = false;
+
+		this.deprBinary = null;
+
+		this.deprList = null;
 
 	}
 
@@ -577,6 +636,126 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		}
 	}
 
+	/**
+	 * This is a docstring comment for a deprecated field that has been spread
+	 * across two lines.
+	 */
+	@Deprecated
+	public boolean isDepr() {
+		return this.depr;
+	}
+
+	/**
+	 * This is a docstring comment for a deprecated field that has been spread
+	 * across two lines.
+	 */
+	@Deprecated
+	public EventWrapper setDepr(boolean depr) {
+		this.depr = depr;
+		setDeprIsSet(true);
+		return this;
+	}
+
+	public void unsetDepr() {
+		__isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __DEPR_ISSET_ID);
+	}
+
+	/** Returns true if field depr is set (has been assigned a value) and false otherwise */
+	@Deprecated
+	public boolean isSetDepr() {
+		return EncodingUtils.testBit(__isset_bitfield, __DEPR_ISSET_ID);
+	}
+
+	@Deprecated
+	public void setDeprIsSet(boolean value) {
+		__isset_bitfield = EncodingUtils.setBit(__isset_bitfield, __DEPR_ISSET_ID, value);
+	}
+
+	@Deprecated
+	public byte[] getDeprBinary() {
+		setDeprBinary(org.apache.thrift.TBaseHelper.rightSize(deprBinary));
+		return deprBinary == null ? null : deprBinary.array();
+	}
+
+	public java.nio.ByteBuffer bufferForDeprBinary() {
+		return org.apache.thrift.TBaseHelper.copyBinary(deprBinary);
+	}
+
+	@Deprecated
+	public EventWrapper setDeprBinary(byte[] deprBinary) {
+		this.deprBinary = deprBinary == null ? (java.nio.ByteBuffer)null : java.nio.ByteBuffer.wrap(Arrays.copyOf(deprBinary, deprBinary.length));
+		return this;
+	}
+
+	@Deprecated
+	public EventWrapper setDeprBinary(java.nio.ByteBuffer deprBinary) {
+		this.deprBinary = org.apache.thrift.TBaseHelper.copyBinary(deprBinary);
+		return this;
+	}
+
+	public void unsetDeprBinary() {
+		this.deprBinary = null;
+	}
+
+	/** Returns true if field deprBinary is set (has been assigned a value) and false otherwise */
+	@Deprecated
+	public boolean isSetDeprBinary() {
+		return this.deprBinary != null;
+	}
+
+	@Deprecated
+	public void setDeprBinaryIsSet(boolean value) {
+		if (!value) {
+			this.deprBinary = null;
+		}
+	}
+
+	@Deprecated
+	public int getDeprListSize() {
+		return (this.deprList == null) ? 0 : this.deprList.size();
+	}
+
+	@Deprecated
+	public java.util.Iterator<Boolean> getDeprListIterator() {
+		return (this.deprList == null) ? null : this.deprList.iterator();
+	}
+
+	@Deprecated
+	public void addToDeprList(boolean elem) {
+		if (this.deprList == null) {
+			this.deprList = new ArrayList<Boolean>();
+		}
+		this.deprList.add(elem);
+	}
+
+	@Deprecated
+	public java.util.List<Boolean> getDeprList() {
+		return this.deprList;
+	}
+
+	@Deprecated
+	public EventWrapper setDeprList(java.util.List<Boolean> deprList) {
+		this.deprList = deprList;
+		return this;
+	}
+
+	public void unsetDeprList() {
+		this.deprList = null;
+	}
+
+	/** Returns true if field deprList is set (has been assigned a value) and false otherwise */
+	@Deprecated
+	public boolean isSetDeprList() {
+		return this.deprList != null;
+	}
+
+	@Deprecated
+	public void setDeprListIsSet(boolean value) {
+		if (!value) {
+			this.deprList = null;
+		}
+	}
+
 	public void setFieldValue(_Fields field, Object value) {
 		switch (field) {
 		case ID:
@@ -659,6 +838,30 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			}
 			break;
 
+		case DEPR:
+			if (value == null) {
+				unsetDepr();
+			} else {
+				setDepr((Boolean)value);
+			}
+			break;
+
+		case DEPR_BINARY:
+			if (value == null) {
+				unsetDeprBinary();
+			} else {
+				setDeprBinary((java.nio.ByteBuffer)value);
+			}
+			break;
+
+		case DEPR_LIST:
+			if (value == null) {
+				unsetDeprList();
+			} else {
+				setDeprList((java.util.List<Boolean>)value);
+			}
+			break;
+
 		}
 	}
 
@@ -694,6 +897,15 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		case TYPEDEF_OF_TYPEDEF:
 			return getTypedefOfTypedef();
 
+		case DEPR:
+			return isDepr();
+
+		case DEPR_BINARY:
+			return getDeprBinary();
+
+		case DEPR_LIST:
+			return getDeprList();
+
 		}
 		throw new IllegalStateException();
 	}
@@ -725,6 +937,12 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			return isSetA_union();
 		case TYPEDEF_OF_TYPEDEF:
 			return isSetTypedefOfTypedef();
+		case DEPR:
+			return isSetDepr();
+		case DEPR_BINARY:
+			return isSetDeprBinary();
+		case DEPR_LIST:
+			return isSetDeprList();
 		}
 		throw new IllegalStateException();
 	}
@@ -832,6 +1050,33 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 				return false;
 		}
 
+		boolean this_present_depr = true;
+		boolean that_present_depr = true;
+		if (this_present_depr || that_present_depr) {
+			if (!(this_present_depr && that_present_depr))
+				return false;
+			if (this.depr != that.depr)
+				return false;
+		}
+
+		boolean this_present_deprBinary = true && this.isSetDeprBinary();
+		boolean that_present_deprBinary = true && that.isSetDeprBinary();
+		if (this_present_deprBinary || that_present_deprBinary) {
+			if (!(this_present_deprBinary && that_present_deprBinary))
+				return false;
+			if (!this.deprBinary.equals(that.deprBinary))
+				return false;
+		}
+
+		boolean this_present_deprList = true && this.isSetDeprList();
+		boolean that_present_deprList = true && that.isSetDeprList();
+		if (this_present_deprList || that_present_deprList) {
+			if (!(this_present_deprList && that_present_deprList))
+				return false;
+			if (!this.deprList.equals(that.deprList))
+				return false;
+		}
+
 		return true;
 	}
 
@@ -888,6 +1133,21 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		list.add(present_typedefOfTypedef);
 		if (present_typedefOfTypedef)
 			list.add(typedefOfTypedef);
+
+		boolean present_depr = true;
+		list.add(present_depr);
+		if (present_depr)
+			list.add(depr);
+
+		boolean present_deprBinary = true && (isSetDeprBinary());
+		list.add(present_deprBinary);
+		if (present_deprBinary)
+			list.add(deprBinary);
+
+		boolean present_deprList = true && (isSetDeprList());
+		list.add(present_deprList);
+		if (present_deprList)
+			list.add(deprList);
 
 		return list.hashCode();
 	}
@@ -1000,6 +1260,36 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 				return lastComparison;
 			}
 		}
+		lastComparison = Boolean.valueOf(isSetDepr()).compareTo(other.isSetDepr());
+		if (lastComparison != 0) {
+			return lastComparison;
+		}
+		if (isSetDepr()) {
+			lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.depr, other.depr);
+			if (lastComparison != 0) {
+				return lastComparison;
+			}
+		}
+		lastComparison = Boolean.valueOf(isSetDeprBinary()).compareTo(other.isSetDeprBinary());
+		if (lastComparison != 0) {
+			return lastComparison;
+		}
+		if (isSetDeprBinary()) {
+			lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.deprBinary, other.deprBinary);
+			if (lastComparison != 0) {
+				return lastComparison;
+			}
+		}
+		lastComparison = Boolean.valueOf(isSetDeprList()).compareTo(other.isSetDeprList());
+		if (lastComparison != 0) {
+			return lastComparison;
+		}
+		if (isSetDeprList()) {
+			lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.deprList, other.deprList);
+			if (lastComparison != 0) {
+				return lastComparison;
+			}
+		}
 		return 0;
 	}
 
@@ -1093,6 +1383,26 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			sb.append(this.typedefOfTypedef);
 		}
 		first = false;
+		if (!first) sb.append(", ");
+		sb.append("depr:");
+		sb.append(this.depr);
+		first = false;
+		if (!first) sb.append(", ");
+		sb.append("deprBinary:");
+		if (this.deprBinary == null) {
+			sb.append("null");
+		} else {
+			org.apache.thrift.TBaseHelper.toString(this.deprBinary, sb);
+		}
+		first = false;
+		if (!first) sb.append(", ");
+		sb.append("deprList:");
+		if (this.deprList == null) {
+			sb.append("null");
+		} else {
+			sb.append(this.deprList);
+		}
+		first = false;
 		sb.append(")");
 		return sb.toString();
 	}
@@ -1162,12 +1472,12 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 						break;
 					case 3: // EVENTS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem106 = iprot.readListBegin();
-							struct.Events = new ArrayList<Event>(elem106.size);
-							for (int elem107 = 0; elem107 < elem106.size; ++elem107) {
-								Event elem108 = new Event();
-								elem108.read(iprot);
-								struct.Events.add(elem108);
+							org.apache.thrift.protocol.TList elem108 = iprot.readListBegin();
+							struct.Events = new ArrayList<Event>(elem108.size);
+							for (int elem109 = 0; elem109 < elem108.size; ++elem109) {
+								Event elem110 = new Event();
+								elem110.read(iprot);
+								struct.Events.add(elem110);
 							}
 							iprot.readListEnd();
 							struct.setEventsIsSet(true);
@@ -1177,12 +1487,12 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 						break;
 					case 4: // EVENTS2
 						if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
-							org.apache.thrift.protocol.TSet elem109 = iprot.readSetBegin();
-							struct.Events2 = new HashSet<Event>(2*elem109.size);
-							for (int elem110 = 0; elem110 < elem109.size; ++elem110) {
-								Event elem111 = new Event();
-								elem111.read(iprot);
-								struct.Events2.add(elem111);
+							org.apache.thrift.protocol.TSet elem111 = iprot.readSetBegin();
+							struct.Events2 = new HashSet<Event>(2*elem111.size);
+							for (int elem112 = 0; elem112 < elem111.size; ++elem112) {
+								Event elem113 = new Event();
+								elem113.read(iprot);
+								struct.Events2.add(elem113);
 							}
 							iprot.readSetEnd();
 							struct.setEvents2IsSet(true);
@@ -1192,13 +1502,13 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 						break;
 					case 5: // EVENT_MAP
 						if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
-							org.apache.thrift.protocol.TMap elem112 = iprot.readMapBegin();
-							struct.EventMap = new HashMap<Long,Event>(2*elem112.size);
-							for (int elem113 = 0; elem113 < elem112.size; ++elem113) {
-								long elem115 = iprot.readI64();
-								Event elem114 = new Event();
-								elem114.read(iprot);
-								struct.EventMap.put(elem115, elem114);
+							org.apache.thrift.protocol.TMap elem114 = iprot.readMapBegin();
+							struct.EventMap = new HashMap<Long,Event>(2*elem114.size);
+							for (int elem115 = 0; elem115 < elem114.size; ++elem115) {
+								long elem117 = iprot.readI64();
+								Event elem116 = new Event();
+								elem116.read(iprot);
+								struct.EventMap.put(elem117, elem116);
 							}
 							iprot.readMapEnd();
 							struct.setEventMapIsSet(true);
@@ -1208,17 +1518,17 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 						break;
 					case 6: // NUMS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem116 = iprot.readListBegin();
-							struct.Nums = new ArrayList<java.util.List<Integer>>(elem116.size);
-							for (int elem117 = 0; elem117 < elem116.size; ++elem117) {
-								org.apache.thrift.protocol.TList elem119 = iprot.readListBegin();
-								java.util.List<Integer> elem118 = new ArrayList<Integer>(elem119.size);
-								for (int elem120 = 0; elem120 < elem119.size; ++elem120) {
-									int elem121 = iprot.readI32();
-									elem118.add(elem121);
+							org.apache.thrift.protocol.TList elem118 = iprot.readListBegin();
+							struct.Nums = new ArrayList<java.util.List<Integer>>(elem118.size);
+							for (int elem119 = 0; elem119 < elem118.size; ++elem119) {
+								org.apache.thrift.protocol.TList elem121 = iprot.readListBegin();
+								java.util.List<Integer> elem120 = new ArrayList<Integer>(elem121.size);
+								for (int elem122 = 0; elem122 < elem121.size; ++elem122) {
+									int elem123 = iprot.readI32();
+									elem120.add(elem123);
 								}
 								iprot.readListEnd();
-								struct.Nums.add(elem118);
+								struct.Nums.add(elem120);
 							}
 							iprot.readListEnd();
 							struct.setNumsIsSet(true);
@@ -1228,11 +1538,11 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 						break;
 					case 7: // ENUMS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem122 = iprot.readListBegin();
-							struct.Enums = new ArrayList<ItsAnEnum>(elem122.size);
-							for (int elem123 = 0; elem123 < elem122.size; ++elem123) {
-								ItsAnEnum elem124 = ItsAnEnum.findByValue(iprot.readI32());
-								struct.Enums.add(elem124);
+							org.apache.thrift.protocol.TList elem124 = iprot.readListBegin();
+							struct.Enums = new ArrayList<ItsAnEnum>(elem124.size);
+							for (int elem125 = 0; elem125 < elem124.size; ++elem125) {
+								ItsAnEnum elem126 = ItsAnEnum.findByValue(iprot.readI32());
+								struct.Enums.add(elem126);
 							}
 							iprot.readListEnd();
 							struct.setEnumsIsSet(true);
@@ -1265,6 +1575,36 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 							org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
 						}
 						break;
+					case 11: // DEPR
+						if (schemeField.type == org.apache.thrift.protocol.TType.BOOL) {
+							struct.depr = iprot.readBool();
+							struct.setDeprIsSet(true);
+						} else {
+							org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+						}
+						break;
+					case 12: // DEPR_BINARY
+						if (schemeField.type == org.apache.thrift.protocol.TType.STRING) {
+							struct.deprBinary = iprot.readBinary();
+							struct.setDeprBinaryIsSet(true);
+						} else {
+							org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+						}
+						break;
+					case 13: // DEPR_LIST
+						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
+							org.apache.thrift.protocol.TList elem127 = iprot.readListBegin();
+							struct.deprList = new ArrayList<Boolean>(elem127.size);
+							for (int elem128 = 0; elem128 < elem127.size; ++elem128) {
+								boolean elem129 = iprot.readBool();
+								struct.deprList.add(elem129);
+							}
+							iprot.readListEnd();
+							struct.setDeprListIsSet(true);
+						} else {
+							org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+						}
+						break;
 					default:
 						org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
 				}
@@ -1282,8 +1622,8 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetID()) {
 				oprot.writeFieldBegin(ID_FIELD_DESC);
-				long elem125 = struct.ID;
-				oprot.writeI64(elem125);
+				long elem130 = struct.ID;
+				oprot.writeI64(elem130);
 				oprot.writeFieldEnd();
 			}
 			if (struct.Ev != null) {
@@ -1294,8 +1634,8 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			if (struct.Events != null) {
 				oprot.writeFieldBegin(EVENTS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.Events.size()));
-				for (Event elem126 : struct.Events) {
-					elem126.write(oprot);
+				for (Event elem131 : struct.Events) {
+					elem131.write(oprot);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -1303,8 +1643,8 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			if (struct.Events2 != null) {
 				oprot.writeFieldBegin(EVENTS2_FIELD_DESC);
 				oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.STRUCT, struct.Events2.size()));
-				for (Event elem127 : struct.Events2) {
-					elem127.write(oprot);
+				for (Event elem132 : struct.Events2) {
+					elem132.write(oprot);
 				}
 				oprot.writeSetEnd();
 				oprot.writeFieldEnd();
@@ -1312,10 +1652,10 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			if (struct.EventMap != null) {
 				oprot.writeFieldBegin(EVENT_MAP_FIELD_DESC);
 				oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, struct.EventMap.size()));
-				for (Map.Entry<Long, Event> elem128 : struct.EventMap.entrySet()) {
-					long elem129 = elem128.getKey();
-					oprot.writeI64(elem129);
-					elem128.getValue().write(oprot);
+				for (Map.Entry<Long, Event> elem133 : struct.EventMap.entrySet()) {
+					long elem134 = elem133.getKey();
+					oprot.writeI64(elem134);
+					elem133.getValue().write(oprot);
 				}
 				oprot.writeMapEnd();
 				oprot.writeFieldEnd();
@@ -1323,11 +1663,11 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			if (struct.Nums != null) {
 				oprot.writeFieldBegin(NUMS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.LIST, struct.Nums.size()));
-				for (java.util.List<Integer> elem130 : struct.Nums) {
-					oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, elem130.size()));
-					for (int elem131 : elem130) {
-						int elem132 = elem131;
-						oprot.writeI32(elem132);
+				for (java.util.List<Integer> elem135 : struct.Nums) {
+					oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, elem135.size()));
+					for (int elem136 : elem135) {
+						int elem137 = elem136;
+						oprot.writeI32(elem137);
 					}
 					oprot.writeListEnd();
 				}
@@ -1337,16 +1677,16 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			if (struct.Enums != null) {
 				oprot.writeFieldBegin(ENUMS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, struct.Enums.size()));
-				for (ItsAnEnum elem133 : struct.Enums) {
-					ItsAnEnum elem134 = elem133;
-					oprot.writeI32(elem134.getValue());
+				for (ItsAnEnum elem138 : struct.Enums) {
+					ItsAnEnum elem139 = elem138;
+					oprot.writeI32(elem139.getValue());
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldBegin(A_BOOL_FIELD_FIELD_DESC);
-			boolean elem135 = struct.aBoolField;
-			oprot.writeBool(elem135);
+			boolean elem140 = struct.aBoolField;
+			oprot.writeBool(elem140);
 			oprot.writeFieldEnd();
 			if (struct.a_union != null) {
 				oprot.writeFieldBegin(A_UNION_FIELD_DESC);
@@ -1355,8 +1695,28 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			}
 			if (struct.typedefOfTypedef != null) {
 				oprot.writeFieldBegin(TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-				String elem136 = struct.typedefOfTypedef;
-				oprot.writeString(elem136);
+				String elem141 = struct.typedefOfTypedef;
+				oprot.writeString(elem141);
+				oprot.writeFieldEnd();
+			}
+			oprot.writeFieldBegin(DEPR_FIELD_DESC);
+			boolean elem142 = struct.depr;
+			oprot.writeBool(elem142);
+			oprot.writeFieldEnd();
+			if (struct.deprBinary != null) {
+				oprot.writeFieldBegin(DEPR_BINARY_FIELD_DESC);
+				java.nio.ByteBuffer elem143 = struct.deprBinary;
+				oprot.writeBinary(elem143);
+				oprot.writeFieldEnd();
+			}
+			if (struct.deprList != null) {
+				oprot.writeFieldBegin(DEPR_LIST_FIELD_DESC);
+				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.BOOL, struct.deprList.size()));
+				for (boolean elem144 : struct.deprList) {
+					boolean elem145 = elem144;
+					oprot.writeBool(elem145);
+				}
+				oprot.writeListEnd();
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -1405,58 +1765,82 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			if (struct.isSetTypedefOfTypedef()) {
 				optionals.set(8);
 			}
-			oprot.writeBitSet(optionals, 9);
+			if (struct.isSetDepr()) {
+				optionals.set(9);
+			}
+			if (struct.isSetDeprBinary()) {
+				optionals.set(10);
+			}
+			if (struct.isSetDeprList()) {
+				optionals.set(11);
+			}
+			oprot.writeBitSet(optionals, 12);
 			if (struct.isSetID()) {
-				long elem137 = struct.ID;
-				oprot.writeI64(elem137);
+				long elem146 = struct.ID;
+				oprot.writeI64(elem146);
 			}
 			if (struct.isSetEvents()) {
 				oprot.writeI32(struct.Events.size());
-				for (Event elem138 : struct.Events) {
-					elem138.write(oprot);
+				for (Event elem147 : struct.Events) {
+					elem147.write(oprot);
 				}
 			}
 			if (struct.isSetEvents2()) {
 				oprot.writeI32(struct.Events2.size());
-				for (Event elem139 : struct.Events2) {
-					elem139.write(oprot);
+				for (Event elem148 : struct.Events2) {
+					elem148.write(oprot);
 				}
 			}
 			if (struct.isSetEventMap()) {
 				oprot.writeI32(struct.EventMap.size());
-				for (Map.Entry<Long, Event> elem140 : struct.EventMap.entrySet()) {
-					long elem141 = elem140.getKey();
-					oprot.writeI64(elem141);
-					elem140.getValue().write(oprot);
+				for (Map.Entry<Long, Event> elem149 : struct.EventMap.entrySet()) {
+					long elem150 = elem149.getKey();
+					oprot.writeI64(elem150);
+					elem149.getValue().write(oprot);
 				}
 			}
 			if (struct.isSetNums()) {
 				oprot.writeI32(struct.Nums.size());
-				for (java.util.List<Integer> elem142 : struct.Nums) {
-					oprot.writeI32(elem142.size());
-					for (int elem143 : elem142) {
-						int elem144 = elem143;
-						oprot.writeI32(elem144);
+				for (java.util.List<Integer> elem151 : struct.Nums) {
+					oprot.writeI32(elem151.size());
+					for (int elem152 : elem151) {
+						int elem153 = elem152;
+						oprot.writeI32(elem153);
 					}
 				}
 			}
 			if (struct.isSetEnums()) {
 				oprot.writeI32(struct.Enums.size());
-				for (ItsAnEnum elem145 : struct.Enums) {
-					ItsAnEnum elem146 = elem145;
-					oprot.writeI32(elem146.getValue());
+				for (ItsAnEnum elem154 : struct.Enums) {
+					ItsAnEnum elem155 = elem154;
+					oprot.writeI32(elem155.getValue());
 				}
 			}
 			if (struct.isSetABoolField()) {
-				boolean elem147 = struct.aBoolField;
-				oprot.writeBool(elem147);
+				boolean elem156 = struct.aBoolField;
+				oprot.writeBool(elem156);
 			}
 			if (struct.isSetA_union()) {
 				struct.a_union.write(oprot);
 			}
 			if (struct.isSetTypedefOfTypedef()) {
-				String elem148 = struct.typedefOfTypedef;
-				oprot.writeString(elem148);
+				String elem157 = struct.typedefOfTypedef;
+				oprot.writeString(elem157);
+			}
+			if (struct.isSetDepr()) {
+				boolean elem158 = struct.depr;
+				oprot.writeBool(elem158);
+			}
+			if (struct.isSetDeprBinary()) {
+				java.nio.ByteBuffer elem159 = struct.deprBinary;
+				oprot.writeBinary(elem159);
+			}
+			if (struct.isSetDeprList()) {
+				oprot.writeI32(struct.deprList.size());
+				for (boolean elem160 : struct.deprList) {
+					boolean elem161 = elem160;
+					oprot.writeBool(elem161);
+				}
 			}
 		}
 
@@ -1466,62 +1850,62 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			struct.Ev = new Event();
 			struct.Ev.read(iprot);
 			struct.setEvIsSet(true);
-			BitSet incoming = iprot.readBitSet(9);
+			BitSet incoming = iprot.readBitSet(12);
 			if (incoming.get(0)) {
 				struct.ID = iprot.readI64();
 				struct.setIDIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TList elem149 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-				struct.Events = new ArrayList<Event>(elem149.size);
-				for (int elem150 = 0; elem150 < elem149.size; ++elem150) {
-					Event elem151 = new Event();
-					elem151.read(iprot);
-					struct.Events.add(elem151);
+				org.apache.thrift.protocol.TList elem162 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+				struct.Events = new ArrayList<Event>(elem162.size);
+				for (int elem163 = 0; elem163 < elem162.size; ++elem163) {
+					Event elem164 = new Event();
+					elem164.read(iprot);
+					struct.Events.add(elem164);
 				}
 				struct.setEventsIsSet(true);
 			}
 			if (incoming.get(2)) {
-				org.apache.thrift.protocol.TSet elem152 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-				struct.Events2 = new HashSet<Event>(2*elem152.size);
-				for (int elem153 = 0; elem153 < elem152.size; ++elem153) {
-					Event elem154 = new Event();
-					elem154.read(iprot);
-					struct.Events2.add(elem154);
+				org.apache.thrift.protocol.TSet elem165 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+				struct.Events2 = new HashSet<Event>(2*elem165.size);
+				for (int elem166 = 0; elem166 < elem165.size; ++elem166) {
+					Event elem167 = new Event();
+					elem167.read(iprot);
+					struct.Events2.add(elem167);
 				}
 				struct.setEvents2IsSet(true);
 			}
 			if (incoming.get(3)) {
-				org.apache.thrift.protocol.TMap elem155 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-				struct.EventMap = new HashMap<Long,Event>(2*elem155.size);
-				for (int elem156 = 0; elem156 < elem155.size; ++elem156) {
-					long elem158 = iprot.readI64();
-					Event elem157 = new Event();
-					elem157.read(iprot);
-					struct.EventMap.put(elem158, elem157);
+				org.apache.thrift.protocol.TMap elem168 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+				struct.EventMap = new HashMap<Long,Event>(2*elem168.size);
+				for (int elem169 = 0; elem169 < elem168.size; ++elem169) {
+					long elem171 = iprot.readI64();
+					Event elem170 = new Event();
+					elem170.read(iprot);
+					struct.EventMap.put(elem171, elem170);
 				}
 				struct.setEventMapIsSet(true);
 			}
 			if (incoming.get(4)) {
-				org.apache.thrift.protocol.TList elem159 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.LIST, iprot.readI32());
-				struct.Nums = new ArrayList<java.util.List<Integer>>(elem159.size);
-				for (int elem160 = 0; elem160 < elem159.size; ++elem160) {
-					org.apache.thrift.protocol.TList elem162 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, iprot.readI32());
-					java.util.List<Integer> elem161 = new ArrayList<Integer>(elem162.size);
-					for (int elem163 = 0; elem163 < elem162.size; ++elem163) {
-						int elem164 = iprot.readI32();
-						elem161.add(elem164);
+				org.apache.thrift.protocol.TList elem172 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.LIST, iprot.readI32());
+				struct.Nums = new ArrayList<java.util.List<Integer>>(elem172.size);
+				for (int elem173 = 0; elem173 < elem172.size; ++elem173) {
+					org.apache.thrift.protocol.TList elem175 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, iprot.readI32());
+					java.util.List<Integer> elem174 = new ArrayList<Integer>(elem175.size);
+					for (int elem176 = 0; elem176 < elem175.size; ++elem176) {
+						int elem177 = iprot.readI32();
+						elem174.add(elem177);
 					}
-					struct.Nums.add(elem161);
+					struct.Nums.add(elem174);
 				}
 				struct.setNumsIsSet(true);
 			}
 			if (incoming.get(5)) {
-				org.apache.thrift.protocol.TList elem165 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, iprot.readI32());
-				struct.Enums = new ArrayList<ItsAnEnum>(elem165.size);
-				for (int elem166 = 0; elem166 < elem165.size; ++elem166) {
-					ItsAnEnum elem167 = ItsAnEnum.findByValue(iprot.readI32());
-					struct.Enums.add(elem167);
+				org.apache.thrift.protocol.TList elem178 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, iprot.readI32());
+				struct.Enums = new ArrayList<ItsAnEnum>(elem178.size);
+				for (int elem179 = 0; elem179 < elem178.size; ++elem179) {
+					ItsAnEnum elem180 = ItsAnEnum.findByValue(iprot.readI32());
+					struct.Enums.add(elem180);
 				}
 				struct.setEnumsIsSet(true);
 			}
@@ -1537,6 +1921,23 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			if (incoming.get(8)) {
 				struct.typedefOfTypedef = iprot.readString();
 				struct.setTypedefOfTypedefIsSet(true);
+			}
+			if (incoming.get(9)) {
+				struct.depr = iprot.readBool();
+				struct.setDeprIsSet(true);
+			}
+			if (incoming.get(10)) {
+				struct.deprBinary = iprot.readBinary();
+				struct.setDeprBinaryIsSet(true);
+			}
+			if (incoming.get(11)) {
+				org.apache.thrift.protocol.TList elem181 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.BOOL, iprot.readI32());
+				struct.deprList = new ArrayList<Boolean>(elem181.size);
+				for (int elem182 = 0; elem182 < elem181.size; ++elem182) {
+					boolean elem183 = iprot.readBool();
+					struct.deprList.add(elem183);
+				}
+				struct.setDeprListIsSet(true);
 			}
 		}
 

--- a/test/expected/java/variety/EventWrapper.java
+++ b/test/expected/java/variety/EventWrapper.java
@@ -656,6 +656,7 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		return this;
 	}
 
+	@Deprecated
 	public void unsetDepr() {
 		__isset_bitfield = EncodingUtils.clearBit(__isset_bitfield, __DEPR_ISSET_ID);
 	}
@@ -693,6 +694,7 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		return this;
 	}
 
+	@Deprecated
 	public void unsetDeprBinary() {
 		this.deprBinary = null;
 	}
@@ -739,6 +741,7 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		return this;
 	}
 
+	@Deprecated
 	public void unsetDeprList() {
 		this.deprList = null;
 	}

--- a/test/expected/java/variety/EventsPublisher.java
+++ b/test/expected/java/variety/EventsPublisher.java
@@ -165,8 +165,8 @@ public class EventsPublisher {
 				FProtocol oprot = protocolFactory.getProtocol(memoryBuffer);
 				oprot.writeRequestHeader(ctx);
 				oprot.writeMessageBegin(new TMessage(op, TMessageType.CALL, 0));
-				long elem272 = req;
-				oprot.writeI64(elem272);
+				long elem290 = req;
+				oprot.writeI64(elem290);
 				oprot.writeMessageEnd();
 				transport.publish(topic, memoryBuffer.getWriteBytes());
 			}
@@ -181,8 +181,8 @@ public class EventsPublisher {
 				FProtocol oprot = protocolFactory.getProtocol(memoryBuffer);
 				oprot.writeRequestHeader(ctx);
 				oprot.writeMessageBegin(new TMessage(op, TMessageType.CALL, 0));
-				String elem273 = req;
-				oprot.writeString(elem273);
+				String elem291 = req;
+				oprot.writeString(elem291);
 				oprot.writeMessageEnd();
 				transport.publish(topic, memoryBuffer.getWriteBytes());
 			}
@@ -198,12 +198,12 @@ public class EventsPublisher {
 				oprot.writeRequestHeader(ctx);
 				oprot.writeMessageBegin(new TMessage(op, TMessageType.CALL, 0));
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.MAP, req.size()));
-				for (java.util.Map<Long, Event> elem274 : req) {
-					oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, elem274.size()));
-					for (Map.Entry<Long, Event> elem275 : elem274.entrySet()) {
-						long elem276 = elem275.getKey();
-						oprot.writeI64(elem276);
-						elem275.getValue().write(oprot);
+				for (java.util.Map<Long, Event> elem292 : req) {
+					oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, elem292.size()));
+					for (Map.Entry<Long, Event> elem293 : elem292.entrySet()) {
+						long elem294 = elem293.getKey();
+						oprot.writeI64(elem294);
+						elem293.getValue().write(oprot);
 					}
 					oprot.writeMapEnd();
 				}

--- a/test/expected/java/variety/EventsPublisher.java
+++ b/test/expected/java/variety/EventsPublisher.java
@@ -165,8 +165,8 @@ public class EventsPublisher {
 				FProtocol oprot = protocolFactory.getProtocol(memoryBuffer);
 				oprot.writeRequestHeader(ctx);
 				oprot.writeMessageBegin(new TMessage(op, TMessageType.CALL, 0));
-				long elem290 = req;
-				oprot.writeI64(elem290);
+				long elem292 = req;
+				oprot.writeI64(elem292);
 				oprot.writeMessageEnd();
 				transport.publish(topic, memoryBuffer.getWriteBytes());
 			}
@@ -181,8 +181,8 @@ public class EventsPublisher {
 				FProtocol oprot = protocolFactory.getProtocol(memoryBuffer);
 				oprot.writeRequestHeader(ctx);
 				oprot.writeMessageBegin(new TMessage(op, TMessageType.CALL, 0));
-				String elem291 = req;
-				oprot.writeString(elem291);
+				String elem293 = req;
+				oprot.writeString(elem293);
 				oprot.writeMessageEnd();
 				transport.publish(topic, memoryBuffer.getWriteBytes());
 			}
@@ -198,12 +198,12 @@ public class EventsPublisher {
 				oprot.writeRequestHeader(ctx);
 				oprot.writeMessageBegin(new TMessage(op, TMessageType.CALL, 0));
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.MAP, req.size()));
-				for (java.util.Map<Long, Event> elem292 : req) {
-					oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, elem292.size()));
-					for (Map.Entry<Long, Event> elem293 : elem292.entrySet()) {
-						long elem294 = elem293.getKey();
-						oprot.writeI64(elem294);
-						elem293.getValue().write(oprot);
+				for (java.util.Map<Long, Event> elem294 : req) {
+					oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, elem294.size()));
+					for (Map.Entry<Long, Event> elem295 : elem294.entrySet()) {
+						long elem296 = elem295.getKey();
+						oprot.writeI64(elem296);
+						elem295.getValue().write(oprot);
 					}
 					oprot.writeMapEnd();
 				}

--- a/test/expected/java/variety/EventsSubscriber.java
+++ b/test/expected/java/variety/EventsSubscriber.java
@@ -242,19 +242,19 @@ public class EventsSubscriber {
 						iprot.readMessageEnd();
 						throw new TApplicationException(TApplicationExceptionType.UNKNOWN_METHOD);
 					}
-					org.apache.thrift.protocol.TList elem277 = iprot.readListBegin();
-					java.util.List<java.util.Map<Long, Event>> received = new ArrayList<java.util.Map<Long, Event>>(elem277.size);
-					for (int elem278 = 0; elem278 < elem277.size; ++elem278) {
-						org.apache.thrift.protocol.TMap elem280 = iprot.readMapBegin();
-						java.util.Map<Long, Event> elem279 = new HashMap<Long,Event>(2*elem280.size);
-						for (int elem281 = 0; elem281 < elem280.size; ++elem281) {
-							long elem283 = iprot.readI64();
-							Event elem282 = new Event();
-							elem282.read(iprot);
-							elem279.put(elem283, elem282);
+					org.apache.thrift.protocol.TList elem295 = iprot.readListBegin();
+					java.util.List<java.util.Map<Long, Event>> received = new ArrayList<java.util.Map<Long, Event>>(elem295.size);
+					for (int elem296 = 0; elem296 < elem295.size; ++elem296) {
+						org.apache.thrift.protocol.TMap elem298 = iprot.readMapBegin();
+						java.util.Map<Long, Event> elem297 = new HashMap<Long,Event>(2*elem298.size);
+						for (int elem299 = 0; elem299 < elem298.size; ++elem299) {
+							long elem301 = iprot.readI64();
+							Event elem300 = new Event();
+							elem300.read(iprot);
+							elem297.put(elem301, elem300);
 						}
 						iprot.readMapEnd();
-						received.add(elem279);
+						received.add(elem297);
 					}
 					iprot.readListEnd();
 					iprot.readMessageEnd();
@@ -376,19 +376,19 @@ public class EventsSubscriber {
 						iprot.readMessageEnd();
 						throw new TApplicationException(TApplicationExceptionType.UNKNOWN_METHOD);
 					}
-					org.apache.thrift.protocol.TList elem284 = iprot.readListBegin();
-					java.util.List<java.util.Map<Long, Event>> received = new ArrayList<java.util.Map<Long, Event>>(elem284.size);
-					for (int elem285 = 0; elem285 < elem284.size; ++elem285) {
-						org.apache.thrift.protocol.TMap elem287 = iprot.readMapBegin();
-						java.util.Map<Long, Event> elem286 = new HashMap<Long,Event>(2*elem287.size);
-						for (int elem288 = 0; elem288 < elem287.size; ++elem288) {
-							long elem290 = iprot.readI64();
-							Event elem289 = new Event();
-							elem289.read(iprot);
-							elem286.put(elem290, elem289);
+					org.apache.thrift.protocol.TList elem302 = iprot.readListBegin();
+					java.util.List<java.util.Map<Long, Event>> received = new ArrayList<java.util.Map<Long, Event>>(elem302.size);
+					for (int elem303 = 0; elem303 < elem302.size; ++elem303) {
+						org.apache.thrift.protocol.TMap elem305 = iprot.readMapBegin();
+						java.util.Map<Long, Event> elem304 = new HashMap<Long,Event>(2*elem305.size);
+						for (int elem306 = 0; elem306 < elem305.size; ++elem306) {
+							long elem308 = iprot.readI64();
+							Event elem307 = new Event();
+							elem307.read(iprot);
+							elem304.put(elem308, elem307);
 						}
 						iprot.readMapEnd();
-						received.add(elem286);
+						received.add(elem304);
 					}
 					iprot.readListEnd();
 					iprot.readMessageEnd();

--- a/test/expected/java/variety/EventsSubscriber.java
+++ b/test/expected/java/variety/EventsSubscriber.java
@@ -242,19 +242,19 @@ public class EventsSubscriber {
 						iprot.readMessageEnd();
 						throw new TApplicationException(TApplicationExceptionType.UNKNOWN_METHOD);
 					}
-					org.apache.thrift.protocol.TList elem295 = iprot.readListBegin();
-					java.util.List<java.util.Map<Long, Event>> received = new ArrayList<java.util.Map<Long, Event>>(elem295.size);
-					for (int elem296 = 0; elem296 < elem295.size; ++elem296) {
-						org.apache.thrift.protocol.TMap elem298 = iprot.readMapBegin();
-						java.util.Map<Long, Event> elem297 = new HashMap<Long,Event>(2*elem298.size);
-						for (int elem299 = 0; elem299 < elem298.size; ++elem299) {
-							long elem301 = iprot.readI64();
-							Event elem300 = new Event();
-							elem300.read(iprot);
-							elem297.put(elem301, elem300);
+					org.apache.thrift.protocol.TList elem297 = iprot.readListBegin();
+					java.util.List<java.util.Map<Long, Event>> received = new ArrayList<java.util.Map<Long, Event>>(elem297.size);
+					for (int elem298 = 0; elem298 < elem297.size; ++elem298) {
+						org.apache.thrift.protocol.TMap elem300 = iprot.readMapBegin();
+						java.util.Map<Long, Event> elem299 = new HashMap<Long,Event>(2*elem300.size);
+						for (int elem301 = 0; elem301 < elem300.size; ++elem301) {
+							long elem303 = iprot.readI64();
+							Event elem302 = new Event();
+							elem302.read(iprot);
+							elem299.put(elem303, elem302);
 						}
 						iprot.readMapEnd();
-						received.add(elem297);
+						received.add(elem299);
 					}
 					iprot.readListEnd();
 					iprot.readMessageEnd();
@@ -376,19 +376,19 @@ public class EventsSubscriber {
 						iprot.readMessageEnd();
 						throw new TApplicationException(TApplicationExceptionType.UNKNOWN_METHOD);
 					}
-					org.apache.thrift.protocol.TList elem302 = iprot.readListBegin();
-					java.util.List<java.util.Map<Long, Event>> received = new ArrayList<java.util.Map<Long, Event>>(elem302.size);
-					for (int elem303 = 0; elem303 < elem302.size; ++elem303) {
-						org.apache.thrift.protocol.TMap elem305 = iprot.readMapBegin();
-						java.util.Map<Long, Event> elem304 = new HashMap<Long,Event>(2*elem305.size);
-						for (int elem306 = 0; elem306 < elem305.size; ++elem306) {
-							long elem308 = iprot.readI64();
-							Event elem307 = new Event();
-							elem307.read(iprot);
-							elem304.put(elem308, elem307);
+					org.apache.thrift.protocol.TList elem304 = iprot.readListBegin();
+					java.util.List<java.util.Map<Long, Event>> received = new ArrayList<java.util.Map<Long, Event>>(elem304.size);
+					for (int elem305 = 0; elem305 < elem304.size; ++elem305) {
+						org.apache.thrift.protocol.TMap elem307 = iprot.readMapBegin();
+						java.util.Map<Long, Event> elem306 = new HashMap<Long,Event>(2*elem307.size);
+						for (int elem308 = 0; elem308 < elem307.size; ++elem308) {
+							long elem310 = iprot.readI64();
+							Event elem309 = new Event();
+							elem309.read(iprot);
+							elem306.put(elem310, elem309);
 						}
 						iprot.readMapEnd();
-						received.add(elem304);
+						received.add(elem306);
 					}
 					iprot.readListEnd();
 					iprot.readMessageEnd();

--- a/test/expected/java/variety/FFoo.java
+++ b/test/expected/java/variety/FFoo.java
@@ -1932,13 +1932,13 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(NUM_FIELD_DESC);
-			int elem196 = struct.num;
-			oprot.writeI32(elem196);
+			int elem214 = struct.num;
+			oprot.writeI32(elem214);
 			oprot.writeFieldEnd();
 			if (struct.Str != null) {
 				oprot.writeFieldBegin(STR_FIELD_DESC);
-				String elem197 = struct.Str;
-				oprot.writeString(elem197);
+				String elem215 = struct.Str;
+				oprot.writeString(elem215);
 				oprot.writeFieldEnd();
 			}
 			if (struct.event != null) {
@@ -1975,12 +1975,12 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetNum()) {
-				int elem198 = struct.num;
-				oprot.writeI32(elem198);
+				int elem216 = struct.num;
+				oprot.writeI32(elem216);
 			}
 			if (struct.isSetStr()) {
-				String elem199 = struct.Str;
-				oprot.writeString(elem199);
+				String elem217 = struct.Str;
+				oprot.writeString(elem217);
 			}
 			if (struct.isSetEvent()) {
 				struct.event.write(oprot);
@@ -2503,8 +2503,8 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				long elem200 = struct.success;
-				oprot.writeI64(elem200);
+				long elem218 = struct.success;
+				oprot.writeI64(elem218);
 				oprot.writeFieldEnd();
 			}
 			if (struct.awe != null) {
@@ -2546,8 +2546,8 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetSuccess()) {
-				long elem201 = struct.success;
-				oprot.writeI64(elem201);
+				long elem219 = struct.success;
+				oprot.writeI64(elem219);
 			}
 			if (struct.isSetAwe()) {
 				struct.awe.write(oprot);
@@ -2965,12 +2965,12 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 						break;
 					case 2: // REQ
 						if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
-							org.apache.thrift.protocol.TMap elem204 = iprot.readMapBegin();
-							struct.req = new HashMap<Integer,String>(2*elem204.size);
-							for (int elem205 = 0; elem205 < elem204.size; ++elem205) {
-								int elem207 = iprot.readI32();
-								String elem206 = iprot.readString();
-								struct.req.put(elem207, elem206);
+							org.apache.thrift.protocol.TMap elem222 = iprot.readMapBegin();
+							struct.req = new HashMap<Integer,String>(2*elem222.size);
+							for (int elem223 = 0; elem223 < elem222.size; ++elem223) {
+								int elem225 = iprot.readI32();
+								String elem224 = iprot.readString();
+								struct.req.put(elem225, elem224);
 							}
 							iprot.readMapEnd();
 							struct.setReqIsSet(true);
@@ -2994,17 +2994,17 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(ID_FIELD_DESC);
-			long elem208 = struct.id;
-			oprot.writeI64(elem208);
+			long elem226 = struct.id;
+			oprot.writeI64(elem226);
 			oprot.writeFieldEnd();
 			if (struct.req != null) {
 				oprot.writeFieldBegin(REQ_FIELD_DESC);
 				oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, struct.req.size()));
-				for (Map.Entry<Integer, String> elem209 : struct.req.entrySet()) {
-					int elem210 = elem209.getKey();
-					oprot.writeI32(elem210);
-					String elem211 = elem209.getValue();
-					oprot.writeString(elem211);
+				for (Map.Entry<Integer, String> elem227 : struct.req.entrySet()) {
+					int elem228 = elem227.getKey();
+					oprot.writeI32(elem228);
+					String elem229 = elem227.getValue();
+					oprot.writeString(elem229);
 				}
 				oprot.writeMapEnd();
 				oprot.writeFieldEnd();
@@ -3035,16 +3035,16 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetId()) {
-				long elem212 = struct.id;
-				oprot.writeI64(elem212);
+				long elem230 = struct.id;
+				oprot.writeI64(elem230);
 			}
 			if (struct.isSetReq()) {
 				oprot.writeI32(struct.req.size());
-				for (Map.Entry<Integer, String> elem213 : struct.req.entrySet()) {
-					int elem214 = elem213.getKey();
-					oprot.writeI32(elem214);
-					String elem215 = elem213.getValue();
-					oprot.writeString(elem215);
+				for (Map.Entry<Integer, String> elem231 : struct.req.entrySet()) {
+					int elem232 = elem231.getKey();
+					oprot.writeI32(elem232);
+					String elem233 = elem231.getValue();
+					oprot.writeString(elem233);
 				}
 			}
 		}
@@ -3058,12 +3058,12 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 				struct.setIdIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TMap elem216 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-				struct.req = new HashMap<Integer,String>(2*elem216.size);
-				for (int elem217 = 0; elem217 < elem216.size; ++elem217) {
-					int elem219 = iprot.readI32();
-					String elem218 = iprot.readString();
-					struct.req.put(elem219, elem218);
+				org.apache.thrift.protocol.TMap elem234 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+				struct.req = new HashMap<Integer,String>(2*elem234.size);
+				for (int elem235 = 0; elem235 < elem234.size; ++elem235) {
+					int elem237 = iprot.readI32();
+					String elem236 = iprot.readString();
+					struct.req.put(elem237, elem236);
 				}
 				struct.setReqIsSet(true);
 			}
@@ -3480,14 +3480,14 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.bin != null) {
 				oprot.writeFieldBegin(BIN_FIELD_DESC);
-				java.nio.ByteBuffer elem220 = struct.bin;
-				oprot.writeBinary(elem220);
+				java.nio.ByteBuffer elem238 = struct.bin;
+				oprot.writeBinary(elem238);
 				oprot.writeFieldEnd();
 			}
 			if (struct.Str != null) {
 				oprot.writeFieldBegin(STR_FIELD_DESC);
-				String elem221 = struct.Str;
-				oprot.writeString(elem221);
+				String elem239 = struct.Str;
+				oprot.writeString(elem239);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -3516,12 +3516,12 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetBin()) {
-				java.nio.ByteBuffer elem222 = struct.bin;
-				oprot.writeBinary(elem222);
+				java.nio.ByteBuffer elem240 = struct.bin;
+				oprot.writeBinary(elem240);
 			}
 			if (struct.isSetStr()) {
-				String elem223 = struct.Str;
-				oprot.writeString(elem223);
+				String elem241 = struct.Str;
+				oprot.writeString(elem241);
 			}
 		}
 
@@ -3954,8 +3954,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.success != null) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				java.nio.ByteBuffer elem224 = struct.success;
-				oprot.writeBinary(elem224);
+				java.nio.ByteBuffer elem242 = struct.success;
+				oprot.writeBinary(elem242);
 				oprot.writeFieldEnd();
 			}
 			if (struct.api != null) {
@@ -3989,8 +3989,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetSuccess()) {
-				java.nio.ByteBuffer elem225 = struct.success;
-				oprot.writeBinary(elem225);
+				java.nio.ByteBuffer elem243 = struct.success;
+				oprot.writeBinary(elem243);
 			}
 			if (struct.isSetApi()) {
 				struct.api.write(oprot);
@@ -4495,16 +4495,16 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(OPT_NUM_FIELD_DESC);
-			int elem226 = struct.opt_num;
-			oprot.writeI32(elem226);
+			int elem244 = struct.opt_num;
+			oprot.writeI32(elem244);
 			oprot.writeFieldEnd();
 			oprot.writeFieldBegin(DEFAULT_NUM_FIELD_DESC);
-			int elem227 = struct.default_num;
-			oprot.writeI32(elem227);
+			int elem245 = struct.default_num;
+			oprot.writeI32(elem245);
 			oprot.writeFieldEnd();
 			oprot.writeFieldBegin(REQ_NUM_FIELD_DESC);
-			int elem228 = struct.req_num;
-			oprot.writeI32(elem228);
+			int elem246 = struct.req_num;
+			oprot.writeI32(elem246);
 			oprot.writeFieldEnd();
 			oprot.writeFieldStop();
 			oprot.writeStructEnd();
@@ -4523,8 +4523,8 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 		@Override
 		public void write(org.apache.thrift.protocol.TProtocol prot, param_modifiers_args struct) throws org.apache.thrift.TException {
 			TTupleProtocol oprot = (TTupleProtocol) prot;
-			int elem229 = struct.req_num;
-			oprot.writeI32(elem229);
+			int elem247 = struct.req_num;
+			oprot.writeI32(elem247);
 			BitSet optionals = new BitSet();
 			if (struct.isSetOpt_num()) {
 				optionals.set(0);
@@ -4534,12 +4534,12 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetOpt_num()) {
-				int elem230 = struct.opt_num;
-				oprot.writeI32(elem230);
+				int elem248 = struct.opt_num;
+				oprot.writeI32(elem248);
 			}
 			if (struct.isSetDefault_num()) {
-				int elem231 = struct.default_num;
-				oprot.writeI32(elem231);
+				int elem249 = struct.default_num;
+				oprot.writeI32(elem249);
 			}
 		}
 
@@ -4870,8 +4870,8 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				long elem232 = struct.success;
-				oprot.writeI64(elem232);
+				long elem250 = struct.success;
+				oprot.writeI64(elem250);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -4897,8 +4897,8 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 			}
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
-				long elem233 = struct.success;
-				oprot.writeI64(elem233);
+				long elem251 = struct.success;
+				oprot.writeI64(elem251);
 			}
 		}
 
@@ -5009,16 +5009,16 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 	public underlying_types_test_args(underlying_types_test_args other) {
 		if (other.isSetList_type()) {
 			this.list_type = new ArrayList<Long>(other.list_type.size());
-			for (long elem234 : other.list_type) {
-				long elem235 = elem234;
-				this.list_type.add(elem235);
+			for (long elem252 : other.list_type) {
+				long elem253 = elem252;
+				this.list_type.add(elem253);
 			}
 		}
 		if (other.isSetSet_type()) {
 			this.set_type = new HashSet<Long>(other.set_type.size());
-			for (long elem236 : other.set_type) {
-				long elem237 = elem236;
-				this.set_type.add(elem237);
+			for (long elem254 : other.set_type) {
+				long elem255 = elem254;
+				this.set_type.add(elem255);
 			}
 		}
 	}
@@ -5320,11 +5320,11 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 				switch (schemeField.id) {
 					case 1: // LIST_TYPE
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem238 = iprot.readListBegin();
-							struct.list_type = new ArrayList<Long>(elem238.size);
-							for (int elem239 = 0; elem239 < elem238.size; ++elem239) {
-								long elem240 = iprot.readI64();
-								struct.list_type.add(elem240);
+							org.apache.thrift.protocol.TList elem256 = iprot.readListBegin();
+							struct.list_type = new ArrayList<Long>(elem256.size);
+							for (int elem257 = 0; elem257 < elem256.size; ++elem257) {
+								long elem258 = iprot.readI64();
+								struct.list_type.add(elem258);
 							}
 							iprot.readListEnd();
 							struct.setList_typeIsSet(true);
@@ -5334,11 +5334,11 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 						break;
 					case 2: // SET_TYPE
 						if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
-							org.apache.thrift.protocol.TSet elem241 = iprot.readSetBegin();
-							struct.set_type = new HashSet<Long>(2*elem241.size);
-							for (int elem242 = 0; elem242 < elem241.size; ++elem242) {
-								long elem243 = iprot.readI64();
-								struct.set_type.add(elem243);
+							org.apache.thrift.protocol.TSet elem259 = iprot.readSetBegin();
+							struct.set_type = new HashSet<Long>(2*elem259.size);
+							for (int elem260 = 0; elem260 < elem259.size; ++elem260) {
+								long elem261 = iprot.readI64();
+								struct.set_type.add(elem261);
 							}
 							iprot.readSetEnd();
 							struct.setSet_typeIsSet(true);
@@ -5364,9 +5364,9 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			if (struct.list_type != null) {
 				oprot.writeFieldBegin(LIST_TYPE_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.list_type.size()));
-				for (long elem244 : struct.list_type) {
-					long elem245 = elem244;
-					oprot.writeI64(elem245);
+				for (long elem262 : struct.list_type) {
+					long elem263 = elem262;
+					oprot.writeI64(elem263);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -5374,9 +5374,9 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			if (struct.set_type != null) {
 				oprot.writeFieldBegin(SET_TYPE_FIELD_DESC);
 				oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, struct.set_type.size()));
-				for (long elem246 : struct.set_type) {
-					long elem247 = elem246;
-					oprot.writeI64(elem247);
+				for (long elem264 : struct.set_type) {
+					long elem265 = elem264;
+					oprot.writeI64(elem265);
 				}
 				oprot.writeSetEnd();
 				oprot.writeFieldEnd();
@@ -5408,16 +5408,16 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetList_type()) {
 				oprot.writeI32(struct.list_type.size());
-				for (long elem248 : struct.list_type) {
-					long elem249 = elem248;
-					oprot.writeI64(elem249);
+				for (long elem266 : struct.list_type) {
+					long elem267 = elem266;
+					oprot.writeI64(elem267);
 				}
 			}
 			if (struct.isSetSet_type()) {
 				oprot.writeI32(struct.set_type.size());
-				for (long elem250 : struct.set_type) {
-					long elem251 = elem250;
-					oprot.writeI64(elem251);
+				for (long elem268 : struct.set_type) {
+					long elem269 = elem268;
+					oprot.writeI64(elem269);
 				}
 			}
 		}
@@ -5427,20 +5427,20 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(2);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem252 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.list_type = new ArrayList<Long>(elem252.size);
-				for (int elem253 = 0; elem253 < elem252.size; ++elem253) {
-					long elem254 = iprot.readI64();
-					struct.list_type.add(elem254);
+				org.apache.thrift.protocol.TList elem270 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.list_type = new ArrayList<Long>(elem270.size);
+				for (int elem271 = 0; elem271 < elem270.size; ++elem271) {
+					long elem272 = iprot.readI64();
+					struct.list_type.add(elem272);
 				}
 				struct.setList_typeIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TSet elem255 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.set_type = new HashSet<Long>(2*elem255.size);
-				for (int elem256 = 0; elem256 < elem255.size; ++elem256) {
-					long elem257 = iprot.readI64();
-					struct.set_type.add(elem257);
+				org.apache.thrift.protocol.TSet elem273 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.set_type = new HashSet<Long>(2*elem273.size);
+				for (int elem274 = 0; elem274 < elem273.size; ++elem274) {
+					long elem275 = iprot.readI64();
+					struct.set_type.add(elem275);
 				}
 				struct.setSet_typeIsSet(true);
 			}
@@ -5536,9 +5536,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 	public underlying_types_test_result(underlying_types_test_result other) {
 		if (other.isSetSuccess()) {
 			this.success = new ArrayList<Long>(other.success.size());
-			for (long elem258 : other.success) {
-				long elem259 = elem258;
-				this.success.add(elem259);
+			for (long elem276 : other.success) {
+				long elem277 = elem276;
+				this.success.add(elem277);
 			}
 		}
 	}
@@ -5754,11 +5754,11 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 				switch (schemeField.id) {
 					case 0: // SUCCESS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem260 = iprot.readListBegin();
-							struct.success = new ArrayList<Long>(elem260.size);
-							for (int elem261 = 0; elem261 < elem260.size; ++elem261) {
-								long elem262 = iprot.readI64();
-								struct.success.add(elem262);
+							org.apache.thrift.protocol.TList elem278 = iprot.readListBegin();
+							struct.success = new ArrayList<Long>(elem278.size);
+							for (int elem279 = 0; elem279 < elem278.size; ++elem279) {
+								long elem280 = iprot.readI64();
+								struct.success.add(elem280);
 							}
 							iprot.readListEnd();
 							struct.setSuccessIsSet(true);
@@ -5784,9 +5784,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			if (struct.success != null) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.success.size()));
-				for (long elem263 : struct.success) {
-					long elem264 = elem263;
-					oprot.writeI64(elem264);
+				for (long elem281 : struct.success) {
+					long elem282 = elem281;
+					oprot.writeI64(elem282);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -5815,9 +5815,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
 				oprot.writeI32(struct.success.size());
-				for (long elem265 : struct.success) {
-					long elem266 = elem265;
-					oprot.writeI64(elem266);
+				for (long elem283 : struct.success) {
+					long elem284 = elem283;
+					oprot.writeI64(elem284);
 				}
 			}
 		}
@@ -5827,11 +5827,11 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(1);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem267 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.success = new ArrayList<Long>(elem267.size);
-				for (int elem268 = 0; elem268 < elem267.size; ++elem268) {
-					long elem269 = iprot.readI64();
-					struct.success.add(elem269);
+				org.apache.thrift.protocol.TList elem285 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.success = new ArrayList<Long>(elem285.size);
+				for (int elem286 = 0; elem286 < elem285.size; ++elem286) {
+					long elem287 = iprot.readI64();
+					struct.success.add(elem287);
 				}
 				struct.setSuccessIsSet(true);
 			}
@@ -6989,8 +6989,8 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				int elem270 = struct.success;
-				oprot.writeI32(elem270);
+				int elem288 = struct.success;
+				oprot.writeI32(elem288);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -7016,8 +7016,8 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 			}
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
-				int elem271 = struct.success;
-				oprot.writeI32(elem271);
+				int elem289 = struct.success;
+				oprot.writeI32(elem289);
 			}
 		}
 

--- a/test/expected/java/variety/FFoo.java
+++ b/test/expected/java/variety/FFoo.java
@@ -1932,13 +1932,13 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(NUM_FIELD_DESC);
-			int elem214 = struct.num;
-			oprot.writeI32(elem214);
+			int elem216 = struct.num;
+			oprot.writeI32(elem216);
 			oprot.writeFieldEnd();
 			if (struct.Str != null) {
 				oprot.writeFieldBegin(STR_FIELD_DESC);
-				String elem215 = struct.Str;
-				oprot.writeString(elem215);
+				String elem217 = struct.Str;
+				oprot.writeString(elem217);
 				oprot.writeFieldEnd();
 			}
 			if (struct.event != null) {
@@ -1975,12 +1975,12 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetNum()) {
-				int elem216 = struct.num;
-				oprot.writeI32(elem216);
+				int elem218 = struct.num;
+				oprot.writeI32(elem218);
 			}
 			if (struct.isSetStr()) {
-				String elem217 = struct.Str;
-				oprot.writeString(elem217);
+				String elem219 = struct.Str;
+				oprot.writeString(elem219);
 			}
 			if (struct.isSetEvent()) {
 				struct.event.write(oprot);
@@ -2503,8 +2503,8 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				long elem218 = struct.success;
-				oprot.writeI64(elem218);
+				long elem220 = struct.success;
+				oprot.writeI64(elem220);
 				oprot.writeFieldEnd();
 			}
 			if (struct.awe != null) {
@@ -2546,8 +2546,8 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetSuccess()) {
-				long elem219 = struct.success;
-				oprot.writeI64(elem219);
+				long elem221 = struct.success;
+				oprot.writeI64(elem221);
 			}
 			if (struct.isSetAwe()) {
 				struct.awe.write(oprot);
@@ -2965,12 +2965,12 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 						break;
 					case 2: // REQ
 						if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
-							org.apache.thrift.protocol.TMap elem222 = iprot.readMapBegin();
-							struct.req = new HashMap<Integer,String>(2*elem222.size);
-							for (int elem223 = 0; elem223 < elem222.size; ++elem223) {
-								int elem225 = iprot.readI32();
-								String elem224 = iprot.readString();
-								struct.req.put(elem225, elem224);
+							org.apache.thrift.protocol.TMap elem224 = iprot.readMapBegin();
+							struct.req = new HashMap<Integer,String>(2*elem224.size);
+							for (int elem225 = 0; elem225 < elem224.size; ++elem225) {
+								int elem227 = iprot.readI32();
+								String elem226 = iprot.readString();
+								struct.req.put(elem227, elem226);
 							}
 							iprot.readMapEnd();
 							struct.setReqIsSet(true);
@@ -2994,17 +2994,17 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(ID_FIELD_DESC);
-			long elem226 = struct.id;
-			oprot.writeI64(elem226);
+			long elem228 = struct.id;
+			oprot.writeI64(elem228);
 			oprot.writeFieldEnd();
 			if (struct.req != null) {
 				oprot.writeFieldBegin(REQ_FIELD_DESC);
 				oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, struct.req.size()));
-				for (Map.Entry<Integer, String> elem227 : struct.req.entrySet()) {
-					int elem228 = elem227.getKey();
-					oprot.writeI32(elem228);
-					String elem229 = elem227.getValue();
-					oprot.writeString(elem229);
+				for (Map.Entry<Integer, String> elem229 : struct.req.entrySet()) {
+					int elem230 = elem229.getKey();
+					oprot.writeI32(elem230);
+					String elem231 = elem229.getValue();
+					oprot.writeString(elem231);
 				}
 				oprot.writeMapEnd();
 				oprot.writeFieldEnd();
@@ -3035,16 +3035,16 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetId()) {
-				long elem230 = struct.id;
-				oprot.writeI64(elem230);
+				long elem232 = struct.id;
+				oprot.writeI64(elem232);
 			}
 			if (struct.isSetReq()) {
 				oprot.writeI32(struct.req.size());
-				for (Map.Entry<Integer, String> elem231 : struct.req.entrySet()) {
-					int elem232 = elem231.getKey();
-					oprot.writeI32(elem232);
-					String elem233 = elem231.getValue();
-					oprot.writeString(elem233);
+				for (Map.Entry<Integer, String> elem233 : struct.req.entrySet()) {
+					int elem234 = elem233.getKey();
+					oprot.writeI32(elem234);
+					String elem235 = elem233.getValue();
+					oprot.writeString(elem235);
 				}
 			}
 		}
@@ -3058,12 +3058,12 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 				struct.setIdIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TMap elem234 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-				struct.req = new HashMap<Integer,String>(2*elem234.size);
-				for (int elem235 = 0; elem235 < elem234.size; ++elem235) {
-					int elem237 = iprot.readI32();
-					String elem236 = iprot.readString();
-					struct.req.put(elem237, elem236);
+				org.apache.thrift.protocol.TMap elem236 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+				struct.req = new HashMap<Integer,String>(2*elem236.size);
+				for (int elem237 = 0; elem237 < elem236.size; ++elem237) {
+					int elem239 = iprot.readI32();
+					String elem238 = iprot.readString();
+					struct.req.put(elem239, elem238);
 				}
 				struct.setReqIsSet(true);
 			}
@@ -3480,14 +3480,14 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.bin != null) {
 				oprot.writeFieldBegin(BIN_FIELD_DESC);
-				java.nio.ByteBuffer elem238 = struct.bin;
-				oprot.writeBinary(elem238);
+				java.nio.ByteBuffer elem240 = struct.bin;
+				oprot.writeBinary(elem240);
 				oprot.writeFieldEnd();
 			}
 			if (struct.Str != null) {
 				oprot.writeFieldBegin(STR_FIELD_DESC);
-				String elem239 = struct.Str;
-				oprot.writeString(elem239);
+				String elem241 = struct.Str;
+				oprot.writeString(elem241);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -3516,12 +3516,12 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetBin()) {
-				java.nio.ByteBuffer elem240 = struct.bin;
-				oprot.writeBinary(elem240);
+				java.nio.ByteBuffer elem242 = struct.bin;
+				oprot.writeBinary(elem242);
 			}
 			if (struct.isSetStr()) {
-				String elem241 = struct.Str;
-				oprot.writeString(elem241);
+				String elem243 = struct.Str;
+				oprot.writeString(elem243);
 			}
 		}
 
@@ -3954,8 +3954,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.success != null) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				java.nio.ByteBuffer elem242 = struct.success;
-				oprot.writeBinary(elem242);
+				java.nio.ByteBuffer elem244 = struct.success;
+				oprot.writeBinary(elem244);
 				oprot.writeFieldEnd();
 			}
 			if (struct.api != null) {
@@ -3989,8 +3989,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetSuccess()) {
-				java.nio.ByteBuffer elem243 = struct.success;
-				oprot.writeBinary(elem243);
+				java.nio.ByteBuffer elem245 = struct.success;
+				oprot.writeBinary(elem245);
 			}
 			if (struct.isSetApi()) {
 				struct.api.write(oprot);
@@ -4495,16 +4495,16 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(OPT_NUM_FIELD_DESC);
-			int elem244 = struct.opt_num;
-			oprot.writeI32(elem244);
+			int elem246 = struct.opt_num;
+			oprot.writeI32(elem246);
 			oprot.writeFieldEnd();
 			oprot.writeFieldBegin(DEFAULT_NUM_FIELD_DESC);
-			int elem245 = struct.default_num;
-			oprot.writeI32(elem245);
+			int elem247 = struct.default_num;
+			oprot.writeI32(elem247);
 			oprot.writeFieldEnd();
 			oprot.writeFieldBegin(REQ_NUM_FIELD_DESC);
-			int elem246 = struct.req_num;
-			oprot.writeI32(elem246);
+			int elem248 = struct.req_num;
+			oprot.writeI32(elem248);
 			oprot.writeFieldEnd();
 			oprot.writeFieldStop();
 			oprot.writeStructEnd();
@@ -4523,8 +4523,8 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 		@Override
 		public void write(org.apache.thrift.protocol.TProtocol prot, param_modifiers_args struct) throws org.apache.thrift.TException {
 			TTupleProtocol oprot = (TTupleProtocol) prot;
-			int elem247 = struct.req_num;
-			oprot.writeI32(elem247);
+			int elem249 = struct.req_num;
+			oprot.writeI32(elem249);
 			BitSet optionals = new BitSet();
 			if (struct.isSetOpt_num()) {
 				optionals.set(0);
@@ -4534,12 +4534,12 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetOpt_num()) {
-				int elem248 = struct.opt_num;
-				oprot.writeI32(elem248);
+				int elem250 = struct.opt_num;
+				oprot.writeI32(elem250);
 			}
 			if (struct.isSetDefault_num()) {
-				int elem249 = struct.default_num;
-				oprot.writeI32(elem249);
+				int elem251 = struct.default_num;
+				oprot.writeI32(elem251);
 			}
 		}
 
@@ -4870,8 +4870,8 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				long elem250 = struct.success;
-				oprot.writeI64(elem250);
+				long elem252 = struct.success;
+				oprot.writeI64(elem252);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -4897,8 +4897,8 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 			}
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
-				long elem251 = struct.success;
-				oprot.writeI64(elem251);
+				long elem253 = struct.success;
+				oprot.writeI64(elem253);
 			}
 		}
 
@@ -5009,16 +5009,16 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 	public underlying_types_test_args(underlying_types_test_args other) {
 		if (other.isSetList_type()) {
 			this.list_type = new ArrayList<Long>(other.list_type.size());
-			for (long elem252 : other.list_type) {
-				long elem253 = elem252;
-				this.list_type.add(elem253);
+			for (long elem254 : other.list_type) {
+				long elem255 = elem254;
+				this.list_type.add(elem255);
 			}
 		}
 		if (other.isSetSet_type()) {
 			this.set_type = new HashSet<Long>(other.set_type.size());
-			for (long elem254 : other.set_type) {
-				long elem255 = elem254;
-				this.set_type.add(elem255);
+			for (long elem256 : other.set_type) {
+				long elem257 = elem256;
+				this.set_type.add(elem257);
 			}
 		}
 	}
@@ -5320,11 +5320,11 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 				switch (schemeField.id) {
 					case 1: // LIST_TYPE
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem256 = iprot.readListBegin();
-							struct.list_type = new ArrayList<Long>(elem256.size);
-							for (int elem257 = 0; elem257 < elem256.size; ++elem257) {
-								long elem258 = iprot.readI64();
-								struct.list_type.add(elem258);
+							org.apache.thrift.protocol.TList elem258 = iprot.readListBegin();
+							struct.list_type = new ArrayList<Long>(elem258.size);
+							for (int elem259 = 0; elem259 < elem258.size; ++elem259) {
+								long elem260 = iprot.readI64();
+								struct.list_type.add(elem260);
 							}
 							iprot.readListEnd();
 							struct.setList_typeIsSet(true);
@@ -5334,11 +5334,11 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 						break;
 					case 2: // SET_TYPE
 						if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
-							org.apache.thrift.protocol.TSet elem259 = iprot.readSetBegin();
-							struct.set_type = new HashSet<Long>(2*elem259.size);
-							for (int elem260 = 0; elem260 < elem259.size; ++elem260) {
-								long elem261 = iprot.readI64();
-								struct.set_type.add(elem261);
+							org.apache.thrift.protocol.TSet elem261 = iprot.readSetBegin();
+							struct.set_type = new HashSet<Long>(2*elem261.size);
+							for (int elem262 = 0; elem262 < elem261.size; ++elem262) {
+								long elem263 = iprot.readI64();
+								struct.set_type.add(elem263);
 							}
 							iprot.readSetEnd();
 							struct.setSet_typeIsSet(true);
@@ -5364,9 +5364,9 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			if (struct.list_type != null) {
 				oprot.writeFieldBegin(LIST_TYPE_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.list_type.size()));
-				for (long elem262 : struct.list_type) {
-					long elem263 = elem262;
-					oprot.writeI64(elem263);
+				for (long elem264 : struct.list_type) {
+					long elem265 = elem264;
+					oprot.writeI64(elem265);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -5374,9 +5374,9 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			if (struct.set_type != null) {
 				oprot.writeFieldBegin(SET_TYPE_FIELD_DESC);
 				oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, struct.set_type.size()));
-				for (long elem264 : struct.set_type) {
-					long elem265 = elem264;
-					oprot.writeI64(elem265);
+				for (long elem266 : struct.set_type) {
+					long elem267 = elem266;
+					oprot.writeI64(elem267);
 				}
 				oprot.writeSetEnd();
 				oprot.writeFieldEnd();
@@ -5408,16 +5408,16 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetList_type()) {
 				oprot.writeI32(struct.list_type.size());
-				for (long elem266 : struct.list_type) {
-					long elem267 = elem266;
-					oprot.writeI64(elem267);
+				for (long elem268 : struct.list_type) {
+					long elem269 = elem268;
+					oprot.writeI64(elem269);
 				}
 			}
 			if (struct.isSetSet_type()) {
 				oprot.writeI32(struct.set_type.size());
-				for (long elem268 : struct.set_type) {
-					long elem269 = elem268;
-					oprot.writeI64(elem269);
+				for (long elem270 : struct.set_type) {
+					long elem271 = elem270;
+					oprot.writeI64(elem271);
 				}
 			}
 		}
@@ -5427,20 +5427,20 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(2);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem270 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.list_type = new ArrayList<Long>(elem270.size);
-				for (int elem271 = 0; elem271 < elem270.size; ++elem271) {
-					long elem272 = iprot.readI64();
-					struct.list_type.add(elem272);
+				org.apache.thrift.protocol.TList elem272 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.list_type = new ArrayList<Long>(elem272.size);
+				for (int elem273 = 0; elem273 < elem272.size; ++elem273) {
+					long elem274 = iprot.readI64();
+					struct.list_type.add(elem274);
 				}
 				struct.setList_typeIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TSet elem273 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.set_type = new HashSet<Long>(2*elem273.size);
-				for (int elem274 = 0; elem274 < elem273.size; ++elem274) {
-					long elem275 = iprot.readI64();
-					struct.set_type.add(elem275);
+				org.apache.thrift.protocol.TSet elem275 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.set_type = new HashSet<Long>(2*elem275.size);
+				for (int elem276 = 0; elem276 < elem275.size; ++elem276) {
+					long elem277 = iprot.readI64();
+					struct.set_type.add(elem277);
 				}
 				struct.setSet_typeIsSet(true);
 			}
@@ -5536,9 +5536,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 	public underlying_types_test_result(underlying_types_test_result other) {
 		if (other.isSetSuccess()) {
 			this.success = new ArrayList<Long>(other.success.size());
-			for (long elem276 : other.success) {
-				long elem277 = elem276;
-				this.success.add(elem277);
+			for (long elem278 : other.success) {
+				long elem279 = elem278;
+				this.success.add(elem279);
 			}
 		}
 	}
@@ -5754,11 +5754,11 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 				switch (schemeField.id) {
 					case 0: // SUCCESS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem278 = iprot.readListBegin();
-							struct.success = new ArrayList<Long>(elem278.size);
-							for (int elem279 = 0; elem279 < elem278.size; ++elem279) {
-								long elem280 = iprot.readI64();
-								struct.success.add(elem280);
+							org.apache.thrift.protocol.TList elem280 = iprot.readListBegin();
+							struct.success = new ArrayList<Long>(elem280.size);
+							for (int elem281 = 0; elem281 < elem280.size; ++elem281) {
+								long elem282 = iprot.readI64();
+								struct.success.add(elem282);
 							}
 							iprot.readListEnd();
 							struct.setSuccessIsSet(true);
@@ -5784,9 +5784,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			if (struct.success != null) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.success.size()));
-				for (long elem281 : struct.success) {
-					long elem282 = elem281;
-					oprot.writeI64(elem282);
+				for (long elem283 : struct.success) {
+					long elem284 = elem283;
+					oprot.writeI64(elem284);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -5815,9 +5815,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
 				oprot.writeI32(struct.success.size());
-				for (long elem283 : struct.success) {
-					long elem284 = elem283;
-					oprot.writeI64(elem284);
+				for (long elem285 : struct.success) {
+					long elem286 = elem285;
+					oprot.writeI64(elem286);
 				}
 			}
 		}
@@ -5827,11 +5827,11 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(1);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem285 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.success = new ArrayList<Long>(elem285.size);
-				for (int elem286 = 0; elem286 < elem285.size; ++elem286) {
-					long elem287 = iprot.readI64();
-					struct.success.add(elem287);
+				org.apache.thrift.protocol.TList elem287 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.success = new ArrayList<Long>(elem287.size);
+				for (int elem288 = 0; elem288 < elem287.size; ++elem288) {
+					long elem289 = iprot.readI64();
+					struct.success.add(elem289);
 				}
 				struct.setSuccessIsSet(true);
 			}
@@ -6989,8 +6989,8 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				int elem288 = struct.success;
-				oprot.writeI32(elem288);
+				int elem290 = struct.success;
+				oprot.writeI32(elem290);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -7016,8 +7016,8 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 			}
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
-				int elem289 = struct.success;
-				oprot.writeI32(elem289);
+				int elem291 = struct.success;
+				oprot.writeI32(elem291);
 			}
 		}
 

--- a/test/expected/java/variety/TestingUnions.java
+++ b/test/expected/java/variety/TestingUnions.java
@@ -43,6 +43,7 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 	private static final org.apache.thrift.protocol.TField AN_INT16_FIELD_DESC = new org.apache.thrift.protocol.TField("AnInt16", org.apache.thrift.protocol.TType.I16, (short)4);
 	private static final org.apache.thrift.protocol.TField REQUESTS_FIELD_DESC = new org.apache.thrift.protocol.TField("Requests", org.apache.thrift.protocol.TType.MAP, (short)5);
 	private static final org.apache.thrift.protocol.TField BIN_FIELD_IN_UNION_FIELD_DESC = new org.apache.thrift.protocol.TField("bin_field_in_union", org.apache.thrift.protocol.TType.STRING, (short)6);
+	private static final org.apache.thrift.protocol.TField DEPR_FIELD_DESC = new org.apache.thrift.protocol.TField("depr", org.apache.thrift.protocol.TType.BOOL, (short)7);
 
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -51,7 +52,8 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 		SOMEOTHERTHING((short)3, "someotherthing"),
 		AN_INT16((short)4, "AnInt16"),
 		REQUESTS((short)5, "Requests"),
-		BIN_FIELD_IN_UNION((short)6, "bin_field_in_union")
+		BIN_FIELD_IN_UNION((short)6, "bin_field_in_union"),
+		DEPR((short)7, "depr")
 ;
 
 		private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
@@ -79,6 +81,8 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 					return REQUESTS;
 				case 6: // BIN_FIELD_IN_UNION
 					return BIN_FIELD_IN_UNION;
+				case 7: // DEPR
+					return DEPR;
 				default:
 					return null;
 			}
@@ -169,6 +173,16 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 		return x;
 	}
 
+	/**
+	 * @deprecated use something else
+	 */
+	@Deprecated
+	public static TestingUnions depr(boolean value) {
+		TestingUnions x = new TestingUnions();
+		x.setDepr(value);
+		return x;
+	}
+
 	@Override
 	protected void checkType(_Fields setField, Object value) throws ClassCastException {
 		switch (setField) {
@@ -202,6 +216,11 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 					break;
 				}
 				throw new ClassCastException("Was expecting value of type java.nio.ByteBuffer for field 'bin_field_in_union', but got " + value.getClass().getSimpleName());
+			case DEPR:
+				if (value instanceof Boolean) {
+					break;
+				}
+				throw new ClassCastException("Was expecting value of type Boolean for field 'depr', but got " + value.getClass().getSimpleName());
 			default:
 				throw new IllegalArgumentException("Unknown field id " + setField);
 		}
@@ -246,12 +265,12 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 					}
 				case REQUESTS:
 					if (field.type == REQUESTS_FIELD_DESC.type) {
-						org.apache.thrift.protocol.TMap elem168 = iprot.readMapBegin();
-						java.util.Map<Integer, String> Requests = new HashMap<Integer,String>(2*elem168.size);
-						for (int elem169 = 0; elem169 < elem168.size; ++elem169) {
-							Integer elem171 = iprot.readI32();
-							String elem170 = iprot.readString();
-							Requests.put(elem171, elem170);
+						org.apache.thrift.protocol.TMap elem184 = iprot.readMapBegin();
+						java.util.Map<Integer, String> Requests = new HashMap<Integer,String>(2*elem184.size);
+						for (int elem185 = 0; elem185 < elem184.size; ++elem185) {
+							Integer elem187 = iprot.readI32();
+							String elem186 = iprot.readString();
+							Requests.put(elem187, elem186);
 						}
 						iprot.readMapEnd();
 						return Requests;
@@ -263,6 +282,14 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 					if (field.type == BIN_FIELD_IN_UNION_FIELD_DESC.type) {
 						java.nio.ByteBuffer bin_field_in_union = iprot.readBinary();
 						return bin_field_in_union;
+					} else {
+						org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
+						return null;
+					}
+				case DEPR:
+					if (field.type == DEPR_FIELD_DESC.type) {
+						Boolean depr = iprot.readBool();
+						return depr;
 					} else {
 						org.apache.thrift.protocol.TProtocolUtil.skip(iprot, field.type);
 						return null;
@@ -281,39 +308,44 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 		switch (setField_) {
 			case AN_ID:
 				Long AnID = (Long)value_;
-				long elem172 = AnID;
-				oprot.writeI64(elem172);
+				long elem188 = AnID;
+				oprot.writeI64(elem188);
 				return;
 			case A_STRING:
 				String aString = (String)value_;
-				String elem173 = aString;
-				oprot.writeString(elem173);
+				String elem189 = aString;
+				oprot.writeString(elem189);
 				return;
 			case SOMEOTHERTHING:
 				Integer someotherthing = (Integer)value_;
-				int elem174 = someotherthing;
-				oprot.writeI32(elem174);
+				int elem190 = someotherthing;
+				oprot.writeI32(elem190);
 				return;
 			case AN_INT16:
 				Short AnInt16 = (Short)value_;
-				short elem175 = AnInt16;
-				oprot.writeI16(elem175);
+				short elem191 = AnInt16;
+				oprot.writeI16(elem191);
 				return;
 			case REQUESTS:
 				java.util.Map<Integer, String> Requests = (java.util.Map<Integer, String>)value_;
 				oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, Requests.size()));
-				for (Map.Entry<Integer, String> elem176 : Requests.entrySet()) {
-					int elem177 = elem176.getKey();
-					oprot.writeI32(elem177);
-					String elem178 = elem176.getValue();
-					oprot.writeString(elem178);
+				for (Map.Entry<Integer, String> elem192 : Requests.entrySet()) {
+					int elem193 = elem192.getKey();
+					oprot.writeI32(elem193);
+					String elem194 = elem192.getValue();
+					oprot.writeString(elem194);
 				}
 				oprot.writeMapEnd();
 				return;
 			case BIN_FIELD_IN_UNION:
 				java.nio.ByteBuffer bin_field_in_union = (java.nio.ByteBuffer)value_;
-				java.nio.ByteBuffer elem179 = bin_field_in_union;
-				oprot.writeBinary(elem179);
+				java.nio.ByteBuffer elem195 = bin_field_in_union;
+				oprot.writeBinary(elem195);
+				return;
+			case DEPR:
+				Boolean depr = (Boolean)value_;
+				boolean elem196 = depr;
+				oprot.writeBool(elem196);
 				return;
 			default:
 				throw new IllegalStateException("Cannot write union with unknown field " + setField_);
@@ -338,18 +370,21 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 					Short AnInt16 = iprot.readI16();
 					return AnInt16;
 				case REQUESTS:
-					org.apache.thrift.protocol.TMap elem180 = iprot.readMapBegin();
-					java.util.Map<Integer, String> Requests = new HashMap<Integer,String>(2*elem180.size);
-					for (int elem181 = 0; elem181 < elem180.size; ++elem181) {
-						Integer elem183 = iprot.readI32();
-						String elem182 = iprot.readString();
-						Requests.put(elem183, elem182);
+					org.apache.thrift.protocol.TMap elem197 = iprot.readMapBegin();
+					java.util.Map<Integer, String> Requests = new HashMap<Integer,String>(2*elem197.size);
+					for (int elem198 = 0; elem198 < elem197.size; ++elem198) {
+						Integer elem200 = iprot.readI32();
+						String elem199 = iprot.readString();
+						Requests.put(elem200, elem199);
 					}
 					iprot.readMapEnd();
 					return Requests;
 				case BIN_FIELD_IN_UNION:
 					java.nio.ByteBuffer bin_field_in_union = iprot.readBinary();
 					return bin_field_in_union;
+				case DEPR:
+					Boolean depr = iprot.readBool();
+					return depr;
 				default:
 					throw new IllegalStateException("setField wasn't null, but didn't match any of the case statements!");
 			}
@@ -363,39 +398,44 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 		switch (setField_) {
 			case AN_ID:
 				Long AnID = (Long)value_;
-				long elem184 = AnID;
-				oprot.writeI64(elem184);
+				long elem201 = AnID;
+				oprot.writeI64(elem201);
 				return;
 			case A_STRING:
 				String aString = (String)value_;
-				String elem185 = aString;
-				oprot.writeString(elem185);
+				String elem202 = aString;
+				oprot.writeString(elem202);
 				return;
 			case SOMEOTHERTHING:
 				Integer someotherthing = (Integer)value_;
-				int elem186 = someotherthing;
-				oprot.writeI32(elem186);
+				int elem203 = someotherthing;
+				oprot.writeI32(elem203);
 				return;
 			case AN_INT16:
 				Short AnInt16 = (Short)value_;
-				short elem187 = AnInt16;
-				oprot.writeI16(elem187);
+				short elem204 = AnInt16;
+				oprot.writeI16(elem204);
 				return;
 			case REQUESTS:
 				java.util.Map<Integer, String> Requests = (java.util.Map<Integer, String>)value_;
 				oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, Requests.size()));
-				for (Map.Entry<Integer, String> elem188 : Requests.entrySet()) {
-					int elem189 = elem188.getKey();
-					oprot.writeI32(elem189);
-					String elem190 = elem188.getValue();
-					oprot.writeString(elem190);
+				for (Map.Entry<Integer, String> elem205 : Requests.entrySet()) {
+					int elem206 = elem205.getKey();
+					oprot.writeI32(elem206);
+					String elem207 = elem205.getValue();
+					oprot.writeString(elem207);
 				}
 				oprot.writeMapEnd();
 				return;
 			case BIN_FIELD_IN_UNION:
 				java.nio.ByteBuffer bin_field_in_union = (java.nio.ByteBuffer)value_;
-				java.nio.ByteBuffer elem191 = bin_field_in_union;
-				oprot.writeBinary(elem191);
+				java.nio.ByteBuffer elem208 = bin_field_in_union;
+				oprot.writeBinary(elem208);
+				return;
+			case DEPR:
+				Boolean depr = (Boolean)value_;
+				boolean elem209 = depr;
+				oprot.writeBool(elem209);
 				return;
 			default:
 				throw new IllegalStateException("Cannot write union with unknown field " + setField_);
@@ -417,6 +457,8 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 				return REQUESTS_FIELD_DESC;
 			case BIN_FIELD_IN_UNION:
 				return BIN_FIELD_IN_UNION_FIELD_DESC;
+			case DEPR:
+				return DEPR_FIELD_DESC;
 			default:
 				throw new IllegalArgumentException("Unknown field id " + setField);
 		}
@@ -518,6 +560,21 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 		value_ = value;
 	}
 
+	@Deprecated
+	public boolean getDepr() {
+		if (getSetField() == _Fields.DEPR) {
+			return (Boolean)getFieldValue();
+		} else {
+			throw new RuntimeException("Cannot get field 'depr' because union is currently set to " + getFieldDesc(getSetField()).name);
+		}
+	}
+
+	@Deprecated
+	public void setDepr(boolean value) {
+		setField_ = _Fields.DEPR;
+		value_ = value;
+	}
+
 	public boolean isSetAnID() {
 		return setField_ == _Fields.AN_ID;
 	}
@@ -540,6 +597,11 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 
 	public boolean isSetBin_field_in_union() {
 		return setField_ == _Fields.BIN_FIELD_IN_UNION;
+	}
+
+	@Deprecated
+	public boolean isSetDepr() {
+		return setField_ == _Fields.DEPR;
 	}
 
 

--- a/test/expected/java/variety_async/FFoo.java
+++ b/test/expected/java/variety_async/FFoo.java
@@ -2015,13 +2015,13 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(NUM_FIELD_DESC);
-			int elem214 = struct.num;
-			oprot.writeI32(elem214);
+			int elem216 = struct.num;
+			oprot.writeI32(elem216);
 			oprot.writeFieldEnd();
 			if (struct.Str != null) {
 				oprot.writeFieldBegin(STR_FIELD_DESC);
-				String elem215 = struct.Str;
-				oprot.writeString(elem215);
+				String elem217 = struct.Str;
+				oprot.writeString(elem217);
 				oprot.writeFieldEnd();
 			}
 			if (struct.event != null) {
@@ -2058,12 +2058,12 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetNum()) {
-				int elem216 = struct.num;
-				oprot.writeI32(elem216);
+				int elem218 = struct.num;
+				oprot.writeI32(elem218);
 			}
 			if (struct.isSetStr()) {
-				String elem217 = struct.Str;
-				oprot.writeString(elem217);
+				String elem219 = struct.Str;
+				oprot.writeString(elem219);
 			}
 			if (struct.isSetEvent()) {
 				struct.event.write(oprot);
@@ -2586,8 +2586,8 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				long elem218 = struct.success;
-				oprot.writeI64(elem218);
+				long elem220 = struct.success;
+				oprot.writeI64(elem220);
 				oprot.writeFieldEnd();
 			}
 			if (struct.awe != null) {
@@ -2629,8 +2629,8 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetSuccess()) {
-				long elem219 = struct.success;
-				oprot.writeI64(elem219);
+				long elem221 = struct.success;
+				oprot.writeI64(elem221);
 			}
 			if (struct.isSetAwe()) {
 				struct.awe.write(oprot);
@@ -3048,12 +3048,12 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 						break;
 					case 2: // REQ
 						if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
-							org.apache.thrift.protocol.TMap elem222 = iprot.readMapBegin();
-							struct.req = new HashMap<Integer,String>(2*elem222.size);
-							for (int elem223 = 0; elem223 < elem222.size; ++elem223) {
-								int elem225 = iprot.readI32();
-								String elem224 = iprot.readString();
-								struct.req.put(elem225, elem224);
+							org.apache.thrift.protocol.TMap elem224 = iprot.readMapBegin();
+							struct.req = new HashMap<Integer,String>(2*elem224.size);
+							for (int elem225 = 0; elem225 < elem224.size; ++elem225) {
+								int elem227 = iprot.readI32();
+								String elem226 = iprot.readString();
+								struct.req.put(elem227, elem226);
 							}
 							iprot.readMapEnd();
 							struct.setReqIsSet(true);
@@ -3077,17 +3077,17 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(ID_FIELD_DESC);
-			long elem226 = struct.id;
-			oprot.writeI64(elem226);
+			long elem228 = struct.id;
+			oprot.writeI64(elem228);
 			oprot.writeFieldEnd();
 			if (struct.req != null) {
 				oprot.writeFieldBegin(REQ_FIELD_DESC);
 				oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, struct.req.size()));
-				for (Map.Entry<Integer, String> elem227 : struct.req.entrySet()) {
-					int elem228 = elem227.getKey();
-					oprot.writeI32(elem228);
-					String elem229 = elem227.getValue();
-					oprot.writeString(elem229);
+				for (Map.Entry<Integer, String> elem229 : struct.req.entrySet()) {
+					int elem230 = elem229.getKey();
+					oprot.writeI32(elem230);
+					String elem231 = elem229.getValue();
+					oprot.writeString(elem231);
 				}
 				oprot.writeMapEnd();
 				oprot.writeFieldEnd();
@@ -3118,16 +3118,16 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetId()) {
-				long elem230 = struct.id;
-				oprot.writeI64(elem230);
+				long elem232 = struct.id;
+				oprot.writeI64(elem232);
 			}
 			if (struct.isSetReq()) {
 				oprot.writeI32(struct.req.size());
-				for (Map.Entry<Integer, String> elem231 : struct.req.entrySet()) {
-					int elem232 = elem231.getKey();
-					oprot.writeI32(elem232);
-					String elem233 = elem231.getValue();
-					oprot.writeString(elem233);
+				for (Map.Entry<Integer, String> elem233 : struct.req.entrySet()) {
+					int elem234 = elem233.getKey();
+					oprot.writeI32(elem234);
+					String elem235 = elem233.getValue();
+					oprot.writeString(elem235);
 				}
 			}
 		}
@@ -3141,12 +3141,12 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 				struct.setIdIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TMap elem234 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-				struct.req = new HashMap<Integer,String>(2*elem234.size);
-				for (int elem235 = 0; elem235 < elem234.size; ++elem235) {
-					int elem237 = iprot.readI32();
-					String elem236 = iprot.readString();
-					struct.req.put(elem237, elem236);
+				org.apache.thrift.protocol.TMap elem236 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+				struct.req = new HashMap<Integer,String>(2*elem236.size);
+				for (int elem237 = 0; elem237 < elem236.size; ++elem237) {
+					int elem239 = iprot.readI32();
+					String elem238 = iprot.readString();
+					struct.req.put(elem239, elem238);
 				}
 				struct.setReqIsSet(true);
 			}
@@ -3563,14 +3563,14 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.bin != null) {
 				oprot.writeFieldBegin(BIN_FIELD_DESC);
-				java.nio.ByteBuffer elem238 = struct.bin;
-				oprot.writeBinary(elem238);
+				java.nio.ByteBuffer elem240 = struct.bin;
+				oprot.writeBinary(elem240);
 				oprot.writeFieldEnd();
 			}
 			if (struct.Str != null) {
 				oprot.writeFieldBegin(STR_FIELD_DESC);
-				String elem239 = struct.Str;
-				oprot.writeString(elem239);
+				String elem241 = struct.Str;
+				oprot.writeString(elem241);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -3599,12 +3599,12 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetBin()) {
-				java.nio.ByteBuffer elem240 = struct.bin;
-				oprot.writeBinary(elem240);
+				java.nio.ByteBuffer elem242 = struct.bin;
+				oprot.writeBinary(elem242);
 			}
 			if (struct.isSetStr()) {
-				String elem241 = struct.Str;
-				oprot.writeString(elem241);
+				String elem243 = struct.Str;
+				oprot.writeString(elem243);
 			}
 		}
 
@@ -4037,8 +4037,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.success != null) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				java.nio.ByteBuffer elem242 = struct.success;
-				oprot.writeBinary(elem242);
+				java.nio.ByteBuffer elem244 = struct.success;
+				oprot.writeBinary(elem244);
 				oprot.writeFieldEnd();
 			}
 			if (struct.api != null) {
@@ -4072,8 +4072,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetSuccess()) {
-				java.nio.ByteBuffer elem243 = struct.success;
-				oprot.writeBinary(elem243);
+				java.nio.ByteBuffer elem245 = struct.success;
+				oprot.writeBinary(elem245);
 			}
 			if (struct.isSetApi()) {
 				struct.api.write(oprot);
@@ -4578,16 +4578,16 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(OPT_NUM_FIELD_DESC);
-			int elem244 = struct.opt_num;
-			oprot.writeI32(elem244);
+			int elem246 = struct.opt_num;
+			oprot.writeI32(elem246);
 			oprot.writeFieldEnd();
 			oprot.writeFieldBegin(DEFAULT_NUM_FIELD_DESC);
-			int elem245 = struct.default_num;
-			oprot.writeI32(elem245);
+			int elem247 = struct.default_num;
+			oprot.writeI32(elem247);
 			oprot.writeFieldEnd();
 			oprot.writeFieldBegin(REQ_NUM_FIELD_DESC);
-			int elem246 = struct.req_num;
-			oprot.writeI32(elem246);
+			int elem248 = struct.req_num;
+			oprot.writeI32(elem248);
 			oprot.writeFieldEnd();
 			oprot.writeFieldStop();
 			oprot.writeStructEnd();
@@ -4606,8 +4606,8 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 		@Override
 		public void write(org.apache.thrift.protocol.TProtocol prot, param_modifiers_args struct) throws org.apache.thrift.TException {
 			TTupleProtocol oprot = (TTupleProtocol) prot;
-			int elem247 = struct.req_num;
-			oprot.writeI32(elem247);
+			int elem249 = struct.req_num;
+			oprot.writeI32(elem249);
 			BitSet optionals = new BitSet();
 			if (struct.isSetOpt_num()) {
 				optionals.set(0);
@@ -4617,12 +4617,12 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetOpt_num()) {
-				int elem248 = struct.opt_num;
-				oprot.writeI32(elem248);
+				int elem250 = struct.opt_num;
+				oprot.writeI32(elem250);
 			}
 			if (struct.isSetDefault_num()) {
-				int elem249 = struct.default_num;
-				oprot.writeI32(elem249);
+				int elem251 = struct.default_num;
+				oprot.writeI32(elem251);
 			}
 		}
 
@@ -4953,8 +4953,8 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				long elem250 = struct.success;
-				oprot.writeI64(elem250);
+				long elem252 = struct.success;
+				oprot.writeI64(elem252);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -4980,8 +4980,8 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 			}
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
-				long elem251 = struct.success;
-				oprot.writeI64(elem251);
+				long elem253 = struct.success;
+				oprot.writeI64(elem253);
 			}
 		}
 
@@ -5092,16 +5092,16 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 	public underlying_types_test_args(underlying_types_test_args other) {
 		if (other.isSetList_type()) {
 			this.list_type = new ArrayList<Long>(other.list_type.size());
-			for (long elem252 : other.list_type) {
-				long elem253 = elem252;
-				this.list_type.add(elem253);
+			for (long elem254 : other.list_type) {
+				long elem255 = elem254;
+				this.list_type.add(elem255);
 			}
 		}
 		if (other.isSetSet_type()) {
 			this.set_type = new HashSet<Long>(other.set_type.size());
-			for (long elem254 : other.set_type) {
-				long elem255 = elem254;
-				this.set_type.add(elem255);
+			for (long elem256 : other.set_type) {
+				long elem257 = elem256;
+				this.set_type.add(elem257);
 			}
 		}
 	}
@@ -5403,11 +5403,11 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 				switch (schemeField.id) {
 					case 1: // LIST_TYPE
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem256 = iprot.readListBegin();
-							struct.list_type = new ArrayList<Long>(elem256.size);
-							for (int elem257 = 0; elem257 < elem256.size; ++elem257) {
-								long elem258 = iprot.readI64();
-								struct.list_type.add(elem258);
+							org.apache.thrift.protocol.TList elem258 = iprot.readListBegin();
+							struct.list_type = new ArrayList<Long>(elem258.size);
+							for (int elem259 = 0; elem259 < elem258.size; ++elem259) {
+								long elem260 = iprot.readI64();
+								struct.list_type.add(elem260);
 							}
 							iprot.readListEnd();
 							struct.setList_typeIsSet(true);
@@ -5417,11 +5417,11 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 						break;
 					case 2: // SET_TYPE
 						if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
-							org.apache.thrift.protocol.TSet elem259 = iprot.readSetBegin();
-							struct.set_type = new HashSet<Long>(2*elem259.size);
-							for (int elem260 = 0; elem260 < elem259.size; ++elem260) {
-								long elem261 = iprot.readI64();
-								struct.set_type.add(elem261);
+							org.apache.thrift.protocol.TSet elem261 = iprot.readSetBegin();
+							struct.set_type = new HashSet<Long>(2*elem261.size);
+							for (int elem262 = 0; elem262 < elem261.size; ++elem262) {
+								long elem263 = iprot.readI64();
+								struct.set_type.add(elem263);
 							}
 							iprot.readSetEnd();
 							struct.setSet_typeIsSet(true);
@@ -5447,9 +5447,9 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			if (struct.list_type != null) {
 				oprot.writeFieldBegin(LIST_TYPE_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.list_type.size()));
-				for (long elem262 : struct.list_type) {
-					long elem263 = elem262;
-					oprot.writeI64(elem263);
+				for (long elem264 : struct.list_type) {
+					long elem265 = elem264;
+					oprot.writeI64(elem265);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -5457,9 +5457,9 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			if (struct.set_type != null) {
 				oprot.writeFieldBegin(SET_TYPE_FIELD_DESC);
 				oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, struct.set_type.size()));
-				for (long elem264 : struct.set_type) {
-					long elem265 = elem264;
-					oprot.writeI64(elem265);
+				for (long elem266 : struct.set_type) {
+					long elem267 = elem266;
+					oprot.writeI64(elem267);
 				}
 				oprot.writeSetEnd();
 				oprot.writeFieldEnd();
@@ -5491,16 +5491,16 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetList_type()) {
 				oprot.writeI32(struct.list_type.size());
-				for (long elem266 : struct.list_type) {
-					long elem267 = elem266;
-					oprot.writeI64(elem267);
+				for (long elem268 : struct.list_type) {
+					long elem269 = elem268;
+					oprot.writeI64(elem269);
 				}
 			}
 			if (struct.isSetSet_type()) {
 				oprot.writeI32(struct.set_type.size());
-				for (long elem268 : struct.set_type) {
-					long elem269 = elem268;
-					oprot.writeI64(elem269);
+				for (long elem270 : struct.set_type) {
+					long elem271 = elem270;
+					oprot.writeI64(elem271);
 				}
 			}
 		}
@@ -5510,20 +5510,20 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(2);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem270 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.list_type = new ArrayList<Long>(elem270.size);
-				for (int elem271 = 0; elem271 < elem270.size; ++elem271) {
-					long elem272 = iprot.readI64();
-					struct.list_type.add(elem272);
+				org.apache.thrift.protocol.TList elem272 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.list_type = new ArrayList<Long>(elem272.size);
+				for (int elem273 = 0; elem273 < elem272.size; ++elem273) {
+					long elem274 = iprot.readI64();
+					struct.list_type.add(elem274);
 				}
 				struct.setList_typeIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TSet elem273 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.set_type = new HashSet<Long>(2*elem273.size);
-				for (int elem274 = 0; elem274 < elem273.size; ++elem274) {
-					long elem275 = iprot.readI64();
-					struct.set_type.add(elem275);
+				org.apache.thrift.protocol.TSet elem275 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.set_type = new HashSet<Long>(2*elem275.size);
+				for (int elem276 = 0; elem276 < elem275.size; ++elem276) {
+					long elem277 = iprot.readI64();
+					struct.set_type.add(elem277);
 				}
 				struct.setSet_typeIsSet(true);
 			}
@@ -5619,9 +5619,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 	public underlying_types_test_result(underlying_types_test_result other) {
 		if (other.isSetSuccess()) {
 			this.success = new ArrayList<Long>(other.success.size());
-			for (long elem276 : other.success) {
-				long elem277 = elem276;
-				this.success.add(elem277);
+			for (long elem278 : other.success) {
+				long elem279 = elem278;
+				this.success.add(elem279);
 			}
 		}
 	}
@@ -5837,11 +5837,11 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 				switch (schemeField.id) {
 					case 0: // SUCCESS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem278 = iprot.readListBegin();
-							struct.success = new ArrayList<Long>(elem278.size);
-							for (int elem279 = 0; elem279 < elem278.size; ++elem279) {
-								long elem280 = iprot.readI64();
-								struct.success.add(elem280);
+							org.apache.thrift.protocol.TList elem280 = iprot.readListBegin();
+							struct.success = new ArrayList<Long>(elem280.size);
+							for (int elem281 = 0; elem281 < elem280.size; ++elem281) {
+								long elem282 = iprot.readI64();
+								struct.success.add(elem282);
 							}
 							iprot.readListEnd();
 							struct.setSuccessIsSet(true);
@@ -5867,9 +5867,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			if (struct.success != null) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.success.size()));
-				for (long elem281 : struct.success) {
-					long elem282 = elem281;
-					oprot.writeI64(elem282);
+				for (long elem283 : struct.success) {
+					long elem284 = elem283;
+					oprot.writeI64(elem284);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -5898,9 +5898,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
 				oprot.writeI32(struct.success.size());
-				for (long elem283 : struct.success) {
-					long elem284 = elem283;
-					oprot.writeI64(elem284);
+				for (long elem285 : struct.success) {
+					long elem286 = elem285;
+					oprot.writeI64(elem286);
 				}
 			}
 		}
@@ -5910,11 +5910,11 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(1);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem285 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.success = new ArrayList<Long>(elem285.size);
-				for (int elem286 = 0; elem286 < elem285.size; ++elem286) {
-					long elem287 = iprot.readI64();
-					struct.success.add(elem287);
+				org.apache.thrift.protocol.TList elem287 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.success = new ArrayList<Long>(elem287.size);
+				for (int elem288 = 0; elem288 < elem287.size; ++elem288) {
+					long elem289 = iprot.readI64();
+					struct.success.add(elem289);
 				}
 				struct.setSuccessIsSet(true);
 			}
@@ -7072,8 +7072,8 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				int elem288 = struct.success;
-				oprot.writeI32(elem288);
+				int elem290 = struct.success;
+				oprot.writeI32(elem290);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -7099,8 +7099,8 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 			}
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
-				int elem289 = struct.success;
-				oprot.writeI32(elem289);
+				int elem291 = struct.success;
+				oprot.writeI32(elem291);
 			}
 		}
 

--- a/test/expected/java/variety_async/FFoo.java
+++ b/test/expected/java/variety_async/FFoo.java
@@ -2015,13 +2015,13 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(NUM_FIELD_DESC);
-			int elem196 = struct.num;
-			oprot.writeI32(elem196);
+			int elem214 = struct.num;
+			oprot.writeI32(elem214);
 			oprot.writeFieldEnd();
 			if (struct.Str != null) {
 				oprot.writeFieldBegin(STR_FIELD_DESC);
-				String elem197 = struct.Str;
-				oprot.writeString(elem197);
+				String elem215 = struct.Str;
+				oprot.writeString(elem215);
 				oprot.writeFieldEnd();
 			}
 			if (struct.event != null) {
@@ -2058,12 +2058,12 @@ public static class blah_args implements org.apache.thrift.TBase<blah_args, blah
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetNum()) {
-				int elem198 = struct.num;
-				oprot.writeI32(elem198);
+				int elem216 = struct.num;
+				oprot.writeI32(elem216);
 			}
 			if (struct.isSetStr()) {
-				String elem199 = struct.Str;
-				oprot.writeString(elem199);
+				String elem217 = struct.Str;
+				oprot.writeString(elem217);
 			}
 			if (struct.isSetEvent()) {
 				struct.event.write(oprot);
@@ -2586,8 +2586,8 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				long elem200 = struct.success;
-				oprot.writeI64(elem200);
+				long elem218 = struct.success;
+				oprot.writeI64(elem218);
 				oprot.writeFieldEnd();
 			}
 			if (struct.awe != null) {
@@ -2629,8 +2629,8 @@ public static class blah_result implements org.apache.thrift.TBase<blah_result, 
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetSuccess()) {
-				long elem201 = struct.success;
-				oprot.writeI64(elem201);
+				long elem219 = struct.success;
+				oprot.writeI64(elem219);
 			}
 			if (struct.isSetAwe()) {
 				struct.awe.write(oprot);
@@ -3048,12 +3048,12 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 						break;
 					case 2: // REQ
 						if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
-							org.apache.thrift.protocol.TMap elem204 = iprot.readMapBegin();
-							struct.req = new HashMap<Integer,String>(2*elem204.size);
-							for (int elem205 = 0; elem205 < elem204.size; ++elem205) {
-								int elem207 = iprot.readI32();
-								String elem206 = iprot.readString();
-								struct.req.put(elem207, elem206);
+							org.apache.thrift.protocol.TMap elem222 = iprot.readMapBegin();
+							struct.req = new HashMap<Integer,String>(2*elem222.size);
+							for (int elem223 = 0; elem223 < elem222.size; ++elem223) {
+								int elem225 = iprot.readI32();
+								String elem224 = iprot.readString();
+								struct.req.put(elem225, elem224);
 							}
 							iprot.readMapEnd();
 							struct.setReqIsSet(true);
@@ -3077,17 +3077,17 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(ID_FIELD_DESC);
-			long elem208 = struct.id;
-			oprot.writeI64(elem208);
+			long elem226 = struct.id;
+			oprot.writeI64(elem226);
 			oprot.writeFieldEnd();
 			if (struct.req != null) {
 				oprot.writeFieldBegin(REQ_FIELD_DESC);
 				oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, struct.req.size()));
-				for (Map.Entry<Integer, String> elem209 : struct.req.entrySet()) {
-					int elem210 = elem209.getKey();
-					oprot.writeI32(elem210);
-					String elem211 = elem209.getValue();
-					oprot.writeString(elem211);
+				for (Map.Entry<Integer, String> elem227 : struct.req.entrySet()) {
+					int elem228 = elem227.getKey();
+					oprot.writeI32(elem228);
+					String elem229 = elem227.getValue();
+					oprot.writeString(elem229);
 				}
 				oprot.writeMapEnd();
 				oprot.writeFieldEnd();
@@ -3118,16 +3118,16 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetId()) {
-				long elem212 = struct.id;
-				oprot.writeI64(elem212);
+				long elem230 = struct.id;
+				oprot.writeI64(elem230);
 			}
 			if (struct.isSetReq()) {
 				oprot.writeI32(struct.req.size());
-				for (Map.Entry<Integer, String> elem213 : struct.req.entrySet()) {
-					int elem214 = elem213.getKey();
-					oprot.writeI32(elem214);
-					String elem215 = elem213.getValue();
-					oprot.writeString(elem215);
+				for (Map.Entry<Integer, String> elem231 : struct.req.entrySet()) {
+					int elem232 = elem231.getKey();
+					oprot.writeI32(elem232);
+					String elem233 = elem231.getValue();
+					oprot.writeString(elem233);
 				}
 			}
 		}
@@ -3141,12 +3141,12 @@ public static class oneWay_args implements org.apache.thrift.TBase<oneWay_args, 
 				struct.setIdIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TMap elem216 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-				struct.req = new HashMap<Integer,String>(2*elem216.size);
-				for (int elem217 = 0; elem217 < elem216.size; ++elem217) {
-					int elem219 = iprot.readI32();
-					String elem218 = iprot.readString();
-					struct.req.put(elem219, elem218);
+				org.apache.thrift.protocol.TMap elem234 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+				struct.req = new HashMap<Integer,String>(2*elem234.size);
+				for (int elem235 = 0; elem235 < elem234.size; ++elem235) {
+					int elem237 = iprot.readI32();
+					String elem236 = iprot.readString();
+					struct.req.put(elem237, elem236);
 				}
 				struct.setReqIsSet(true);
 			}
@@ -3563,14 +3563,14 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.bin != null) {
 				oprot.writeFieldBegin(BIN_FIELD_DESC);
-				java.nio.ByteBuffer elem220 = struct.bin;
-				oprot.writeBinary(elem220);
+				java.nio.ByteBuffer elem238 = struct.bin;
+				oprot.writeBinary(elem238);
 				oprot.writeFieldEnd();
 			}
 			if (struct.Str != null) {
 				oprot.writeFieldBegin(STR_FIELD_DESC);
-				String elem221 = struct.Str;
-				oprot.writeString(elem221);
+				String elem239 = struct.Str;
+				oprot.writeString(elem239);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -3599,12 +3599,12 @@ public static class bin_method_args implements org.apache.thrift.TBase<bin_metho
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetBin()) {
-				java.nio.ByteBuffer elem222 = struct.bin;
-				oprot.writeBinary(elem222);
+				java.nio.ByteBuffer elem240 = struct.bin;
+				oprot.writeBinary(elem240);
 			}
 			if (struct.isSetStr()) {
-				String elem223 = struct.Str;
-				oprot.writeString(elem223);
+				String elem241 = struct.Str;
+				oprot.writeString(elem241);
 			}
 		}
 
@@ -4037,8 +4037,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.success != null) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				java.nio.ByteBuffer elem224 = struct.success;
-				oprot.writeBinary(elem224);
+				java.nio.ByteBuffer elem242 = struct.success;
+				oprot.writeBinary(elem242);
 				oprot.writeFieldEnd();
 			}
 			if (struct.api != null) {
@@ -4072,8 +4072,8 @@ public static class bin_method_result implements org.apache.thrift.TBase<bin_met
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetSuccess()) {
-				java.nio.ByteBuffer elem225 = struct.success;
-				oprot.writeBinary(elem225);
+				java.nio.ByteBuffer elem243 = struct.success;
+				oprot.writeBinary(elem243);
 			}
 			if (struct.isSetApi()) {
 				struct.api.write(oprot);
@@ -4578,16 +4578,16 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(OPT_NUM_FIELD_DESC);
-			int elem226 = struct.opt_num;
-			oprot.writeI32(elem226);
+			int elem244 = struct.opt_num;
+			oprot.writeI32(elem244);
 			oprot.writeFieldEnd();
 			oprot.writeFieldBegin(DEFAULT_NUM_FIELD_DESC);
-			int elem227 = struct.default_num;
-			oprot.writeI32(elem227);
+			int elem245 = struct.default_num;
+			oprot.writeI32(elem245);
 			oprot.writeFieldEnd();
 			oprot.writeFieldBegin(REQ_NUM_FIELD_DESC);
-			int elem228 = struct.req_num;
-			oprot.writeI32(elem228);
+			int elem246 = struct.req_num;
+			oprot.writeI32(elem246);
 			oprot.writeFieldEnd();
 			oprot.writeFieldStop();
 			oprot.writeStructEnd();
@@ -4606,8 +4606,8 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 		@Override
 		public void write(org.apache.thrift.protocol.TProtocol prot, param_modifiers_args struct) throws org.apache.thrift.TException {
 			TTupleProtocol oprot = (TTupleProtocol) prot;
-			int elem229 = struct.req_num;
-			oprot.writeI32(elem229);
+			int elem247 = struct.req_num;
+			oprot.writeI32(elem247);
 			BitSet optionals = new BitSet();
 			if (struct.isSetOpt_num()) {
 				optionals.set(0);
@@ -4617,12 +4617,12 @@ public static class param_modifiers_args implements org.apache.thrift.TBase<para
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetOpt_num()) {
-				int elem230 = struct.opt_num;
-				oprot.writeI32(elem230);
+				int elem248 = struct.opt_num;
+				oprot.writeI32(elem248);
 			}
 			if (struct.isSetDefault_num()) {
-				int elem231 = struct.default_num;
-				oprot.writeI32(elem231);
+				int elem249 = struct.default_num;
+				oprot.writeI32(elem249);
 			}
 		}
 
@@ -4953,8 +4953,8 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				long elem232 = struct.success;
-				oprot.writeI64(elem232);
+				long elem250 = struct.success;
+				oprot.writeI64(elem250);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -4980,8 +4980,8 @@ public static class param_modifiers_result implements org.apache.thrift.TBase<pa
 			}
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
-				long elem233 = struct.success;
-				oprot.writeI64(elem233);
+				long elem251 = struct.success;
+				oprot.writeI64(elem251);
 			}
 		}
 
@@ -5092,16 +5092,16 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 	public underlying_types_test_args(underlying_types_test_args other) {
 		if (other.isSetList_type()) {
 			this.list_type = new ArrayList<Long>(other.list_type.size());
-			for (long elem234 : other.list_type) {
-				long elem235 = elem234;
-				this.list_type.add(elem235);
+			for (long elem252 : other.list_type) {
+				long elem253 = elem252;
+				this.list_type.add(elem253);
 			}
 		}
 		if (other.isSetSet_type()) {
 			this.set_type = new HashSet<Long>(other.set_type.size());
-			for (long elem236 : other.set_type) {
-				long elem237 = elem236;
-				this.set_type.add(elem237);
+			for (long elem254 : other.set_type) {
+				long elem255 = elem254;
+				this.set_type.add(elem255);
 			}
 		}
 	}
@@ -5403,11 +5403,11 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 				switch (schemeField.id) {
 					case 1: // LIST_TYPE
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem238 = iprot.readListBegin();
-							struct.list_type = new ArrayList<Long>(elem238.size);
-							for (int elem239 = 0; elem239 < elem238.size; ++elem239) {
-								long elem240 = iprot.readI64();
-								struct.list_type.add(elem240);
+							org.apache.thrift.protocol.TList elem256 = iprot.readListBegin();
+							struct.list_type = new ArrayList<Long>(elem256.size);
+							for (int elem257 = 0; elem257 < elem256.size; ++elem257) {
+								long elem258 = iprot.readI64();
+								struct.list_type.add(elem258);
 							}
 							iprot.readListEnd();
 							struct.setList_typeIsSet(true);
@@ -5417,11 +5417,11 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 						break;
 					case 2: // SET_TYPE
 						if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
-							org.apache.thrift.protocol.TSet elem241 = iprot.readSetBegin();
-							struct.set_type = new HashSet<Long>(2*elem241.size);
-							for (int elem242 = 0; elem242 < elem241.size; ++elem242) {
-								long elem243 = iprot.readI64();
-								struct.set_type.add(elem243);
+							org.apache.thrift.protocol.TSet elem259 = iprot.readSetBegin();
+							struct.set_type = new HashSet<Long>(2*elem259.size);
+							for (int elem260 = 0; elem260 < elem259.size; ++elem260) {
+								long elem261 = iprot.readI64();
+								struct.set_type.add(elem261);
 							}
 							iprot.readSetEnd();
 							struct.setSet_typeIsSet(true);
@@ -5447,9 +5447,9 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			if (struct.list_type != null) {
 				oprot.writeFieldBegin(LIST_TYPE_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.list_type.size()));
-				for (long elem244 : struct.list_type) {
-					long elem245 = elem244;
-					oprot.writeI64(elem245);
+				for (long elem262 : struct.list_type) {
+					long elem263 = elem262;
+					oprot.writeI64(elem263);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -5457,9 +5457,9 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			if (struct.set_type != null) {
 				oprot.writeFieldBegin(SET_TYPE_FIELD_DESC);
 				oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, struct.set_type.size()));
-				for (long elem246 : struct.set_type) {
-					long elem247 = elem246;
-					oprot.writeI64(elem247);
+				for (long elem264 : struct.set_type) {
+					long elem265 = elem264;
+					oprot.writeI64(elem265);
 				}
 				oprot.writeSetEnd();
 				oprot.writeFieldEnd();
@@ -5491,16 +5491,16 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetList_type()) {
 				oprot.writeI32(struct.list_type.size());
-				for (long elem248 : struct.list_type) {
-					long elem249 = elem248;
-					oprot.writeI64(elem249);
+				for (long elem266 : struct.list_type) {
+					long elem267 = elem266;
+					oprot.writeI64(elem267);
 				}
 			}
 			if (struct.isSetSet_type()) {
 				oprot.writeI32(struct.set_type.size());
-				for (long elem250 : struct.set_type) {
-					long elem251 = elem250;
-					oprot.writeI64(elem251);
+				for (long elem268 : struct.set_type) {
+					long elem269 = elem268;
+					oprot.writeI64(elem269);
 				}
 			}
 		}
@@ -5510,20 +5510,20 @@ public static class underlying_types_test_args implements org.apache.thrift.TBas
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(2);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem252 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.list_type = new ArrayList<Long>(elem252.size);
-				for (int elem253 = 0; elem253 < elem252.size; ++elem253) {
-					long elem254 = iprot.readI64();
-					struct.list_type.add(elem254);
+				org.apache.thrift.protocol.TList elem270 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.list_type = new ArrayList<Long>(elem270.size);
+				for (int elem271 = 0; elem271 < elem270.size; ++elem271) {
+					long elem272 = iprot.readI64();
+					struct.list_type.add(elem272);
 				}
 				struct.setList_typeIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TSet elem255 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.set_type = new HashSet<Long>(2*elem255.size);
-				for (int elem256 = 0; elem256 < elem255.size; ++elem256) {
-					long elem257 = iprot.readI64();
-					struct.set_type.add(elem257);
+				org.apache.thrift.protocol.TSet elem273 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.set_type = new HashSet<Long>(2*elem273.size);
+				for (int elem274 = 0; elem274 < elem273.size; ++elem274) {
+					long elem275 = iprot.readI64();
+					struct.set_type.add(elem275);
 				}
 				struct.setSet_typeIsSet(true);
 			}
@@ -5619,9 +5619,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 	public underlying_types_test_result(underlying_types_test_result other) {
 		if (other.isSetSuccess()) {
 			this.success = new ArrayList<Long>(other.success.size());
-			for (long elem258 : other.success) {
-				long elem259 = elem258;
-				this.success.add(elem259);
+			for (long elem276 : other.success) {
+				long elem277 = elem276;
+				this.success.add(elem277);
 			}
 		}
 	}
@@ -5837,11 +5837,11 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 				switch (schemeField.id) {
 					case 0: // SUCCESS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem260 = iprot.readListBegin();
-							struct.success = new ArrayList<Long>(elem260.size);
-							for (int elem261 = 0; elem261 < elem260.size; ++elem261) {
-								long elem262 = iprot.readI64();
-								struct.success.add(elem262);
+							org.apache.thrift.protocol.TList elem278 = iprot.readListBegin();
+							struct.success = new ArrayList<Long>(elem278.size);
+							for (int elem279 = 0; elem279 < elem278.size; ++elem279) {
+								long elem280 = iprot.readI64();
+								struct.success.add(elem280);
 							}
 							iprot.readListEnd();
 							struct.setSuccessIsSet(true);
@@ -5867,9 +5867,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			if (struct.success != null) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.success.size()));
-				for (long elem263 : struct.success) {
-					long elem264 = elem263;
-					oprot.writeI64(elem264);
+				for (long elem281 : struct.success) {
+					long elem282 = elem281;
+					oprot.writeI64(elem282);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -5898,9 +5898,9 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
 				oprot.writeI32(struct.success.size());
-				for (long elem265 : struct.success) {
-					long elem266 = elem265;
-					oprot.writeI64(elem266);
+				for (long elem283 : struct.success) {
+					long elem284 = elem283;
+					oprot.writeI64(elem284);
 				}
 			}
 		}
@@ -5910,11 +5910,11 @@ public static class underlying_types_test_result implements org.apache.thrift.TB
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(1);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem267 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-				struct.success = new ArrayList<Long>(elem267.size);
-				for (int elem268 = 0; elem268 < elem267.size; ++elem268) {
-					long elem269 = iprot.readI64();
-					struct.success.add(elem269);
+				org.apache.thrift.protocol.TList elem285 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+				struct.success = new ArrayList<Long>(elem285.size);
+				for (int elem286 = 0; elem286 < elem285.size; ++elem286) {
+					long elem287 = iprot.readI64();
+					struct.success.add(elem287);
 				}
 				struct.setSuccessIsSet(true);
 			}
@@ -7072,8 +7072,8 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetSuccess()) {
 				oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-				int elem270 = struct.success;
-				oprot.writeI32(elem270);
+				int elem288 = struct.success;
+				oprot.writeI32(elem288);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -7099,8 +7099,8 @@ public static class getMyInt_result implements org.apache.thrift.TBase<getMyInt_
 			}
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetSuccess()) {
-				int elem271 = struct.success;
-				oprot.writeI32(elem271);
+				int elem289 = struct.success;
+				oprot.writeI32(elem289);
 			}
 		}
 

--- a/test/expected/python.asyncio/actual_base/ttypes.py
+++ b/test/expected/python.asyncio/actual_base/ttypes.py
@@ -114,11 +114,11 @@ class nested_thing(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.things = []
-                    (_, elem64) = iprot.readListBegin()
-                    for _ in range(elem64):
-                        elem65 = thing()
-                        elem65.read(iprot)
-                        self.things.append(elem65)
+                    (_, elem67) = iprot.readListBegin()
+                    for _ in range(elem67):
+                        elem68 = thing()
+                        elem68.read(iprot)
+                        self.things.append(elem68)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -134,8 +134,8 @@ class nested_thing(object):
         if self.things is not None:
             oprot.writeFieldBegin('things', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.things))
-            for elem66 in self.things:
-                elem66.write(oprot)
+            for elem69 in self.things:
+                elem69.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()

--- a/test/expected/python.asyncio/variety/f_Events_publisher.py
+++ b/test/expected/python.asyncio/variety/f_Events_publisher.py
@@ -149,11 +149,11 @@ class EventsPublisher(object):
         oprot.write_request_headers(ctx)
         oprot.writeMessageBegin(op, TMessageType.CALL, 0)
         oprot.writeListBegin(TType.MAP, len(req))
-        for elem56 in req:
-            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(elem56))
-            for elem58, elem57 in elem56.items():
-                oprot.writeI64(elem58)
-                elem57.write(oprot)
+        for elem59 in req:
+            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(elem59))
+            for elem61, elem60 in elem59.items():
+                oprot.writeI64(elem61)
+                elem60.write(oprot)
             oprot.writeMapEnd()
         oprot.writeListEnd()
         oprot.writeMessageEnd()

--- a/test/expected/python.asyncio/variety/f_Events_subscriber.py
+++ b/test/expected/python.asyncio/variety/f_Events_subscriber.py
@@ -198,17 +198,17 @@ class EventsSubscriber(object):
                 iprot.readMessageEnd()
                 raise TApplicationException(TApplicationExceptionType.UNKNOWN_METHOD)
             req = []
-            (_, elem59) = iprot.readListBegin()
-            for _ in range(elem59):
-                elem60 = {}
-                (_, _, elem61) = iprot.readMapBegin()
-                for _ in range(elem61):
-                    elem63 = iprot.readI64()
-                    elem62 = Event()
-                    elem62.read(iprot)
-                    elem60[elem63] = elem62
+            (_, elem62) = iprot.readListBegin()
+            for _ in range(elem62):
+                elem63 = {}
+                (_, _, elem64) = iprot.readMapBegin()
+                for _ in range(elem64):
+                    elem66 = iprot.readI64()
+                    elem65 = Event()
+                    elem65.read(iprot)
+                    elem63[elem66] = elem65
                 iprot.readMapEnd()
-                req.append(elem60)
+                req.append(elem63)
             iprot.readListEnd()
             iprot.readMessageEnd()
             try:

--- a/test/expected/python.asyncio/variety/f_Foo.py
+++ b/test/expected/python.asyncio/variety/f_Foo.py
@@ -1104,11 +1104,11 @@ class oneWay_args(object):
             elif fid == 2:
                 if ftype == TType.MAP:
                     self.req = {}
-                    (_, _, elem42) = iprot.readMapBegin()
-                    for _ in range(elem42):
-                        elem44 = iprot.readI32()
-                        elem43 = iprot.readString()
-                        self.req[elem44] = elem43
+                    (_, _, elem45) = iprot.readMapBegin()
+                    for _ in range(elem45):
+                        elem47 = iprot.readI32()
+                        elem46 = iprot.readString()
+                        self.req[elem47] = elem46
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -1128,9 +1128,9 @@ class oneWay_args(object):
         if self.req is not None:
             oprot.writeFieldBegin('req', TType.MAP, 2)
             oprot.writeMapBegin(TType.I32, TType.STRING, len(self.req))
-            for elem46, elem45 in self.req.items():
-                oprot.writeI32(elem46)
-                oprot.writeString(elem45)
+            for elem49, elem48 in self.req.items():
+                oprot.writeI32(elem49)
+                oprot.writeString(elem48)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1442,20 +1442,20 @@ class underlying_types_test_args(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.list_type = []
-                    (_, elem47) = iprot.readListBegin()
-                    for _ in range(elem47):
-                        elem48 = iprot.readI64()
-                        self.list_type.append(elem48)
+                    (_, elem50) = iprot.readListBegin()
+                    for _ in range(elem50):
+                        elem51 = iprot.readI64()
+                        self.list_type.append(elem51)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.SET:
                     self.set_type = set()
-                    (_, elem49) = iprot.readSetBegin()
-                    for _ in range(elem49):
-                        elem50 = iprot.readI64()
-                        self.set_type.add(elem50)
+                    (_, elem52) = iprot.readSetBegin()
+                    for _ in range(elem52):
+                        elem53 = iprot.readI64()
+                        self.set_type.add(elem53)
                     iprot.readSetEnd()
                 else:
                     iprot.skip(ftype)
@@ -1471,15 +1471,15 @@ class underlying_types_test_args(object):
         if self.list_type is not None:
             oprot.writeFieldBegin('list_type', TType.LIST, 1)
             oprot.writeListBegin(TType.I64, len(self.list_type))
-            for elem51 in self.list_type:
-                oprot.writeI64(elem51)
+            for elem54 in self.list_type:
+                oprot.writeI64(elem54)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.set_type is not None:
             oprot.writeFieldBegin('set_type', TType.SET, 2)
             oprot.writeSetBegin(TType.I64, len(self.set_type))
-            for elem52 in self.set_type:
-                oprot.writeI64(elem52)
+            for elem55 in self.set_type:
+                oprot.writeI64(elem55)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1522,10 +1522,10 @@ class underlying_types_test_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_, elem53) = iprot.readListBegin()
-                    for _ in range(elem53):
-                        elem54 = iprot.readI64()
-                        self.success.append(elem54)
+                    (_, elem56) = iprot.readListBegin()
+                    for _ in range(elem56):
+                        elem57 = iprot.readI64()
+                        self.success.append(elem57)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -1541,8 +1541,8 @@ class underlying_types_test_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.I64, len(self.success))
-            for elem55 in self.success:
-                oprot.writeI64(elem55)
+            for elem58 in self.success:
+                oprot.writeI64(elem58)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()

--- a/test/expected/python.asyncio/variety/ttypes.py
+++ b/test/expected/python.asyncio/variety/ttypes.py
@@ -625,8 +625,15 @@ class EventWrapper(object):
      - aBoolField
      - a_union
      - typedefOfTypedef
+     - depr: This is a docstring comment for a deprecated field that has been spread
+       across two lines.
+       Deprecated: use something else
+     - deprBinary
+       Deprecated: use something else
+     - deprList
+       Deprecated: use something else
     """
-    def __init__(self, ID=None, Ev=None, Events=None, Events2=None, EventMap=None, Nums=None, Enums=None, aBoolField=None, a_union=None, typedefOfTypedef=None):
+    def __init__(self, ID=None, Ev=None, Events=None, Events2=None, EventMap=None, Nums=None, Enums=None, aBoolField=None, a_union=None, typedefOfTypedef=None, depr=None, deprBinary=None, deprList=None):
         self.ID = ID
         self.Ev = Ev
         self.Events = Events
@@ -637,6 +644,9 @@ class EventWrapper(object):
         self.aBoolField = aBoolField
         self.a_union = a_union
         self.typedefOfTypedef = typedefOfTypedef
+        self.depr = depr
+        self.deprBinary = deprBinary
+        self.deprList = deprList
 
     def read(self, iprot):
         iprot.readStructBegin()
@@ -730,6 +740,26 @@ class EventWrapper(object):
                     self.typedefOfTypedef = iprot.readString()
                 else:
                     iprot.skip(ftype)
+            elif fid == 11:
+                if ftype == TType.BOOL:
+                    self.depr = iprot.readBool()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 12:
+                if ftype == TType.STRING:
+                    self.deprBinary = iprot.readBinary()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 13:
+                if ftype == TType.LIST:
+                    self.deprList = []
+                    (_, elem30) = iprot.readListBegin()
+                    for _ in range(elem30):
+                        elem31 = iprot.readBool()
+                        self.deprList.append(elem31)
+                    iprot.readListEnd()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -750,40 +780,40 @@ class EventWrapper(object):
         if self.Events is not None:
             oprot.writeFieldBegin('Events', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.Events))
-            for elem30 in self.Events:
-                elem30.write(oprot)
+            for elem32 in self.Events:
+                elem32.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.Events2 is not None:
             oprot.writeFieldBegin('Events2', TType.SET, 4)
             oprot.writeSetBegin(TType.STRUCT, len(self.Events2))
-            for elem31 in self.Events2:
-                elem31.write(oprot)
+            for elem33 in self.Events2:
+                elem33.write(oprot)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         if self.EventMap is not None:
             oprot.writeFieldBegin('EventMap', TType.MAP, 5)
             oprot.writeMapBegin(TType.I64, TType.STRUCT, len(self.EventMap))
-            for elem33, elem32 in self.EventMap.items():
-                oprot.writeI64(elem33)
-                elem32.write(oprot)
+            for elem35, elem34 in self.EventMap.items():
+                oprot.writeI64(elem35)
+                elem34.write(oprot)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.Nums is not None:
             oprot.writeFieldBegin('Nums', TType.LIST, 6)
             oprot.writeListBegin(TType.LIST, len(self.Nums))
-            for elem34 in self.Nums:
-                oprot.writeListBegin(TType.I32, len(elem34))
-                for elem35 in elem34:
-                    oprot.writeI32(elem35)
+            for elem36 in self.Nums:
+                oprot.writeListBegin(TType.I32, len(elem36))
+                for elem37 in elem36:
+                    oprot.writeI32(elem37)
                 oprot.writeListEnd()
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.Enums is not None:
             oprot.writeFieldBegin('Enums', TType.LIST, 7)
             oprot.writeListBegin(TType.I32, len(self.Enums))
-            for elem36 in self.Enums:
-                oprot.writeI32(elem36)
+            for elem38 in self.Enums:
+                oprot.writeI32(elem38)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.aBoolField is not None:
@@ -797,6 +827,21 @@ class EventWrapper(object):
         if self.typedefOfTypedef is not None:
             oprot.writeFieldBegin('typedefOfTypedef', TType.STRING, 10)
             oprot.writeString(self.typedefOfTypedef)
+            oprot.writeFieldEnd()
+        if self.depr is not None:
+            oprot.writeFieldBegin('depr', TType.BOOL, 11)
+            oprot.writeBool(self.depr)
+            oprot.writeFieldEnd()
+        if self.deprBinary is not None:
+            oprot.writeFieldBegin('deprBinary', TType.STRING, 12)
+            oprot.writeBinary(self.deprBinary)
+            oprot.writeFieldEnd()
+        if self.deprList is not None:
+            oprot.writeFieldBegin('deprList', TType.LIST, 13)
+            oprot.writeListBegin(TType.BOOL, len(self.deprList))
+            for elem39 in self.deprList:
+                oprot.writeBool(elem39)
+            oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -818,6 +863,9 @@ class EventWrapper(object):
         value = (value * 31) ^ hash(make_hashable(self.aBoolField))
         value = (value * 31) ^ hash(make_hashable(self.a_union))
         value = (value * 31) ^ hash(make_hashable(self.typedefOfTypedef))
+        value = (value * 31) ^ hash(make_hashable(self.depr))
+        value = (value * 31) ^ hash(make_hashable(self.deprBinary))
+        value = (value * 31) ^ hash(make_hashable(self.deprList))
         return value
 
     def __repr__(self):
@@ -840,14 +888,17 @@ class TestingUnions(object):
      - AnInt16
      - Requests
      - bin_field_in_union
+     - depr
+       Deprecated: use something else
     """
-    def __init__(self, AnID=None, aString=None, someotherthing=None, AnInt16=None, Requests=None, bin_field_in_union=None):
+    def __init__(self, AnID=None, aString=None, someotherthing=None, AnInt16=None, Requests=None, bin_field_in_union=None, depr=None):
         self.AnID = AnID
         self.aString = aString
         self.someotherthing = someotherthing
         self.AnInt16 = AnInt16
         self.Requests = Requests
         self.bin_field_in_union = bin_field_in_union
+        self.depr = depr
 
     def read(self, iprot):
         iprot.readStructBegin()
@@ -878,17 +929,22 @@ class TestingUnions(object):
             elif fid == 5:
                 if ftype == TType.MAP:
                     self.Requests = {}
-                    (_, _, elem37) = iprot.readMapBegin()
-                    for _ in range(elem37):
-                        elem39 = iprot.readI32()
-                        elem38 = iprot.readString()
-                        self.Requests[elem39] = elem38
+                    (_, _, elem40) = iprot.readMapBegin()
+                    for _ in range(elem40):
+                        elem42 = iprot.readI32()
+                        elem41 = iprot.readString()
+                        self.Requests[elem42] = elem41
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
                 if ftype == TType.STRING:
                     self.bin_field_in_union = iprot.readBinary()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 7:
+                if ftype == TType.BOOL:
+                    self.depr = iprot.readBool()
                 else:
                     iprot.skip(ftype)
             else:
@@ -919,14 +975,18 @@ class TestingUnions(object):
         if self.Requests is not None:
             oprot.writeFieldBegin('Requests', TType.MAP, 5)
             oprot.writeMapBegin(TType.I32, TType.STRING, len(self.Requests))
-            for elem41, elem40 in self.Requests.items():
-                oprot.writeI32(elem41)
-                oprot.writeString(elem40)
+            for elem44, elem43 in self.Requests.items():
+                oprot.writeI32(elem44)
+                oprot.writeString(elem43)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.bin_field_in_union is not None:
             oprot.writeFieldBegin('bin_field_in_union', TType.STRING, 6)
             oprot.writeBinary(self.bin_field_in_union)
+            oprot.writeFieldEnd()
+        if self.depr is not None:
+            oprot.writeFieldBegin('depr', TType.BOOL, 7)
+            oprot.writeBool(self.depr)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -945,6 +1005,8 @@ class TestingUnions(object):
             set_fields += 1
         if self.bin_field_in_union is not None:
             set_fields += 1
+        if self.depr is not None:
+            set_fields += 1
         if set_fields != 1:
             raise TProtocol.TProtocolException(type=TProtocol.TProtocolException.INVALID_DATA, message='The union did not have exactly one field set, {} were set'.format(set_fields))
         return
@@ -957,6 +1019,7 @@ class TestingUnions(object):
         value = (value * 31) ^ hash(make_hashable(self.AnInt16))
         value = (value * 31) ^ hash(make_hashable(self.Requests))
         value = (value * 31) ^ hash(make_hashable(self.bin_field_in_union))
+        value = (value * 31) ^ hash(make_hashable(self.depr))
         return value
 
     def __repr__(self):

--- a/test/expected/python.asyncio/variety/ttypes.py
+++ b/test/expected/python.asyncio/variety/ttypes.py
@@ -1038,10 +1038,13 @@ class AwesomeException(TException):
     Attributes:
      - ID: ID is a unique identifier for an awesome exception.
      - Reason: Reason contains the error message.
+     - depr
+       Deprecated: use something else
     """
-    def __init__(self, ID=None, Reason=None):
+    def __init__(self, ID=None, Reason=None, depr=None):
         self.ID = ID
         self.Reason = Reason
+        self.depr = depr
 
     def read(self, iprot):
         iprot.readStructBegin()
@@ -1057,6 +1060,11 @@ class AwesomeException(TException):
             elif fid == 2:
                 if ftype == TType.STRING:
                     self.Reason = iprot.readString()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 3:
+                if ftype == TType.BOOL:
+                    self.depr = iprot.readBool()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1076,6 +1084,10 @@ class AwesomeException(TException):
             oprot.writeFieldBegin('Reason', TType.STRING, 2)
             oprot.writeString(self.Reason)
             oprot.writeFieldEnd()
+        if self.depr is not None:
+            oprot.writeFieldBegin('depr', TType.BOOL, 3)
+            oprot.writeBool(self.depr)
+            oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
 
@@ -1089,6 +1101,7 @@ class AwesomeException(TException):
         value = 17
         value = (value * 31) ^ hash(make_hashable(self.ID))
         value = (value * 31) ^ hash(make_hashable(self.Reason))
+        value = (value * 31) ^ hash(make_hashable(self.depr))
         return value
 
     def __repr__(self):

--- a/test/expected/python.tornado/actual_base/ttypes.py
+++ b/test/expected/python.tornado/actual_base/ttypes.py
@@ -114,11 +114,11 @@ class nested_thing(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.things = []
-                    (_, elem64) = iprot.readListBegin()
-                    for _ in range(elem64):
-                        elem65 = thing()
-                        elem65.read(iprot)
-                        self.things.append(elem65)
+                    (_, elem67) = iprot.readListBegin()
+                    for _ in range(elem67):
+                        elem68 = thing()
+                        elem68.read(iprot)
+                        self.things.append(elem68)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -134,8 +134,8 @@ class nested_thing(object):
         if self.things is not None:
             oprot.writeFieldBegin('things', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.things))
-            for elem66 in self.things:
-                elem66.write(oprot)
+            for elem69 in self.things:
+                elem69.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()

--- a/test/expected/python.tornado/variety/f_Events_publisher.py
+++ b/test/expected/python.tornado/variety/f_Events_publisher.py
@@ -159,11 +159,11 @@ class EventsPublisher(object):
         oprot.write_request_headers(ctx)
         oprot.writeMessageBegin(op, TMessageType.CALL, 0)
         oprot.writeListBegin(TType.MAP, len(req))
-        for elem56 in req:
-            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(elem56))
-            for elem58, elem57 in elem56.items():
-                oprot.writeI64(elem58)
-                elem57.write(oprot)
+        for elem59 in req:
+            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(elem59))
+            for elem61, elem60 in elem59.items():
+                oprot.writeI64(elem61)
+                elem60.write(oprot)
             oprot.writeMapEnd()
         oprot.writeListEnd()
         oprot.writeMessageEnd()

--- a/test/expected/python.tornado/variety/f_Events_subscriber.py
+++ b/test/expected/python.tornado/variety/f_Events_subscriber.py
@@ -196,17 +196,17 @@ class EventsSubscriber(object):
                 iprot.readMessageEnd()
                 raise TApplicationException(TApplicationExceptionType.UNKNOWN_METHOD)
             req = []
-            (_, elem59) = iprot.readListBegin()
-            for _ in range(elem59):
-                elem60 = {}
-                (_, _, elem61) = iprot.readMapBegin()
-                for _ in range(elem61):
-                    elem63 = iprot.readI64()
-                    elem62 = Event()
-                    elem62.read(iprot)
-                    elem60[elem63] = elem62
+            (_, elem62) = iprot.readListBegin()
+            for _ in range(elem62):
+                elem63 = {}
+                (_, _, elem64) = iprot.readMapBegin()
+                for _ in range(elem64):
+                    elem66 = iprot.readI64()
+                    elem65 = Event()
+                    elem65.read(iprot)
+                    elem63[elem66] = elem65
                 iprot.readMapEnd()
-                req.append(elem60)
+                req.append(elem63)
             iprot.readListEnd()
             iprot.readMessageEnd()
             try:

--- a/test/expected/python.tornado/variety/f_Foo.py
+++ b/test/expected/python.tornado/variety/f_Foo.py
@@ -1092,11 +1092,11 @@ class oneWay_args(object):
             elif fid == 2:
                 if ftype == TType.MAP:
                     self.req = {}
-                    (_, _, elem42) = iprot.readMapBegin()
-                    for _ in range(elem42):
-                        elem44 = iprot.readI32()
-                        elem43 = iprot.readString()
-                        self.req[elem44] = elem43
+                    (_, _, elem45) = iprot.readMapBegin()
+                    for _ in range(elem45):
+                        elem47 = iprot.readI32()
+                        elem46 = iprot.readString()
+                        self.req[elem47] = elem46
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -1116,9 +1116,9 @@ class oneWay_args(object):
         if self.req is not None:
             oprot.writeFieldBegin('req', TType.MAP, 2)
             oprot.writeMapBegin(TType.I32, TType.STRING, len(self.req))
-            for elem46, elem45 in self.req.items():
-                oprot.writeI32(elem46)
-                oprot.writeString(elem45)
+            for elem49, elem48 in self.req.items():
+                oprot.writeI32(elem49)
+                oprot.writeString(elem48)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1430,20 +1430,20 @@ class underlying_types_test_args(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.list_type = []
-                    (_, elem47) = iprot.readListBegin()
-                    for _ in range(elem47):
-                        elem48 = iprot.readI64()
-                        self.list_type.append(elem48)
+                    (_, elem50) = iprot.readListBegin()
+                    for _ in range(elem50):
+                        elem51 = iprot.readI64()
+                        self.list_type.append(elem51)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.SET:
                     self.set_type = set()
-                    (_, elem49) = iprot.readSetBegin()
-                    for _ in range(elem49):
-                        elem50 = iprot.readI64()
-                        self.set_type.add(elem50)
+                    (_, elem52) = iprot.readSetBegin()
+                    for _ in range(elem52):
+                        elem53 = iprot.readI64()
+                        self.set_type.add(elem53)
                     iprot.readSetEnd()
                 else:
                     iprot.skip(ftype)
@@ -1459,15 +1459,15 @@ class underlying_types_test_args(object):
         if self.list_type is not None:
             oprot.writeFieldBegin('list_type', TType.LIST, 1)
             oprot.writeListBegin(TType.I64, len(self.list_type))
-            for elem51 in self.list_type:
-                oprot.writeI64(elem51)
+            for elem54 in self.list_type:
+                oprot.writeI64(elem54)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.set_type is not None:
             oprot.writeFieldBegin('set_type', TType.SET, 2)
             oprot.writeSetBegin(TType.I64, len(self.set_type))
-            for elem52 in self.set_type:
-                oprot.writeI64(elem52)
+            for elem55 in self.set_type:
+                oprot.writeI64(elem55)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1510,10 +1510,10 @@ class underlying_types_test_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_, elem53) = iprot.readListBegin()
-                    for _ in range(elem53):
-                        elem54 = iprot.readI64()
-                        self.success.append(elem54)
+                    (_, elem56) = iprot.readListBegin()
+                    for _ in range(elem56):
+                        elem57 = iprot.readI64()
+                        self.success.append(elem57)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -1529,8 +1529,8 @@ class underlying_types_test_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.I64, len(self.success))
-            for elem55 in self.success:
-                oprot.writeI64(elem55)
+            for elem58 in self.success:
+                oprot.writeI64(elem58)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()

--- a/test/expected/python.tornado/variety/ttypes.py
+++ b/test/expected/python.tornado/variety/ttypes.py
@@ -625,8 +625,15 @@ class EventWrapper(object):
      - aBoolField
      - a_union
      - typedefOfTypedef
+     - depr: This is a docstring comment for a deprecated field that has been spread
+       across two lines.
+       Deprecated: use something else
+     - deprBinary
+       Deprecated: use something else
+     - deprList
+       Deprecated: use something else
     """
-    def __init__(self, ID=None, Ev=None, Events=None, Events2=None, EventMap=None, Nums=None, Enums=None, aBoolField=None, a_union=None, typedefOfTypedef=None):
+    def __init__(self, ID=None, Ev=None, Events=None, Events2=None, EventMap=None, Nums=None, Enums=None, aBoolField=None, a_union=None, typedefOfTypedef=None, depr=None, deprBinary=None, deprList=None):
         self.ID = ID
         self.Ev = Ev
         self.Events = Events
@@ -637,6 +644,9 @@ class EventWrapper(object):
         self.aBoolField = aBoolField
         self.a_union = a_union
         self.typedefOfTypedef = typedefOfTypedef
+        self.depr = depr
+        self.deprBinary = deprBinary
+        self.deprList = deprList
 
     def read(self, iprot):
         iprot.readStructBegin()
@@ -730,6 +740,26 @@ class EventWrapper(object):
                     self.typedefOfTypedef = iprot.readString()
                 else:
                     iprot.skip(ftype)
+            elif fid == 11:
+                if ftype == TType.BOOL:
+                    self.depr = iprot.readBool()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 12:
+                if ftype == TType.STRING:
+                    self.deprBinary = iprot.readBinary()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 13:
+                if ftype == TType.LIST:
+                    self.deprList = []
+                    (_, elem30) = iprot.readListBegin()
+                    for _ in range(elem30):
+                        elem31 = iprot.readBool()
+                        self.deprList.append(elem31)
+                    iprot.readListEnd()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -750,40 +780,40 @@ class EventWrapper(object):
         if self.Events is not None:
             oprot.writeFieldBegin('Events', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.Events))
-            for elem30 in self.Events:
-                elem30.write(oprot)
+            for elem32 in self.Events:
+                elem32.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.Events2 is not None:
             oprot.writeFieldBegin('Events2', TType.SET, 4)
             oprot.writeSetBegin(TType.STRUCT, len(self.Events2))
-            for elem31 in self.Events2:
-                elem31.write(oprot)
+            for elem33 in self.Events2:
+                elem33.write(oprot)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         if self.EventMap is not None:
             oprot.writeFieldBegin('EventMap', TType.MAP, 5)
             oprot.writeMapBegin(TType.I64, TType.STRUCT, len(self.EventMap))
-            for elem33, elem32 in self.EventMap.items():
-                oprot.writeI64(elem33)
-                elem32.write(oprot)
+            for elem35, elem34 in self.EventMap.items():
+                oprot.writeI64(elem35)
+                elem34.write(oprot)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.Nums is not None:
             oprot.writeFieldBegin('Nums', TType.LIST, 6)
             oprot.writeListBegin(TType.LIST, len(self.Nums))
-            for elem34 in self.Nums:
-                oprot.writeListBegin(TType.I32, len(elem34))
-                for elem35 in elem34:
-                    oprot.writeI32(elem35)
+            for elem36 in self.Nums:
+                oprot.writeListBegin(TType.I32, len(elem36))
+                for elem37 in elem36:
+                    oprot.writeI32(elem37)
                 oprot.writeListEnd()
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.Enums is not None:
             oprot.writeFieldBegin('Enums', TType.LIST, 7)
             oprot.writeListBegin(TType.I32, len(self.Enums))
-            for elem36 in self.Enums:
-                oprot.writeI32(elem36)
+            for elem38 in self.Enums:
+                oprot.writeI32(elem38)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.aBoolField is not None:
@@ -797,6 +827,21 @@ class EventWrapper(object):
         if self.typedefOfTypedef is not None:
             oprot.writeFieldBegin('typedefOfTypedef', TType.STRING, 10)
             oprot.writeString(self.typedefOfTypedef)
+            oprot.writeFieldEnd()
+        if self.depr is not None:
+            oprot.writeFieldBegin('depr', TType.BOOL, 11)
+            oprot.writeBool(self.depr)
+            oprot.writeFieldEnd()
+        if self.deprBinary is not None:
+            oprot.writeFieldBegin('deprBinary', TType.STRING, 12)
+            oprot.writeBinary(self.deprBinary)
+            oprot.writeFieldEnd()
+        if self.deprList is not None:
+            oprot.writeFieldBegin('deprList', TType.LIST, 13)
+            oprot.writeListBegin(TType.BOOL, len(self.deprList))
+            for elem39 in self.deprList:
+                oprot.writeBool(elem39)
+            oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -818,6 +863,9 @@ class EventWrapper(object):
         value = (value * 31) ^ hash(make_hashable(self.aBoolField))
         value = (value * 31) ^ hash(make_hashable(self.a_union))
         value = (value * 31) ^ hash(make_hashable(self.typedefOfTypedef))
+        value = (value * 31) ^ hash(make_hashable(self.depr))
+        value = (value * 31) ^ hash(make_hashable(self.deprBinary))
+        value = (value * 31) ^ hash(make_hashable(self.deprList))
         return value
 
     def __repr__(self):
@@ -840,14 +888,17 @@ class TestingUnions(object):
      - AnInt16
      - Requests
      - bin_field_in_union
+     - depr
+       Deprecated: use something else
     """
-    def __init__(self, AnID=None, aString=None, someotherthing=None, AnInt16=None, Requests=None, bin_field_in_union=None):
+    def __init__(self, AnID=None, aString=None, someotherthing=None, AnInt16=None, Requests=None, bin_field_in_union=None, depr=None):
         self.AnID = AnID
         self.aString = aString
         self.someotherthing = someotherthing
         self.AnInt16 = AnInt16
         self.Requests = Requests
         self.bin_field_in_union = bin_field_in_union
+        self.depr = depr
 
     def read(self, iprot):
         iprot.readStructBegin()
@@ -878,17 +929,22 @@ class TestingUnions(object):
             elif fid == 5:
                 if ftype == TType.MAP:
                     self.Requests = {}
-                    (_, _, elem37) = iprot.readMapBegin()
-                    for _ in range(elem37):
-                        elem39 = iprot.readI32()
-                        elem38 = iprot.readString()
-                        self.Requests[elem39] = elem38
+                    (_, _, elem40) = iprot.readMapBegin()
+                    for _ in range(elem40):
+                        elem42 = iprot.readI32()
+                        elem41 = iprot.readString()
+                        self.Requests[elem42] = elem41
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
                 if ftype == TType.STRING:
                     self.bin_field_in_union = iprot.readBinary()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 7:
+                if ftype == TType.BOOL:
+                    self.depr = iprot.readBool()
                 else:
                     iprot.skip(ftype)
             else:
@@ -919,14 +975,18 @@ class TestingUnions(object):
         if self.Requests is not None:
             oprot.writeFieldBegin('Requests', TType.MAP, 5)
             oprot.writeMapBegin(TType.I32, TType.STRING, len(self.Requests))
-            for elem41, elem40 in self.Requests.items():
-                oprot.writeI32(elem41)
-                oprot.writeString(elem40)
+            for elem44, elem43 in self.Requests.items():
+                oprot.writeI32(elem44)
+                oprot.writeString(elem43)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.bin_field_in_union is not None:
             oprot.writeFieldBegin('bin_field_in_union', TType.STRING, 6)
             oprot.writeBinary(self.bin_field_in_union)
+            oprot.writeFieldEnd()
+        if self.depr is not None:
+            oprot.writeFieldBegin('depr', TType.BOOL, 7)
+            oprot.writeBool(self.depr)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -945,6 +1005,8 @@ class TestingUnions(object):
             set_fields += 1
         if self.bin_field_in_union is not None:
             set_fields += 1
+        if self.depr is not None:
+            set_fields += 1
         if set_fields != 1:
             raise TProtocol.TProtocolException(type=TProtocol.TProtocolException.INVALID_DATA, message='The union did not have exactly one field set, {} were set'.format(set_fields))
         return
@@ -957,6 +1019,7 @@ class TestingUnions(object):
         value = (value * 31) ^ hash(make_hashable(self.AnInt16))
         value = (value * 31) ^ hash(make_hashable(self.Requests))
         value = (value * 31) ^ hash(make_hashable(self.bin_field_in_union))
+        value = (value * 31) ^ hash(make_hashable(self.depr))
         return value
 
     def __repr__(self):

--- a/test/expected/python.tornado/variety/ttypes.py
+++ b/test/expected/python.tornado/variety/ttypes.py
@@ -1038,10 +1038,13 @@ class AwesomeException(TException):
     Attributes:
      - ID: ID is a unique identifier for an awesome exception.
      - Reason: Reason contains the error message.
+     - depr
+       Deprecated: use something else
     """
-    def __init__(self, ID=None, Reason=None):
+    def __init__(self, ID=None, Reason=None, depr=None):
         self.ID = ID
         self.Reason = Reason
+        self.depr = depr
 
     def read(self, iprot):
         iprot.readStructBegin()
@@ -1057,6 +1060,11 @@ class AwesomeException(TException):
             elif fid == 2:
                 if ftype == TType.STRING:
                     self.Reason = iprot.readString()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 3:
+                if ftype == TType.BOOL:
+                    self.depr = iprot.readBool()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1076,6 +1084,10 @@ class AwesomeException(TException):
             oprot.writeFieldBegin('Reason', TType.STRING, 2)
             oprot.writeString(self.Reason)
             oprot.writeFieldEnd()
+        if self.depr is not None:
+            oprot.writeFieldBegin('depr', TType.BOOL, 3)
+            oprot.writeBool(self.depr)
+            oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
 
@@ -1089,6 +1101,7 @@ class AwesomeException(TException):
         value = 17
         value = (value * 31) ^ hash(make_hashable(self.ID))
         value = (value * 31) ^ hash(make_hashable(self.Reason))
+        value = (value * 31) ^ hash(make_hashable(self.depr))
         return value
 
     def __repr__(self):

--- a/test/expected/python/actual_base/ttypes.py
+++ b/test/expected/python/actual_base/ttypes.py
@@ -114,11 +114,11 @@ class nested_thing(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.things = []
-                    (_, elem59) = iprot.readListBegin()
-                    for _ in range(elem59):
-                        elem60 = thing()
-                        elem60.read(iprot)
-                        self.things.append(elem60)
+                    (_, elem62) = iprot.readListBegin()
+                    for _ in range(elem62):
+                        elem63 = thing()
+                        elem63.read(iprot)
+                        self.things.append(elem63)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -134,8 +134,8 @@ class nested_thing(object):
         if self.things is not None:
             oprot.writeFieldBegin('things', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.things))
-            for elem61 in self.things:
-                elem61.write(oprot)
+            for elem64 in self.things:
+                elem64.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()

--- a/test/expected/python/variety/f_Events_publisher.py
+++ b/test/expected/python/variety/f_Events_publisher.py
@@ -139,11 +139,11 @@ class EventsPublisher(object):
         oprot.write_request_headers(ctx)
         oprot.writeMessageBegin(op, TMessageType.CALL, 0)
         oprot.writeListBegin(TType.MAP, len(req))
-        for elem56 in req:
-            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(elem56))
-            for elem58, elem57 in elem56.items():
-                oprot.writeI64(elem58)
-                elem57.write(oprot)
+        for elem59 in req:
+            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(elem59))
+            for elem61, elem60 in elem59.items():
+                oprot.writeI64(elem61)
+                elem60.write(oprot)
             oprot.writeMapEnd()
         oprot.writeListEnd()
         oprot.writeMessageEnd()

--- a/test/expected/python/variety/f_Foo.py
+++ b/test/expected/python/variety/f_Foo.py
@@ -1145,11 +1145,11 @@ class oneWay_args(object):
             elif fid == 2:
                 if ftype == TType.MAP:
                     self.req = {}
-                    (_, _, elem42) = iprot.readMapBegin()
-                    for _ in range(elem42):
-                        elem44 = iprot.readI32()
-                        elem43 = iprot.readString()
-                        self.req[elem44] = elem43
+                    (_, _, elem45) = iprot.readMapBegin()
+                    for _ in range(elem45):
+                        elem47 = iprot.readI32()
+                        elem46 = iprot.readString()
+                        self.req[elem47] = elem46
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -1169,9 +1169,9 @@ class oneWay_args(object):
         if self.req is not None:
             oprot.writeFieldBegin('req', TType.MAP, 2)
             oprot.writeMapBegin(TType.I32, TType.STRING, len(self.req))
-            for elem46, elem45 in self.req.items():
-                oprot.writeI32(elem46)
-                oprot.writeString(elem45)
+            for elem49, elem48 in self.req.items():
+                oprot.writeI32(elem49)
+                oprot.writeString(elem48)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1483,20 +1483,20 @@ class underlying_types_test_args(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.list_type = []
-                    (_, elem47) = iprot.readListBegin()
-                    for _ in range(elem47):
-                        elem48 = iprot.readI64()
-                        self.list_type.append(elem48)
+                    (_, elem50) = iprot.readListBegin()
+                    for _ in range(elem50):
+                        elem51 = iprot.readI64()
+                        self.list_type.append(elem51)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.SET:
                     self.set_type = set()
-                    (_, elem49) = iprot.readSetBegin()
-                    for _ in range(elem49):
-                        elem50 = iprot.readI64()
-                        self.set_type.add(elem50)
+                    (_, elem52) = iprot.readSetBegin()
+                    for _ in range(elem52):
+                        elem53 = iprot.readI64()
+                        self.set_type.add(elem53)
                     iprot.readSetEnd()
                 else:
                     iprot.skip(ftype)
@@ -1512,15 +1512,15 @@ class underlying_types_test_args(object):
         if self.list_type is not None:
             oprot.writeFieldBegin('list_type', TType.LIST, 1)
             oprot.writeListBegin(TType.I64, len(self.list_type))
-            for elem51 in self.list_type:
-                oprot.writeI64(elem51)
+            for elem54 in self.list_type:
+                oprot.writeI64(elem54)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.set_type is not None:
             oprot.writeFieldBegin('set_type', TType.SET, 2)
             oprot.writeSetBegin(TType.I64, len(self.set_type))
-            for elem52 in self.set_type:
-                oprot.writeI64(elem52)
+            for elem55 in self.set_type:
+                oprot.writeI64(elem55)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1563,10 +1563,10 @@ class underlying_types_test_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_, elem53) = iprot.readListBegin()
-                    for _ in range(elem53):
-                        elem54 = iprot.readI64()
-                        self.success.append(elem54)
+                    (_, elem56) = iprot.readListBegin()
+                    for _ in range(elem56):
+                        elem57 = iprot.readI64()
+                        self.success.append(elem57)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -1582,8 +1582,8 @@ class underlying_types_test_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.I64, len(self.success))
-            for elem55 in self.success:
-                oprot.writeI64(elem55)
+            for elem58 in self.success:
+                oprot.writeI64(elem58)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()

--- a/test/expected/python/variety/ttypes.py
+++ b/test/expected/python/variety/ttypes.py
@@ -625,8 +625,15 @@ class EventWrapper(object):
      - aBoolField
      - a_union
      - typedefOfTypedef
+     - depr: This is a docstring comment for a deprecated field that has been spread
+       across two lines.
+       Deprecated: use something else
+     - deprBinary
+       Deprecated: use something else
+     - deprList
+       Deprecated: use something else
     """
-    def __init__(self, ID=None, Ev=None, Events=None, Events2=None, EventMap=None, Nums=None, Enums=None, aBoolField=None, a_union=None, typedefOfTypedef=None):
+    def __init__(self, ID=None, Ev=None, Events=None, Events2=None, EventMap=None, Nums=None, Enums=None, aBoolField=None, a_union=None, typedefOfTypedef=None, depr=None, deprBinary=None, deprList=None):
         self.ID = ID
         self.Ev = Ev
         self.Events = Events
@@ -637,6 +644,9 @@ class EventWrapper(object):
         self.aBoolField = aBoolField
         self.a_union = a_union
         self.typedefOfTypedef = typedefOfTypedef
+        self.depr = depr
+        self.deprBinary = deprBinary
+        self.deprList = deprList
 
     def read(self, iprot):
         iprot.readStructBegin()
@@ -730,6 +740,26 @@ class EventWrapper(object):
                     self.typedefOfTypedef = iprot.readString()
                 else:
                     iprot.skip(ftype)
+            elif fid == 11:
+                if ftype == TType.BOOL:
+                    self.depr = iprot.readBool()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 12:
+                if ftype == TType.STRING:
+                    self.deprBinary = iprot.readBinary()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 13:
+                if ftype == TType.LIST:
+                    self.deprList = []
+                    (_, elem30) = iprot.readListBegin()
+                    for _ in range(elem30):
+                        elem31 = iprot.readBool()
+                        self.deprList.append(elem31)
+                    iprot.readListEnd()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -750,40 +780,40 @@ class EventWrapper(object):
         if self.Events is not None:
             oprot.writeFieldBegin('Events', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.Events))
-            for elem30 in self.Events:
-                elem30.write(oprot)
+            for elem32 in self.Events:
+                elem32.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.Events2 is not None:
             oprot.writeFieldBegin('Events2', TType.SET, 4)
             oprot.writeSetBegin(TType.STRUCT, len(self.Events2))
-            for elem31 in self.Events2:
-                elem31.write(oprot)
+            for elem33 in self.Events2:
+                elem33.write(oprot)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         if self.EventMap is not None:
             oprot.writeFieldBegin('EventMap', TType.MAP, 5)
             oprot.writeMapBegin(TType.I64, TType.STRUCT, len(self.EventMap))
-            for elem33, elem32 in self.EventMap.items():
-                oprot.writeI64(elem33)
-                elem32.write(oprot)
+            for elem35, elem34 in self.EventMap.items():
+                oprot.writeI64(elem35)
+                elem34.write(oprot)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.Nums is not None:
             oprot.writeFieldBegin('Nums', TType.LIST, 6)
             oprot.writeListBegin(TType.LIST, len(self.Nums))
-            for elem34 in self.Nums:
-                oprot.writeListBegin(TType.I32, len(elem34))
-                for elem35 in elem34:
-                    oprot.writeI32(elem35)
+            for elem36 in self.Nums:
+                oprot.writeListBegin(TType.I32, len(elem36))
+                for elem37 in elem36:
+                    oprot.writeI32(elem37)
                 oprot.writeListEnd()
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.Enums is not None:
             oprot.writeFieldBegin('Enums', TType.LIST, 7)
             oprot.writeListBegin(TType.I32, len(self.Enums))
-            for elem36 in self.Enums:
-                oprot.writeI32(elem36)
+            for elem38 in self.Enums:
+                oprot.writeI32(elem38)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.aBoolField is not None:
@@ -797,6 +827,21 @@ class EventWrapper(object):
         if self.typedefOfTypedef is not None:
             oprot.writeFieldBegin('typedefOfTypedef', TType.STRING, 10)
             oprot.writeString(self.typedefOfTypedef)
+            oprot.writeFieldEnd()
+        if self.depr is not None:
+            oprot.writeFieldBegin('depr', TType.BOOL, 11)
+            oprot.writeBool(self.depr)
+            oprot.writeFieldEnd()
+        if self.deprBinary is not None:
+            oprot.writeFieldBegin('deprBinary', TType.STRING, 12)
+            oprot.writeBinary(self.deprBinary)
+            oprot.writeFieldEnd()
+        if self.deprList is not None:
+            oprot.writeFieldBegin('deprList', TType.LIST, 13)
+            oprot.writeListBegin(TType.BOOL, len(self.deprList))
+            for elem39 in self.deprList:
+                oprot.writeBool(elem39)
+            oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -818,6 +863,9 @@ class EventWrapper(object):
         value = (value * 31) ^ hash(make_hashable(self.aBoolField))
         value = (value * 31) ^ hash(make_hashable(self.a_union))
         value = (value * 31) ^ hash(make_hashable(self.typedefOfTypedef))
+        value = (value * 31) ^ hash(make_hashable(self.depr))
+        value = (value * 31) ^ hash(make_hashable(self.deprBinary))
+        value = (value * 31) ^ hash(make_hashable(self.deprList))
         return value
 
     def __repr__(self):
@@ -840,14 +888,17 @@ class TestingUnions(object):
      - AnInt16
      - Requests
      - bin_field_in_union
+     - depr
+       Deprecated: use something else
     """
-    def __init__(self, AnID=None, aString=None, someotherthing=None, AnInt16=None, Requests=None, bin_field_in_union=None):
+    def __init__(self, AnID=None, aString=None, someotherthing=None, AnInt16=None, Requests=None, bin_field_in_union=None, depr=None):
         self.AnID = AnID
         self.aString = aString
         self.someotherthing = someotherthing
         self.AnInt16 = AnInt16
         self.Requests = Requests
         self.bin_field_in_union = bin_field_in_union
+        self.depr = depr
 
     def read(self, iprot):
         iprot.readStructBegin()
@@ -878,17 +929,22 @@ class TestingUnions(object):
             elif fid == 5:
                 if ftype == TType.MAP:
                     self.Requests = {}
-                    (_, _, elem37) = iprot.readMapBegin()
-                    for _ in range(elem37):
-                        elem39 = iprot.readI32()
-                        elem38 = iprot.readString()
-                        self.Requests[elem39] = elem38
+                    (_, _, elem40) = iprot.readMapBegin()
+                    for _ in range(elem40):
+                        elem42 = iprot.readI32()
+                        elem41 = iprot.readString()
+                        self.Requests[elem42] = elem41
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
                 if ftype == TType.STRING:
                     self.bin_field_in_union = iprot.readBinary()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 7:
+                if ftype == TType.BOOL:
+                    self.depr = iprot.readBool()
                 else:
                     iprot.skip(ftype)
             else:
@@ -919,14 +975,18 @@ class TestingUnions(object):
         if self.Requests is not None:
             oprot.writeFieldBegin('Requests', TType.MAP, 5)
             oprot.writeMapBegin(TType.I32, TType.STRING, len(self.Requests))
-            for elem41, elem40 in self.Requests.items():
-                oprot.writeI32(elem41)
-                oprot.writeString(elem40)
+            for elem44, elem43 in self.Requests.items():
+                oprot.writeI32(elem44)
+                oprot.writeString(elem43)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.bin_field_in_union is not None:
             oprot.writeFieldBegin('bin_field_in_union', TType.STRING, 6)
             oprot.writeBinary(self.bin_field_in_union)
+            oprot.writeFieldEnd()
+        if self.depr is not None:
+            oprot.writeFieldBegin('depr', TType.BOOL, 7)
+            oprot.writeBool(self.depr)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -945,6 +1005,8 @@ class TestingUnions(object):
             set_fields += 1
         if self.bin_field_in_union is not None:
             set_fields += 1
+        if self.depr is not None:
+            set_fields += 1
         if set_fields != 1:
             raise TProtocol.TProtocolException(type=TProtocol.TProtocolException.INVALID_DATA, message='The union did not have exactly one field set, {} were set'.format(set_fields))
         return
@@ -957,6 +1019,7 @@ class TestingUnions(object):
         value = (value * 31) ^ hash(make_hashable(self.AnInt16))
         value = (value * 31) ^ hash(make_hashable(self.Requests))
         value = (value * 31) ^ hash(make_hashable(self.bin_field_in_union))
+        value = (value * 31) ^ hash(make_hashable(self.depr))
         return value
 
     def __repr__(self):

--- a/test/expected/python/variety/ttypes.py
+++ b/test/expected/python/variety/ttypes.py
@@ -1038,10 +1038,13 @@ class AwesomeException(TException):
     Attributes:
      - ID: ID is a unique identifier for an awesome exception.
      - Reason: Reason contains the error message.
+     - depr
+       Deprecated: use something else
     """
-    def __init__(self, ID=None, Reason=None):
+    def __init__(self, ID=None, Reason=None, depr=None):
         self.ID = ID
         self.Reason = Reason
+        self.depr = depr
 
     def read(self, iprot):
         iprot.readStructBegin()
@@ -1057,6 +1060,11 @@ class AwesomeException(TException):
             elif fid == 2:
                 if ftype == TType.STRING:
                     self.Reason = iprot.readString()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 3:
+                if ftype == TType.BOOL:
+                    self.depr = iprot.readBool()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1076,6 +1084,10 @@ class AwesomeException(TException):
             oprot.writeFieldBegin('Reason', TType.STRING, 2)
             oprot.writeString(self.Reason)
             oprot.writeFieldEnd()
+        if self.depr is not None:
+            oprot.writeFieldBegin('depr', TType.BOOL, 3)
+            oprot.writeBool(self.depr)
+            oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
 
@@ -1089,6 +1101,7 @@ class AwesomeException(TException):
         value = 17
         value = (value * 31) ^ hash(make_hashable(self.ID))
         value = (value * 31) ^ hash(make_hashable(self.Reason))
+        value = (value * 31) ^ hash(make_hashable(self.depr))
         return value
 
     def __repr__(self):

--- a/test/idl/variety.frugal
+++ b/test/idl/variety.frugal
@@ -78,6 +78,7 @@ union TestingUnions {
 	4: i16 AnInt16,
 	5: request Requests,
 	6: binary bin_field_in_union,
+	7: bool depr (deprecated="use something else"),
 }
 
 /**@
@@ -136,6 +137,13 @@ struct EventWrapper {
     8: bool aBoolField,
     9: TestingUnions a_union,
     10: t2_string typedefOfTypedef,
+    /**@
+     * This is a docstring comment for a deprecated field that has been spread
+     * across two lines.
+     */
+    11: bool depr (deprecated="use something else"),
+    12: binary deprBinary (deprecated="use something else"),
+    13: list<bool> deprList (deprecated="use something else"),
 }
 
 exception AwesomeException {

--- a/test/idl/variety.frugal
+++ b/test/idl/variety.frugal
@@ -152,6 +152,8 @@ exception AwesomeException {
 
     /**@ Reason contains the error message. */
     2: string Reason
+
+    3: bool depr (deprecated="use something else")
 }
 
 /**@


### PR DESCRIPTION
The support varies depending on the language:
- Dart: Add the `@deprecated` annotation, but only add "/// Deprecated" doc comments to the get/set for fields to avoid too much reptition.
- Go: Append "Deprecated" to the comments of the exported field. Additionally, add the deprecation value to service method comments.
- HTML: Append "Deprecated" to the comments column of the field.
- Java: Add the `@Deprecated` annotation to the public fields and all field-related methods, but only add javadoc to fields and get/set methods to avoid too much reptition.
- Python: Append "Deprecated" to the comment for the field in the class docstring.  Additionally, indent second and later comment lines so that it does not appear the following field is deprecated.

@Workiva/messaging-pp 