### PR TITLE
Glide examples

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,3 @@
 Pull requests should be made against the 'develop' branch, not master.
+
+@Workiva/messaging-pp @Workiva/product2

--- a/examples/go/Makefile
+++ b/examples/go/Makefile
@@ -1,0 +1,13 @@
+
+.PHONY: all
+all: install
+
+# Installs dependencies while sym linking the local frugal into the
+# vendor folder so local changes can be easily tested
+.PHONY: install
+install:
+	rm -rf vendor && \
+		glide install && \
+		rm -rf vendor/github.com/Workiva/frugal/lib/go && \
+		ln -s ${GOPATH}/src/github.com/Workiva/frugal/lib/go vendor/github.com/Workiva/frugal/lib/go
+

--- a/examples/go/glide.yaml
+++ b/examples/go/glide.yaml
@@ -1,0 +1,22 @@
+package: github.com/Workiva/frugal/examples/go
+import:
+- package: git.apache.org/thrift.git
+  subpackages:
+  - lib/go/thrift
+  version: 0.10.0
+- package: github.com/Sirupsen/logrus
+  repo: git@github.com:/sirupsen/logrus
+  vcs: git
+  version: ^v1.0.5
+- package: github.com/Workiva/frugal
+  subpackages:
+  - lib/go
+  version: 2.17.0
+- package: github.com/nats-io/go-nats
+  version: 6b6bf392d34d01f57cc563ae123f00c13778bd57
+- package: github.com/rs/cors
+  version: v1.3.0
+- package: golang.org/x/sys
+  version: b126b21c05a91c856b027c16779c12e3bf236954
+  subpackages:
+  - unix


### PR DESCRIPTION
- Added vendoring to the go example so it was easier to run
- Added a makefile that would sym link the local frugal dependency so they could be easily tested in the examples
- Added group mentions to the pr template