### PR TITLE
Python: Allow generation using absolute output directory path

### DIFF
--- a/compiler/generator/generator.go
+++ b/compiler/generator/generator.go
@@ -158,7 +158,9 @@ func NewProgramGenerator(generator LanguageGenerator, splitPublisherSubscriber b
 // Generate the Frugal in the given directory.
 func (o *programGenerator) Generate(frugal *parser.Frugal, outputDir string) error {
 	o.SetFrugal(frugal)
-	o.SetupGenerator(outputDir)
+	if err := o.SetupGenerator(outputDir); err != nil {
+		return err
+	}
 
 	if err := o.GenerateDependencies(outputDir); err != nil {
 		return err

--- a/compiler/generator/python/generator.go
+++ b/compiler/generator/python/generator.go
@@ -98,13 +98,15 @@ func (g *Generator) SetupGenerator(outputDir string) error {
 		return err
 	}
 
-	for dir != "." {
+	var priorDir string
+	for dir != priorDir {
 		file, err := g.GenerateFile("__init__", filepath.Join(absoluteOutputRoot, dir), generator.ObjectFile)
 		file.Close()
 		if err != nil {
 			return err
 		}
 
+		priorDir = dir
 		dir = filepath.Dir(dir)
 	}
 

--- a/compiler/generator/python/generator.go
+++ b/compiler/generator/python/generator.go
@@ -75,9 +75,31 @@ func NewGenerator(options map[string]string) generator.LanguageGenerator {
 func (g *Generator) SetupGenerator(outputDir string) error {
 	g.outputDir = outputDir
 
-	dir := g.outputDir
-	for filepath.Dir(dir) != "." {
-		file, err := g.GenerateFile("__init__", dir, generator.ObjectFile)
+	// To prevent littering the filesystem with __init__ in every folder between outputDir and the present working
+	// directory, use the relative path between the root output directory and the target outputDir. This creates
+	// __init__ files only in the folders used for frugal generation.
+	outputRoot := globals.Out
+	if outputRoot == "" {
+		outputRoot = g.DefaultOutputDir()
+	}
+
+	absoluteOutputRoot, err := filepath.Abs(outputRoot)
+	if err != nil {
+		return err
+	}
+
+	absoluteOutputDir, err := filepath.Abs(outputDir)
+	if err != nil {
+		return err
+	}
+
+	dir, err := filepath.Rel(absoluteOutputRoot, absoluteOutputDir)
+	if err != nil {
+		return err
+	}
+
+	for dir != "." {
+		file, err := g.GenerateFile("__init__", filepath.Join(absoluteOutputRoot, dir), generator.ObjectFile)
 		file.Close()
 		if err != nil {
 			return err

--- a/test/python_test.go
+++ b/test/python_test.go
@@ -151,3 +151,38 @@ func TestPythonExtendServiceSameFile(t *testing.T) {
 	copyAllFiles(t, files)
 	compareAllFiles(t, files)
 }
+
+func TestPythonAbsoluteOutputPath(t *testing.T) {
+	absoluteOutputDir, err := filepath.Abs(filepath.Join(outputDir, "absolute_path"))
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+
+	options := compiler.Options{
+		File:    frugalGenFile,
+		Gen:     "py",
+		Out:     absoluteOutputDir,
+		Delim:   delim,
+		Recurse: true,
+	}
+	if err := compiler.Compile(options); err != nil {
+		t.Fatal("unexpected error", err)
+	}
+
+	files := []FileComparisonPair{
+		{"expected/python/variety/__init__.py", filepath.Join(absoluteOutputDir, "variety", "python", "__init__.py")},
+		{"expected/python/variety/constants.py", filepath.Join(absoluteOutputDir, "variety", "python", "constants.py")},
+		{"expected/python/variety/ttypes.py", filepath.Join(absoluteOutputDir, "variety", "python", "ttypes.py")},
+		{"expected/python/variety/f_Events_publisher.py", filepath.Join(absoluteOutputDir, "variety", "python", "f_Events_publisher.py")},
+		{"expected/python/variety/f_Events_subscriber.py", filepath.Join(absoluteOutputDir, "variety", "python", "f_Events_subscriber.py")},
+		{"expected/python/variety/f_Foo.py", filepath.Join(absoluteOutputDir, "variety", "python", "f_Foo.py")},
+
+		{"expected/python/actual_base/__init__.py", filepath.Join(absoluteOutputDir, "actual_base", "python", "__init__.py")},
+		{"expected/python/actual_base/constants.py", filepath.Join(absoluteOutputDir, "actual_base", "python", "constants.py")},
+		{"expected/python/actual_base/ttypes.py", filepath.Join(absoluteOutputDir, "actual_base", "python", "ttypes.py")},
+		{"expected/python/actual_base/f_BaseFoo.py", filepath.Join(absoluteOutputDir, "actual_base", "python", "f_BaseFoo.py")},
+	}
+
+	copyAllFiles(t, files)
+	compareAllFiles(t, files)
+}


### PR DESCRIPTION
When given an absolute path for the output directory, the existing SetupGenerator
code for python either went into an infinite loop once it hit the filesystem root
when walking up the directory hierarchy or would silently error once it hit a
folder the running user did not have write permission. Additionally, the existing
algorithm would cause __init__.py to be created in folders unrelated to frugal code
generation simply because the folder existed along the relative path given for output
directory

Update the python generation code to
- Respect errors returned by the SetupGenerator method
- Only generate __init__.py files in the folders that exist between the root output
  directory and the target output directory for the generator. This change also
  addresses the potential infinite loop issue as the path used in the traversal
  algorithm will now be a relative path regardless of user input

@Workiva/messaging-pp @Workiva/product2
