### PR TITLE
Golang: Replacing encoding/binary imports with internal.go

### DIFF
--- a/lib/go/bounded_memory_buffer.go
+++ b/lib/go/bounded_memory_buffer.go
@@ -14,7 +14,6 @@
 package frugal
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
@@ -60,7 +59,7 @@ func (f *TMemoryOutputBuffer) Reset() {
 // Bytes retrieves the framed contents of the buffer.
 func (f *TMemoryOutputBuffer) Bytes() []byte {
 	data := f.TMemoryBuffer.Bytes()
-	binary.BigEndian.PutUint32(data, uint32(len(data)-4))
+	bigEndianPutUint32(data, uint32(len(data)-4))
 	return data
 }
 

--- a/lib/go/framed_transport.go
+++ b/lib/go/framed_transport.go
@@ -16,7 +16,6 @@ package frugal
 import (
 	"bufio"
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"sync"
@@ -128,7 +127,7 @@ func (p *TFramedTransport) Write(buf []byte) (int, error) {
 func (p *TFramedTransport) Flush() error {
 	size := p.buf.Len()
 	buf := p.writeBuffer[:4]
-	binary.BigEndian.PutUint32(buf, uint32(size))
+	bigEndianPutUint32(buf, uint32(size))
 	_, err := p.transport.Write(buf)
 	if err != nil {
 		return thrift.NewTTransportExceptionFromError(err)
@@ -150,7 +149,7 @@ func (p *TFramedTransport) readFrameHeader() (uint32, error) {
 	if _, err := io.ReadFull(p.reader, buf); err != nil {
 		return 0, err
 	}
-	size := binary.BigEndian.Uint32(buf)
+	size := bigEndianUint32(buf)
 	if size < 0 || size > p.maxLength {
 		return 0, thrift.NewTTransportException(TRANSPORT_EXCEPTION_UNKNOWN,
 			fmt.Sprintf("frugal: incorrect frame size (%d)", size))

--- a/lib/go/http_transport.go
+++ b/lib/go/http_transport.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -113,7 +112,7 @@ func NewFrugalHandlerFunc(processor FProcessor, protocolFactory *FProtocolFactor
 			encoder = newEncoder(encoded)
 			err     error
 		)
-		binary.BigEndian.PutUint32(frameSize, uint32(outBuf.Len()))
+		bigEndianPutUint32(frameSize, uint32(outBuf.Len()))
 		if _, e := encoder.Write(frameSize); e != nil {
 			err = e
 		}
@@ -279,7 +278,7 @@ func (h *fHTTPTransport) Request(ctx FContext, data []byte) (thrift.TTransport, 
 	// If there are only 4 bytes, this needs to be a one-way
 	// (i.e. frame size 0)
 	if len(response) == 4 {
-		if binary.BigEndian.Uint32(response) != 0 {
+		if bigEndianUint32(response) != 0 {
 			return nil, thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA,
 				errors.New("frugal: missing data"))
 		}

--- a/lib/go/http_transport_test.go
+++ b/lib/go/http_transport_test.go
@@ -16,7 +16,6 @@ package frugal
 import (
 	"bytes"
 	"encoding/base64"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -317,7 +316,7 @@ func TestHTTPTransportLifecycle(t *testing.T) {
 	framedRequestBytes := prependFrameSize(requestBytes)
 	responseBytes := []byte("I must've called a thousand times")
 	f := make([]byte, 4)
-	binary.BigEndian.PutUint32(f, uint32(len(responseBytes)))
+	bigEndianPutUint32(f, uint32(len(responseBytes)))
 	framedResponse := append(f, responseBytes...)
 
 	// Setup test server
@@ -360,7 +359,7 @@ func TestHTTPRequestHeaders(t *testing.T) {
 	framedRequestBytes := prependFrameSize(requestBytes)
 	responseBytes := []byte("I must've called a thousand times")
 	f := make([]byte, 4)
-	binary.BigEndian.PutUint32(f, uint32(len(responseBytes)))
+	bigEndianPutUint32(f, uint32(len(responseBytes)))
 	framedResponse := append(f, responseBytes...)
 
 	// Setup test server
@@ -672,7 +671,7 @@ func TestHTTPRequestHeadersWithContext(t *testing.T) {
 	framedRequestBytes := prependFrameSize(requestBytes)
 	responseBytes := []byte("I must've called a thousand times")
 	f := make([]byte, 4)
-	binary.BigEndian.PutUint32(f, uint32(len(responseBytes)))
+	bigEndianPutUint32(f, uint32(len(responseBytes)))
 	framedResponse := append(f, responseBytes...)
 
 	// Setup test server
@@ -723,7 +722,7 @@ func TestHTTPRequestHeadersWithContextReturnsEmptyMap(t *testing.T) {
 	framedRequestBytes := prependFrameSize(requestBytes)
 	responseBytes := []byte("I must've called a thousand times")
 	f := make([]byte, 4)
-	binary.BigEndian.PutUint32(f, uint32(len(responseBytes)))
+	bigEndianPutUint32(f, uint32(len(responseBytes)))
 	framedResponse := append(f, responseBytes...)
 
 	// Setup test server

--- a/lib/go/internal.go
+++ b/lib/go/internal.go
@@ -1,0 +1,16 @@
+package frugal
+
+// Borrowed from golang.org/src/encoding/binary/binary.go
+func bigEndianUint32(b []byte) uint32 {
+	_ = b[3] // bounds check hint to compiler; see golang.org/issue/14808
+	return uint32(b[3]) | uint32(b[2])<<8 | uint32(b[1])<<16 | uint32(b[0])<<24
+}
+
+// Borrowed from golang.org/src/encoding/binary/binary.go
+func bigEndianPutUint32(b []byte, v uint32) {
+	_ = b[3] // early bounds check to guarantee safety of writes below
+	b[0] = byte(v >> 24)
+	b[1] = byte(v >> 16)
+	b[2] = byte(v >> 8)
+	b[3] = byte(v)
+}

--- a/lib/go/protocol_test.go
+++ b/lib/go/protocol_test.go
@@ -15,7 +15,6 @@ package frugal
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"strconv"
@@ -65,7 +64,6 @@ func TestReadRequestHeader(t *testing.T) {
 	assert := assert.New(t)
 	transport := &thrift.TMemoryBuffer{Buffer: bytes.NewBuffer(frugalFrame)}
 	proto := &FProtocol{tProtocolFactory.GetProtocol(transport)}
-
 
 	ctx, err := proto.ReadRequestHeader()
 	assert.Nil(err)
@@ -310,7 +308,7 @@ func TestAddHeadersToFrameBadVersion(t *testing.T) {
 func TestAddHeadersToFrameBadFrameSize(t *testing.T) {
 	assert := assert.New(t)
 	frame := make([]byte, 10)
-	binary.BigEndian.PutUint32(frame[5:], 9000)
+	bigEndianPutUint32(frame[5:], 9000)
 	frame[4] = protocolV0
 	_, err := addHeadersToFrame(frame, make(map[string]string))
 	assert.NotNil(err)

--- a/lib/go/transport.go
+++ b/lib/go/transport.go
@@ -15,8 +15,6 @@ package frugal
 
 import (
 	"bytes"
-	"encoding/binary"
-	//"errors"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
 )
@@ -159,6 +157,6 @@ func (f *fBaseTransport) Closed() <-chan error {
 
 func prependFrameSize(buf []byte) []byte {
 	frame := make([]byte, 4)
-	binary.BigEndian.PutUint32(frame, uint32(len(buf)))
+	bigEndianPutUint32(frame, uint32(len(buf)))
 	return append(frame, buf...)
 }


### PR DESCRIPTION
Simple improvement to reduce the dependency tree and see what the release cadence of this repository is.

@Workiva/messaging-pp @Workiva/product2
