### PR TITLE
Update uuid version range for Dart 2

### DIFF
--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.7
-  uuid: ^0.5.0
+  uuid: '>=0.5.0 <2.0.0'
   w_common: ^1.8.1
   w_transport: '>=2.9.4 <4.0.0'
 description: A frugal client for Dart


### PR DESCRIPTION
The current version range on the `uuid` dependency is not compatible with Dart 2.

The latest version of `uuid` is compatible with both Dart 1 and 2, and contains no breaking changes.

Update the allowed version range of `uuid`.

@Workiva/messaging-pp @Workiva/product2
