### PR TITLE
Golang: Replacing gocql/uuid with nats-io/nuid

### DIFF
--- a/lib/go/context.go
+++ b/lib/go/context.go
@@ -16,12 +16,11 @@ package frugal
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/mattrobenolt/gocql/uuid"
+	"github.com/nats-io/nuid"
 )
 
 const (
@@ -99,7 +98,7 @@ type FContext interface {
 // TODO 3.0 consider adding this to the FContext interface.
 func Clone(ctx FContext) FContext {
 	clone := &FContextImpl{
-		requestHeaders: ctx.RequestHeaders(),
+		requestHeaders:  ctx.RequestHeaders(),
 		responseHeaders: ctx.ResponseHeaders(),
 	}
 	clone.requestHeaders[opIDHeader] = getNextOpID()
@@ -255,5 +254,5 @@ func setResponseOpID(ctx FContext, id string) {
 // generateCorrelationID returns a random string id. It's assigned to a var for
 // testability purposes.
 var generateCorrelationID = func() string {
-	return strings.Replace(uuid.RandomUUID().String(), "-", "", -1)
+	return nuid.Next()
 }

--- a/lib/go/glide.yaml
+++ b/lib/go/glide.yaml
@@ -6,10 +6,6 @@ import:
   - lib/go/thrift
 - package: github.com/Sirupsen/logrus
   version: ~0.11.0
-- package: github.com/mattrobenolt/gocql
-  version: 56c5a46b65eead93e1e53e983d1b2e7dbfde570d
-  subpackages:
-  - uuid
 - package: github.com/nats-io/go-nats
   version: 6b6bf392d34d01f57cc563ae123f00c13778bd57
   subpackages:


### PR DESCRIPTION
`github.com/nats-io/nuid` is already required for `github.com/nats-io/nats` which is used by this repository.

Replacing this dependency removes the necessity of vendoring a cassandra client for unique identifier generation.

For reference, the NUID library description is quoted as follows:

> NUID needs to be very fast to generate and truly unique, all while being entropy pool friendly.
> We will use 12 bytes of crypto generated data (entropy draining), and 10 bytes of sequential data
> that is started at a pseudo random number and increments with a pseudo-random increment.
> Total is 22 bytes of base 62 ascii text :)

This seems to be a suitable replacement for UUIDs.

@Workiva/messaging-pp @Workiva/product2
