### PR TITLE
INFENG-6382: DART: change generation of dart exceptions to implement Exception

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -637,10 +637,11 @@ func (g *Generator) generateStruct(s *parser.Struct) string {
 	}
 
 	contents += fmt.Sprintf("class %s ", s.Name)
+	contents += "implements thrift.TBase"
 	if s.Type == parser.StructTypeException {
-		contents += "extends Error "
+		contents += ", Exception"
 	}
-	contents += "implements thrift.TBase {\n"
+	contents += " {\n"
 
 	// Struct and field descriptors
 	contents += fmt.Sprintf(tab+"static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct(\"%s\");\n", s.Name)

--- a/test/expected/dart/actual_base/f_api_exception.dart
+++ b/test/expected/dart/actual_base/f_api_exception.dart
@@ -5,7 +5,7 @@ import 'dart:typed_data' show Uint8List;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:actual_base_dart/actual_base_dart.dart' as t_actual_base_dart;
 
-class api_exception extends Error implements thrift.TBase {
+class api_exception implements thrift.TBase, Exception {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("api_exception");
 
 

--- a/test/expected/dart/variety/f_awesome_exception.dart
+++ b/test/expected/dart/variety/f_awesome_exception.dart
@@ -10,7 +10,7 @@ import 'package:validStructs/validStructs.dart' as t_validStructs;
 import 'package:ValidTypes/ValidTypes.dart' as t_ValidTypes;
 import 'package:subdir_include_ns/subdir_include_ns.dart' as t_subdir_include_ns;
 
-class AwesomeException extends Error implements thrift.TBase {
+class AwesomeException implements thrift.TBase, Exception {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("AwesomeException");
   static final thrift.TField _ID_FIELD_DESC = new thrift.TField("ID", thrift.TType.I64, 1);
   static final thrift.TField _REASON_FIELD_DESC = new thrift.TField("Reason", thrift.TType.STRING, 2);


### PR DESCRIPTION
This PR addresses an issue wherein the generator is building exception classes by `extends Error` rather than the preferred `implements Exception`.

@Workiva/messaging-pp @Workiva/product2
