### PR TITLE
Fix travis for forks and dont try to push artifacts if not Workiva repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ env:
   - TWINE_REPOSITORY_URL=https://upload.pypi.org/latest/
 
 before_install:
+  - mkdir -p $GOPATH/src/github.com/Workiva/frugal
+  - rsync -av $TRAVIS_BUILD_DIR/ $GOPATH/src/github.com/Workiva/frugal
+  - export TRAVIS_BUILD_DIR=$GOPATH/src/github.com/Workiva/frugal
+  - cd $TRAVIS_BUILD_DIR
   - sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
   - sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
   - mkdir $HOME/.virtuanenvs && echo "export WORKON_HOME=$HOME/.virtualenvs" >> $HOME/.bashrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 dist: trusty
 group: deprecated-2017Q3
 language: go
+git:
+  depth: 1
 
 env:
   - TWINE_USERNAME=messaging
@@ -15,30 +17,22 @@ before_install:
   - cd $TRAVIS_BUILD_DIR
   - sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
   - sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-  - mkdir $HOME/.virtuanenvs && echo "export WORKON_HOME=$HOME/.virtualenvs" >> $HOME/.bashrc
+  - export PATH=/usr/lib/dart/bin:$PATH
   - sudo add-apt-repository -y ppa:openjdk-r/ppa
   - sudo add-apt-repository -y ppa:masterminds/glide
   - sudo apt-get update -qq
   - sudo apt-get -y install python3-pip python-dev build-essential virtualenvwrapper openjdk-8-jdk maven dart glide
-  - pip install -U setuptools virtualenv virtualenvwrapper
-  - echo "source /etc/bash_completion.d/virtualenvwrapper" >> $HOME/.bashrc && source $HOME/.bashrc
-  - cd $TRAVIS_BUILD_DIR/lib/python
-  - mkvirtualenv py2 && make deps-tornado deps-gae
-  - mkvirtualenv py3 -p $(which python3) && make deps-asyncio
+  - pip install -U virtualenv
 
 script:
-  - cd $TRAVIS_BUILD_DIR && go test ./test -race
-  - cd $TRAVIS_BUILD_DIR/lib/go && glide install && go test -race $(glide nv)
-  - cd $TRAVIS_BUILD_DIR/lib/python
-  - workon py2 && make xunit-py2 flake8-py2
-  - workon py3 && make xunit-py3 flake8-py3
-  - cd $TRAVIS_BUILD_DIR/lib/java && mvn clean verify
+  - make
 
 cache:
   directories:
   - "~/.m2/repository"
 
 after_success:
+  - bash <(curl -s https://codecov.io/bash)
   - cd $TRAVIS_BUILD_DIR && ./scripts/travis/before-deploy-java.sh
   - cd $TRAVIS_BUILD_DIR && ./scripts/travis/deploy-java.sh
   - cd $TRAVIS_BUILD_DIR && ./scripts/travis/deploy-python.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+THIS_REPO := github.com/Workiva/frugal
+
+all: unit
+
+clean:
+	@rm -rf /tmp/frugal
+	@rm -rf /tmp/frugal-py3
+
+unit: clean unit-cli unit-go unit-java unit-py2 unit-py3
+
+unit-cli:
+	go test ./test -race
+
+unit-go:
+	cd lib/go && glide install && go test -v -race 
+
+unit-java:
+	mvn -f lib/java/pom.xml checkstyle:check clean verify
+
+unit-py2:
+	virtualenv -p /usr/bin/python /tmp/frugal && \
+	. /tmp/frugal/bin/activate && \
+	$(MAKE) -C $(PWD)/lib/python deps-tornado deps-gae xunit-py2 flake8-py2 &&\
+	deactivate
+
+unit-py3:
+	virtualenv -p python3 /tmp/frugal-py3 && \
+	. /tmp/frugal-py3/bin/activate && \
+	$(MAKE) -C $(PWD)/lib/python deps-asyncio xunit-py3 flake8-py3 && \
+	deactivate
+
+.PHONY: \
+	all \
+	clean \
+	unit \
+	unit-cli \
+	unit-go \
+	unit-java \
+	venv-py2 \
+	venv-py3 \
+	unit-py2 \
+	unit-py3

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,4 @@
 # codecov inherits bot from team, do not add bot to this yml
-codecov:
-  url: "https://codecov.workiva.net"
-
 coverage:
   precision: 3
   round: down

--- a/scripts/travis/deploy-java.sh
+++ b/scripts/travis/deploy-java.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
+if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ] && [ "$TRAVIS_REPO_SLUG" == 'Workiva/frugal' ]; then
     cd $TRAVIS_BUILD_DIR/lib/java && mvn clean deploy -P sign,build-extras \
         --settings $TRAVIS_BUILD_DIR/lib/java/.travis.settings.xml \
         -Dmaven.test.skip=true

--- a/scripts/travis/deploy-python.sh
+++ b/scripts/travis/deploy-python.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
+if [ "$TRAVIS_BRANCH" = 'master' ] && [ "$TRAVIS_PULL_REQUEST" == 'false'  ] && [ "$TRAVIS_REPO_SLUG" == 'Workiva/frugal' ]; then
     pip install twine
     cd $TRAVIS_BUILD_DIR/lib/python
     make install


### PR DESCRIPTION
Forks do some funky stuff with the gopath since it clones into user/repo. Just moving the repo to the upstreams checkout folder appears to fix it. 

Also the script was trying to push on commits to master of my fork. This obviously fails because my travis fork doesn't have the necessary encrypted vars, but we should still just skip trying to deploy if not Workiva/frugal.

@brianshannan-wf @tylerrinnan-wf 