### PR TITLE
Upgrade asyncio-nats-client; Loosen python requirements

### DIFF
--- a/lib/python/frugal/tests/aio/utils.py
+++ b/lib/python/frugal/tests/aio/utils.py
@@ -10,9 +10,8 @@
 # limitations under the License.
 
 import asyncio
+import unittest
 from functools import wraps
-
-from asyncio.test_utils import TestCase
 
 
 def async_runner(f):
@@ -29,12 +28,10 @@ def default_gen():
         time_requested = yield time_requested
 
 
-class AsyncIOTestCase(TestCase):
+class AsyncIOTestCase(unittest.TestCase):
     def setUp(self, gen=None):
         super().setUp()
-        if gen is None:
-            gen = default_gen
-        self.loop = self.new_test_loop(gen=gen)
+        self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
 
     def tearDown(self):

--- a/lib/python/requirements.txt
+++ b/lib/python/requirements.txt
@@ -1,3 +1,3 @@
-six==1.10.0
+six>=1.10.0,<2
 thrift==0.10.0
-requests==2.12.5
+requests>=2.12.5,<3

--- a/lib/python/requirements_dev_asyncio.txt
+++ b/lib/python/requirements_dev_asyncio.txt
@@ -1,6 +1,5 @@
-asyncio-nats-client==0.7.2
-multidict==3.1.3 # DO NOT CHANGE without verifying asyncio nats with tls works
-aiohttp==3.1.2
-async-timeout==2.0.1
+aiohttp>=3.0.9,<4
+asyncio-nats-client==0.8.0
+async-timeout>=2.0.1,<4
 
 -r requirements_dev_common.txt

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -22,19 +22,17 @@ setup(
     url='http://github.com/Workiva/frugal',
     packages=find_packages(exclude=('frugal.tests', 'frugal.tests.*')),
     install_requires=[
-        "six>=1.10.0,<2",
-        "thrift==0.10.0",
-        "requests>=2.12.5,<3",
+        'six>=1.10.0,<2',
+        'thrift==0.10.0',
+        'requests>=2.12.5,<3',
     ],
     extras_require={
-        'tornado': ["nats-client==0.7.2"],
+        'tornado': ['nats-client==0.7.2'],
         'asyncio': [
-            "async-timeout==2.0.1",
-            "asyncio-nats-client==0.7.2",
-            # DO NOT CHANGE without verifying asyncio nats with tls works
-            "multidict==3.1.3",
-            "aiohttp==3.1.2",
+            'aiohttp>=3.0.9,<4',
+            'asyncio-nats-client==0.8.0',
+            'async-timeout>=2.0.1,<4',
         ],
-        'gae': ["webapp2==2.5.2"],
+        'gae': ['webapp2==2.5.2'],
     }
 )


### PR DESCRIPTION
Latest version of asyncio-nats-client includes python3.7 support.

Additionally, generic python requirements should be pinned to a major version to pick up minor version changes and give consumers flexibility in which versions they choose to use. I removed the explicit multidict requirement because it seems that at some point this became unnecessary https://github.com/Workiva/frugal/pull/946

Lastly, I got the tests running on Python3.7 locally but didn't upgrade runner image because it's more work than it's worth.

@Workiva/messaging-pp @Workiva/product2
