### PR TITLE
INFENG-5834: Allow loose pinning of minor versions of requests and six

### DIFF
--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -22,9 +22,9 @@ setup(
     url='http://github.com/Workiva/frugal',
     packages=find_packages(exclude=('frugal.tests', 'frugal.tests.*')),
     install_requires=[
-        "six==1.10.0",
+        "six>=1.10.0,<2",
         "thrift==0.10.0",
-        "requests==2.12.5",
+        "requests>=2.12.5,<3",
     ],
     extras_require={
         'tornado': ["nats-client==0.5.0"],


### PR DESCRIPTION
The frugal python package pins its versions which causes warnings for consumers if the versions aren't exactly resolved. It would be nice to open up those ranges some so that this doesn't occur.

@Workiva/messaging-pp @Workiva/product2 @georgelesica-wf 
