### PR TITLE
java: Include cause for HTTP timeout exception

### DIFF
--- a/lib/java/src/main/java/com/workiva/frugal/transport/FHttpTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FHttpTransport.java
@@ -256,9 +256,12 @@ public class FHttpTransport extends FTransport {
         CloseableHttpResponse response;
         try {
             response = httpClient.execute(request);
-        } catch (ConnectTimeoutException | SocketTimeoutException e) {
+        } catch (ConnectTimeoutException e) {
             throw new TTransportException(TTransportExceptionType.TIMED_OUT,
-                    "http request timed out: " + e.getMessage());
+                    "http request connection timed out: " + e.getMessage(), e);
+        } catch (SocketTimeoutException e) {
+            throw new TTransportException(TTransportExceptionType.TIMED_OUT,
+                    "http request socket timed out: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new TTransportException("http request failed: " + e.getMessage(), e);
         }


### PR DESCRIPTION
In #1005, I convinced myself the timeout exception messages had sufficient context, but while debugging an issue, I found that it would have been helpful if there were more context.

@Workiva/messaging-pp @Workiva/product2
