### PR TITLE
Consume messaging-docker-images 0.0.23

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -8,7 +8,7 @@ run:  # local tests only, never run in Skynet
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:210905
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:323744
 
 env:
   - IN_SKYNET_CLI=true
@@ -41,7 +41,7 @@ requires:
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:210905
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:323744
 
 env:
   - PYTHONIOENCODING=utf-8

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,7 +1,7 @@
 project: frugal
 language: golang
 
-runner_image: drydock-prod.workiva.net/workiva/messaging-docker-images:210905
+runner_image: drydock-prod.workiva.net/workiva/messaging-docker-images:323744
 
 script:
     - ./scripts/smithy.sh


### PR DESCRIPTION

Pulls Included in Release:
* [INFENG-4640 trusty -> xenial; also remove thrift](https://github.com/Workiva/messaging-docker-images/pull/39)


Requested by: @brianshannan-wf

@jacobmoss-wf @jacobmoss-wf
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5198026715955200/logs/)