### PR TITLE
Support deprecated annotation for enum values

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -537,9 +537,7 @@ func (g *Generator) generateEnumUsingClasses(enum *parser.Enum) string {
 	contents := ""
 	contents += fmt.Sprintf("class %s {\n", enum.Name)
 	for _, field := range enum.Values {
-		if field.Comment != nil {
-			contents += g.generateDocComment(field.Comment, tab)
-		}
+		contents += g.generateCommentWithDeprecated(field.Comment, tab, field.Annotations)
 		contents += fmt.Sprintf(tab+"static const int %s = %d;\n", field.Name, field.Value)
 	}
 	contents += "\n"
@@ -563,9 +561,9 @@ func (g *Generator) generateEnumUsingEnums(enum *parser.Enum) string {
 	contents := ""
 	contents += fmt.Sprintf("enum %s {\n", enum.Name)
 	for _, field := range enum.Values {
-		if field.Comment != nil {
-			contents += g.generateDocComment(field.Comment, tab)
-		}
+		// The @deprecated annotation is not allowed on enum values:
+		// https://github.com/dart-lang/sdk/issues/23441
+		contents += g.generateCommentWithDeprecatedImpl(field.Comment, tab, field.Annotations, false)
 		contents += fmt.Sprintf(tab+"%s,\n", field.Name)
 	}
 	contents += "}\n\n"
@@ -1512,7 +1510,7 @@ func (g *Generator) GenerateService(file *os.File, s *parser.Service) error {
 	return err
 }
 
-func (g *Generator) generateCommentWithDeprecated(comment []string, indent string, anns parser.Annotations) string {
+func (g *Generator) generateCommentWithDeprecatedImpl(comment []string, indent string, anns parser.Annotations, deprecatedAnn bool) string {
 	contents := ""
 	if comment != nil {
 		contents += g.generateDocComment(comment, indent)
@@ -1522,10 +1520,16 @@ func (g *Generator) generateCommentWithDeprecated(comment []string, indent strin
 		if deprecationValue != "" {
 			contents += g.generateDocComment([]string{"Deprecated: " + deprecationValue}, indent)
 		}
-		contents += indent + "@deprecated\n"
+		if deprecatedAnn {
+			contents += indent + "@deprecated\n"
+		}
 	}
 
 	return contents
+}
+
+func (g *Generator) generateCommentWithDeprecated(comment []string, indent string, anns parser.Annotations) string {
+	return g.generateCommentWithDeprecatedImpl(comment, indent, anns, true)
 }
 
 func (g *Generator) generateInterface(service *parser.Service) string {

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -371,6 +371,10 @@ func (g *Generator) GenerateDocStringComment(file *os.File) error {
 	return err
 }
 
+func (g *Generator) generateDocComment(comment []string, indent string) string {
+	return g.GenerateInlineComment(comment, indent+"/")
+}
+
 // GenerateConstantsContents generates constants.
 func (g *Generator) GenerateConstantsContents(constants []*parser.Constant) error {
 	if len(constants) == 0 {
@@ -398,7 +402,7 @@ func (g *Generator) GenerateConstantsContents(constants []*parser.Constant) erro
 	contents += fmt.Sprintf("class %s {\n", className)
 	for _, constant := range constants {
 		if constant.Comment != nil {
-			contents += g.GenerateInlineComment(constant.Comment, tab+"/")
+			contents += g.generateDocComment(constant.Comment, tab)
 		}
 		value := g.generateConstantValue(constant.Type, constant.Value, "")
 		contents += fmt.Sprintf(tab+"static final %s %s = %s;\n",
@@ -534,7 +538,7 @@ func (g *Generator) generateEnumUsingClasses(enum *parser.Enum) string {
 	contents += fmt.Sprintf("class %s {\n", enum.Name)
 	for _, field := range enum.Values {
 		if field.Comment != nil {
-			contents += g.GenerateInlineComment(field.Comment, tab+"/")
+			contents += g.generateDocComment(field.Comment, tab)
 		}
 		contents += fmt.Sprintf(tab+"static const int %s = %d;\n", field.Name, field.Value)
 	}
@@ -560,7 +564,7 @@ func (g *Generator) generateEnumUsingEnums(enum *parser.Enum) string {
 	contents += fmt.Sprintf("enum %s {\n", enum.Name)
 	for _, field := range enum.Values {
 		if field.Comment != nil {
-			contents += g.GenerateInlineComment(field.Comment, tab+"/")
+			contents += g.generateDocComment(field.Comment, tab)
 		}
 		contents += fmt.Sprintf(tab+"%s,\n", field.Name)
 	}
@@ -1376,7 +1380,7 @@ func (g *Generator) GeneratePublisher(file *os.File, scope *parser.Scope) error 
 		publishers += prefix
 		prefix = "\n\n"
 		if op.Comment != nil {
-			publishers += g.GenerateInlineComment(op.Comment, tab+"/")
+			publishers += g.generateDocComment(op.Comment, tab)
 		}
 
 		publishers += fmt.Sprintf(tab+"Future publish%s(frugal.FContext ctx, %s%s req) {\n", op.Name, args, g.getDartTypeFromThriftType(op.Type))
@@ -1455,7 +1459,7 @@ func (g *Generator) GenerateSubscriber(file *os.File, scope *parser.Scope) error
 		subscribers += prefix
 		prefix = "\n\n"
 		if op.Comment != nil {
-			subscribers += g.GenerateInlineComment(op.Comment, tab+"/")
+			subscribers += g.generateDocComment(op.Comment, tab)
 		}
 		subscribers += fmt.Sprintf(tab+"Future<frugal.FSubscription> subscribe%s(%sdynamic on%s(frugal.FContext ctx, %s req)) async {\n",
 			op.Name, args, op.Type.ParamName(), g.getDartTypeFromThriftType(op.Type))
@@ -1511,12 +1515,12 @@ func (g *Generator) GenerateService(file *os.File, s *parser.Service) error {
 func (g *Generator) generateCommentWithDeprecated(comment []string, indent string, anns parser.Annotations) string {
 	contents := ""
 	if comment != nil {
-		contents += g.GenerateInlineComment(comment, indent+"/")
+		contents += g.generateDocComment(comment, indent)
 	}
 
 	if deprecationValue, deprecated := anns.Deprecated(); deprecated {
 		if deprecationValue != "" {
-			contents += g.GenerateInlineComment([]string{"Deprecated: " + deprecationValue}, indent+"/")
+			contents += g.generateDocComment([]string{"Deprecated: " + deprecationValue}, indent)
 		}
 		contents += indent + "@deprecated\n"
 	}

--- a/compiler/generator/golang/generator.go
+++ b/compiler/generator/golang/generator.go
@@ -330,9 +330,7 @@ func (g *Generator) GenerateEnum(enum *parser.Enum) error {
 	contents += fmt.Sprintf("type %s int64\n\n", eName)
 	contents += "const (\n"
 	for _, field := range enum.Values {
-		if field.Comment != nil {
-			contents += g.GenerateInlineComment(field.Comment, "\t")
-		}
+		contents += g.generateCommentWithDeprecated(field.Comment, "\t", field.Annotations)
 		contents += fmt.Sprintf("\t%s_%s %s = %d\n", eName, field.Name, eName, field.Value)
 	}
 	contents += ")\n\n"

--- a/compiler/generator/html/module_template.go
+++ b/compiler/generator/html/module_template.go
@@ -121,6 +121,7 @@ const moduleTemplate = `
 							{{ range .Comment }}
 								{{ . }}<br />
 							{{ end }}
+								{{ if .Annotations.IsDeprecated }}Deprecated{{ if .Annotations.DeprecationValue }}: {{ .Annotations.DeprecationValue }}{{ end }}{{ end }}
 							</td>
 						</tr>
 					{{ end }}
@@ -143,6 +144,7 @@ const moduleTemplate = `
 						{{ range .Comment }}
 						{{ . }}<br />
 						{{ end }}
+						{{ if .Annotations.IsDeprecated }}Deprecated{{ if .Annotations.DeprecationValue }}: {{ .Annotations.DeprecationValue }}{{ end }}{{ end }}
 					</blockquote>
 					{{ end }}
 				</div>

--- a/compiler/generator/java/generator.go
+++ b/compiler/generator/java/generator.go
@@ -363,9 +363,7 @@ func (g *Generator) GenerateEnum(enum *parser.Enum) error {
 		if idx == len(enum.Values)-1 {
 			terminator = ";"
 		}
-		if value.Comment != nil {
-			contents += g.GenerateBlockComment(value.Comment, tab)
-		}
+		contents += g.generateCommentWithDeprecated(value.Comment, tab, value.Annotations)
 		contents += fmt.Sprintf(tab+"%s(%d)%s\n", value.Name, value.Value, terminator)
 	}
 	contents += "\n"

--- a/compiler/generator/python/generator.go
+++ b/compiler/generator/python/generator.go
@@ -293,8 +293,16 @@ func (g *Generator) GenerateEnum(enum *parser.Enum) error {
 	contents += fmt.Sprintf("class %s(int):\n", enum.Name)
 	comment := append([]string{}, enum.Comment...)
 	for _, value := range enum.Values {
+		valueComment := []string{}
 		if value.Comment != nil {
-			comment = append(append(comment, value.Name+": "+value.Comment[0]), value.Comment[1:]...)
+			valueComment = append(valueComment, value.Comment...)
+		}
+		deprecationValue, deprecated := value.Annotations.Deprecated()
+		if deprecated {
+			valueComment = append(valueComment, "Deprecated: "+deprecationValue)
+		}
+		if len(valueComment) != 0 {
+			comment = append(append(comment, value.Name+": "+valueComment[0]), valueComment[1:]...)
 		}
 	}
 	if len(comment) != 0 {

--- a/test/expected/dart/enum/f_testing_enums.dart
+++ b/test/expected/dart/enum/f_testing_enums.dart
@@ -5,7 +5,11 @@ enum testing_enums {
   /// This docstring gets added to the generated code because it
   /// has the @ sign.
   one,
+  /// Deprecated: use something else
   two,
+  /// This is a docstring comment for a deprecated enum value that has been
+  /// spread across two lines.
+  /// Deprecated: don't use this; use "something else"
   Three,
 }
 

--- a/test/expected/dart/variety/f_health_condition.dart
+++ b/test/expected/dart/variety/f_health_condition.dart
@@ -8,7 +8,13 @@ class HealthCondition {
   /// This docstring also gets added to the generated code
   /// because it has the @ sign.
   static const int WARN = 2;
+  /// Deprecated: use something else
+  @deprecated
   static const int FAIL = 3;
+  /// This is a docstring comment for a deprecated enum value that has been
+  /// spread across two lines.
+  /// Deprecated: don't use this; use "something else"
+  @deprecated
   static const int UNKNOWN = 4;
 
   static final Set<int> VALID_VALUES = new Set.from([

--- a/test/expected/go/variety/f_types.txt
+++ b/test/expected/go/variety/f_types.txt
@@ -121,8 +121,12 @@ const (
 	HealthCondition_PASS HealthCondition = 1
 	// This docstring also gets added to the generated code
 	// because it has the @ sign.
-	HealthCondition_WARN    HealthCondition = 2
-	HealthCondition_FAIL    HealthCondition = 3
+	HealthCondition_WARN HealthCondition = 2
+	// Deprecated: use something else
+	HealthCondition_FAIL HealthCondition = 3
+	// This is a docstring comment for a deprecated enum value that has been
+	// spread across two lines.
+	// Deprecated: don't use this; use "something else"
 	HealthCondition_UNKNOWN HealthCondition = 4
 )
 

--- a/test/expected/html/base.html
+++ b/test/expected/html/base.html
@@ -83,6 +83,7 @@
 							<td><code>1</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -91,6 +92,7 @@
 							<td><code>2</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -99,6 +101,7 @@
 							<td><code>3</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -107,6 +110,7 @@
 							<td><code>4</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					

--- a/test/expected/html/standalone/base.html
+++ b/test/expected/html/standalone/base.html
@@ -268,6 +268,7 @@ code { line-height: 20px; }
 							<td><code>1</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -276,6 +277,7 @@ code { line-height: 20px; }
 							<td><code>2</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -284,6 +286,7 @@ code { line-height: 20px; }
 							<td><code>3</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -292,6 +295,7 @@ code { line-height: 20px; }
 							<td><code>4</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					

--- a/test/expected/html/standalone/variety.html
+++ b/test/expected/html/standalone/variety.html
@@ -481,6 +481,7 @@ code { line-height: 20px; }
 							
 								has the @ sign.<br />
 							
+								
 							</td>
 						</tr>
 					
@@ -493,6 +494,7 @@ code { line-height: 20px; }
 							
 								because it has the @ sign.<br />
 							
+								
 							</td>
 						</tr>
 					
@@ -501,6 +503,7 @@ code { line-height: 20px; }
 							<td><code>3</code></td>
 							<td>
 							
+								Deprecated: use something else
 							</td>
 						</tr>
 					
@@ -509,6 +512,11 @@ code { line-height: 20px; }
 							<td><code>4</code></td>
 							<td>
 							
+								This is a docstring comment for a deprecated enum value that has been<br />
+							
+								spread across two lines.<br />
+							
+								Deprecated: don&#39;t use this; use &#34;something else&#34;
 							</td>
 						</tr>
 					
@@ -525,6 +533,7 @@ code { line-height: 20px; }
 							<td><code>2</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -533,6 +542,7 @@ code { line-height: 20px; }
 							<td><code>3</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -541,6 +551,7 @@ code { line-height: 20px; }
 							<td><code>4</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -549,6 +560,7 @@ code { line-height: 20px; }
 							<td><code>5</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -557,6 +569,7 @@ code { line-height: 20px; }
 							<td><code>6</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -565,6 +578,7 @@ code { line-height: 20px; }
 							<td><code>7</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					

--- a/test/expected/html/variety.html
+++ b/test/expected/html/variety.html
@@ -296,6 +296,7 @@
 							
 								has the @ sign.<br />
 							
+								
 							</td>
 						</tr>
 					
@@ -308,6 +309,7 @@
 							
 								because it has the @ sign.<br />
 							
+								
 							</td>
 						</tr>
 					
@@ -316,6 +318,7 @@
 							<td><code>3</code></td>
 							<td>
 							
+								Deprecated: use something else
 							</td>
 						</tr>
 					
@@ -324,6 +327,11 @@
 							<td><code>4</code></td>
 							<td>
 							
+								This is a docstring comment for a deprecated enum value that has been<br />
+							
+								spread across two lines.<br />
+							
+								Deprecated: don&#39;t use this; use &#34;something else&#34;
 							</td>
 						</tr>
 					
@@ -340,6 +348,7 @@
 							<td><code>2</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -348,6 +357,7 @@
 							<td><code>3</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -356,6 +366,7 @@
 							<td><code>4</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -364,6 +375,7 @@
 							<td><code>5</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -372,6 +384,7 @@
 							<td><code>6</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					
@@ -380,6 +393,7 @@
 							<td><code>7</code></td>
 							<td>
 							
+								
 							</td>
 						</tr>
 					

--- a/test/expected/java/variety/HealthCondition.java
+++ b/test/expected/java/variety/HealthCondition.java
@@ -21,7 +21,17 @@ public enum HealthCondition implements org.apache.thrift.TEnum {
 	 * because it has the @ sign.
 	 */
 	WARN(2),
+	/**
+	 * @deprecated use something else
+	 */
+	@Deprecated
 	FAIL(3),
+	/**
+	 * This is a docstring comment for a deprecated enum value that has been
+	 * spread across two lines.
+	 * @deprecated don't use this; use "something else"
+	 */
+	@Deprecated
 	UNKNOWN(4);
 
 	private final int value;

--- a/test/expected/python.asyncio/variety/ttypes.py
+++ b/test/expected/python.asyncio/variety/ttypes.py
@@ -27,6 +27,10 @@ class HealthCondition(int):
     has the @ sign.
     WARN: This docstring also gets added to the generated code
     because it has the @ sign.
+    FAIL: Deprecated: use something else
+    UNKNOWN: This is a docstring comment for a deprecated enum value that has been
+    spread across two lines.
+    Deprecated: don't use this; use "something else"
     """
     PASS = 1
     WARN = 2

--- a/test/expected/python.tornado/variety/ttypes.py
+++ b/test/expected/python.tornado/variety/ttypes.py
@@ -27,6 +27,10 @@ class HealthCondition(int):
     has the @ sign.
     WARN: This docstring also gets added to the generated code
     because it has the @ sign.
+    FAIL: Deprecated: use something else
+    UNKNOWN: This is a docstring comment for a deprecated enum value that has been
+    spread across two lines.
+    Deprecated: don't use this; use "something else"
     """
     PASS = 1
     WARN = 2

--- a/test/expected/python/variety/ttypes.py
+++ b/test/expected/python/variety/ttypes.py
@@ -27,6 +27,10 @@ class HealthCondition(int):
     has the @ sign.
     WARN: This docstring also gets added to the generated code
     because it has the @ sign.
+    FAIL: Deprecated: use something else
+    UNKNOWN: This is a docstring comment for a deprecated enum value that has been
+    spread across two lines.
+    Deprecated: don't use this; use "something else"
     """
     PASS = 1
     WARN = 2

--- a/test/idl/enum.frugal
+++ b/test/idl/enum.frugal
@@ -6,6 +6,10 @@ enum testing_enums {
      * has the @ sign.
      */
     one = 45,
-    two = 3,
-    Three = 76,
+    two = 3 (deprecated="use something else"),
+    /**@
+     * This is a docstring comment for a deprecated enum value that has been
+     * spread across two lines.
+     */
+    Three = 76 (deprecated="don't use this; use \"something else\""),
 }

--- a/test/idl/variety.frugal
+++ b/test/idl/variety.frugal
@@ -67,8 +67,12 @@ enum HealthCondition {
      * because it has the @ sign.
      */
     WARN = 2,
-    FAIL = 3,
-    UNKNOWN = 4
+    FAIL = 3 (deprecated="use something else"),
+    /**@
+     * This is a docstring comment for a deprecated enum value that has been
+     * spread across two lines.
+     */
+    UNKNOWN = 4 (deprecated="don't use this; use \"something else\"")
 }
 
 union TestingUnions {


### PR DESCRIPTION
Commits are intended to be reviewed independently:
* Clean up Dart "doc comment" mentioned in [previous PR review](https://github.com/Workiva/frugal/pull/985#discussion_r177766884)
* Support deprecated annotation for enum values using the same pattern as #985.  The one caveat is that Dart enum values do not support annotations (see comment in code), so we just generate a comment for those.

@Workiva/messaging-pp 