### PR TITLE
Consume messaging-docker-images 0.0.25

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -8,7 +8,7 @@ run:  # local tests only, never run in Skynet
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:378733
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:382518
 
 env:
   - IN_SKYNET_CLI=true
@@ -41,7 +41,7 @@ requires:
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:378733
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:382518
 
 env:
   - PYTHONIOENCODING=utf-8

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,7 +1,7 @@
 project: frugal
 language: golang
 
-runner_image: drydock-prod.workiva.net/workiva/messaging-docker-images:378733
+runner_image: drydock-prod.workiva.net/workiva/messaging-docker-images:382518
 
 script:
     - ./scripts/smithy.sh


### PR DESCRIPTION

Pulls Included in Release:
* [INFENG-6100 INFRE: Update Dockerfile to mirror smithy.yaml](https://github.com/Workiva/messaging-docker-images/pull/43)


Requested by: @brianshannan-wf

@workiva/squad2 @workiva/squad2
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5198026715955200/logs/)