### PR TITLE
Java jms transport

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.workiva</groupId>
             <artifactId>frugal</artifactId>
-            <version>2.23.0</version>
+            <version>LOCAL</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -38,6 +38,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.22</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-client</artifactId>
+            <version>5.15.7</version>
         </dependency>
     </dependencies>
 

--- a/examples/java/src/main/java/examples/ActiveMQPublisher.java
+++ b/examples/java/src/main/java/examples/ActiveMQPublisher.java
@@ -1,0 +1,62 @@
+package examples;
+
+import com.sun.istack.internal.logging.Logger;
+import com.workiva.frugal.FContext;
+import com.workiva.frugal.protocol.FProtocolFactory;
+import com.workiva.frugal.provider.FScopeProvider;
+import com.workiva.frugal.transport.FJmsPublisherTransport;
+import com.workiva.frugal.transport.FPublisherTransportFactory;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import java.util.logging.Level;
+import v1.music.Album;
+import v1.music.AlbumWinnersPublisher;
+import v1.music.PerfRightsOrg;
+import v1.music.Track;
+
+import javax.jms.Connection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class ActiveMQPublisher {
+    public static void main(String[] args) throws Exception {
+        Logger.getLogger(FJmsPublisherTransport.class).setLevel(Level.ALL);
+
+        FProtocolFactory protocolFactory = new FProtocolFactory(new TBinaryProtocol.Factory());
+
+        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory();
+        Connection connection = connectionFactory.createConnection();
+        connection.start();
+
+        FPublisherTransportFactory publisherFactory = new FJmsPublisherTransport.Factory(connection, "VirtualTopic.", true);
+
+        FScopeProvider provider = new FScopeProvider(publisherFactory, null, protocolFactory);
+
+        AlbumWinnersPublisher.Iface publisher = new AlbumWinnersPublisher.Client(provider);
+        publisher.open();
+
+        // Publish a winner announcement
+        Album album = new Album();
+        album.setASIN(UUID.randomUUID().toString());
+        album.setDuration(1200);
+        album.addToTracks(
+                new Track(
+                        "Comme des enfants",
+                        "Coeur de pirate",
+                        "Grosse Boîte",
+                        "Béatrice Martin",
+                        169,
+                        PerfRightsOrg.ASCAP));
+        publisher.publishWinner(new FContext(), album);
+        List<Album> albums = new ArrayList<>();
+        albums.add(album);
+        albums.add(album);
+        publisher.publishContestStart(new FContext(), albums);
+
+        System.out.println("Published event");
+
+        publisher.close();
+        connection.close();
+    }
+}

--- a/examples/java/src/main/java/examples/ActiveMQSubscriber.java
+++ b/examples/java/src/main/java/examples/ActiveMQSubscriber.java
@@ -1,0 +1,29 @@
+package examples;
+
+import com.workiva.frugal.protocol.FProtocolFactory;
+import com.workiva.frugal.provider.FScopeProvider;
+import com.workiva.frugal.transport.FJmsSubscriberTransport;
+import com.workiva.frugal.transport.FSubscriberTransportFactory;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import v1.music.AlbumWinnersSubscriber;
+
+import javax.jms.Connection;
+
+public class ActiveMQSubscriber {
+    public static void main(String[] args) throws Exception {
+        FProtocolFactory protocolFactory = new FProtocolFactory(new TBinaryProtocol.Factory());
+
+        ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory();
+        Connection connection = connectionFactory.createConnection();
+        connection.start();
+
+        FSubscriberTransportFactory subscriberFactory = new FJmsSubscriberTransport.Factory(connection, "Consumer.frugal-examples.VirtualTopic.");
+        FScopeProvider provider = new FScopeProvider(null, subscriberFactory, protocolFactory);
+
+        AlbumWinnersSubscriber.Iface subscriber = new AlbumWinnersSubscriber.Client(provider);
+        subscriber.subscribeWinner((ctx, album) -> System.out.println("You won! " + album));
+        subscriber.subscribeContestStart((ctx, albums) -> System.out.println("Contest started, available albums: " + albums));
+        System.out.println("Subscriber started...");
+    }
+}

--- a/examples/java/src/main/java/examples/ActiveMQSubscriber.java
+++ b/examples/java/src/main/java/examples/ActiveMQSubscriber.java
@@ -18,7 +18,7 @@ public class ActiveMQSubscriber {
         Connection connection = connectionFactory.createConnection();
         connection.start();
 
-        FSubscriberTransportFactory subscriberFactory = new FJmsSubscriberTransport.Factory(connection, "Consumer.frugal-examples.VirtualTopic.");
+        FSubscriberTransportFactory subscriberFactory = new FJmsSubscriberTransport.Factory(connection, "Consumer.frugal-examples.VirtualTopic.", true);
         FScopeProvider provider = new FScopeProvider(null, subscriberFactory, protocolFactory);
 
         AlbumWinnersSubscriber.Iface subscriber = new AlbumWinnersSubscriber.Client(provider);

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.workiva</groupId>
     <artifactId>frugal</artifactId>
-    <version>LOCAL</version>
+    <version>2.23.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -55,6 +55,11 @@
             <version>4.5</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-client</artifactId>
+            <version>5.15.7</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.0</version>

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -64,8 +64,9 @@
         </dependency>
         <dependency>
             <groupId>javax.jms</groupId>
-            <artifactId>jms</artifactId>
-            <version>1.1</version>
+            <artifactId>javax.jms-api</artifactId>
+            <version>2.0.1</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.workiva</groupId>
     <artifactId>frugal</artifactId>
-    <version>LOCAL</version>
+    <version>2.23.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -38,6 +38,14 @@
         <url>http://github.com/Workiva/frugal</url>
     </scm>
 
+    <repositories>
+        <repository>
+            <id>repository.jboss.org-public</id>
+            <name>JBoss.org Maven repository</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.thrift</groupId>
@@ -55,9 +63,9 @@
             <version>4.5</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-client</artifactId>
-            <version>5.15.7</version>
+            <groupId>javax.jms</groupId>
+            <artifactId>jms</artifactId>
+            <version>1.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.workiva</groupId>
     <artifactId>frugal</artifactId>
-    <version>2.23.0</version>
+    <version>LOCAL</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsPublisherTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsPublisherTransport.java
@@ -1,64 +1,82 @@
 package com.workiva.frugal.transport;
 
+import com.workiva.frugal.exception.TTransportExceptionType;
 import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jms.BytesMessage;
+import javax.jms.Connection;
+import javax.jms.DeliveryMode;
 import javax.jms.JMSException;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
 import javax.jms.Topic;
 
+import static com.workiva.frugal.transport.FNatsTransport.FRUGAL_PREFIX;
+
 /**
- * TODO.
+ * FJmsPublisherTransport implements FPublisherTransport by utilizing a JMS
+ * connection.
  */
 public class FJmsPublisherTransport implements FPublisherTransport {
     private static final Logger LOGGER = LoggerFactory.getLogger(FJmsPublisherTransport.class);
 
-    // TODO frugal prefixing of topics
+    // TODO should we try to batch with sessions at some point?
+    // TODO sessions aren't threadsafe, do we need to do more than sync on publish?
+    private final Connection connection;
+    private final String topicPrefix;
+    private final boolean durablePublishes;
+    Session session;
+    MessageProducer producer;
 
-    // TODO session or connection?
-    private final Session session;
-    private MessageProducer producer;
-    // TODO useTopics flag?
-
-    protected FJmsPublisherTransport(Session session) {
-        this.session = session;
+    FJmsPublisherTransport(Connection connection, String topicPrefix, boolean durablePublishes) {
+        this.connection = connection;
+        this.topicPrefix = topicPrefix;
+        this.durablePublishes = durablePublishes;
     }
 
     /**
-     * TODO.
+     * An FPublisherTransportFacory implementation which creates
+     * FPublisherTransports backed by a JMS connection.
      */
     public static class Factory implements FPublisherTransportFactory {
 
-        private final Session session;
+        private final Connection connection;
+        private final String topicPrefix;
+        private final boolean durablePublishes;
 
-        public Factory(Session session) {
-            this.session = session;
+        // TODO should we make a builder for this?
+        public Factory(Connection connection, String topicPrefix, boolean durablePublishes) {
+            this.connection = connection;
+            this.topicPrefix = topicPrefix;
+            this.durablePublishes = durablePublishes;
         }
 
         public FPublisherTransport getTransport() {
-            return new FJmsPublisherTransport(session);
+            return new FJmsPublisherTransport(connection, topicPrefix, durablePublishes);
         }
     }
 
     @Override
     public boolean isOpen() {
-        return producer != null;
+        return session != null && producer != null;
     }
 
     @Override
     public void open() throws TTransportException {
         // TODO test
-        // TODO right defaults?
         if (isOpen()) {
-            LOGGER.debug("jms transport already open, returning");
+            LOGGER.info("jms transport already open, returning");
             return;
         }
 
         try {
+            session = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
             producer = session.createProducer(null);
+            if (!durablePublishes) {
+                producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+            }
         } catch (JMSException e) {
             throw new TTransportException(e);
         }
@@ -67,28 +85,29 @@ public class FJmsPublisherTransport implements FPublisherTransport {
     @Override
     public void close() {
         if (!isOpen()) {
-            LOGGER.debug("jms transport already closed, returning");
+            LOGGER.info("jms transport already closed, returning");
             return;
         }
-        // TODO preconditions
         // TODO test
         try {
             producer.close();
+            session.close();
         } catch (JMSException e) {
             LOGGER.error("failed to close jms producer", e);
         } finally {
             producer = null;
+            session = null;
         }
     }
 
     @Override
     public int getPublishSizeLimit() {
         // TODO check this number
-        return Integer.MAX_VALUE;
+        return 32 * 1024 * 1024;
     }
 
     @Override
-    public void publish(String topic, byte[] payload) throws TTransportException {
+    public synchronized void publish(String topic, byte[] payload) throws TTransportException {
         // TODO test
         if (!isOpen()) {
             throw new TTransportException(TTransportException.NOT_OPEN, "failed to publish, jms client not open");
@@ -98,16 +117,28 @@ public class FJmsPublisherTransport implements FPublisherTransport {
             throw new TTransportException("publish topic cannot be empty");
         }
 
-        // TODO size check?
+        if (payload.length > getPublishSizeLimit()) {
+            throw new TTransportException(TTransportExceptionType.REQUEST_TOO_LARGE,
+                    String.format("message exceeds %d bytes, was %d bytes",
+                            getPublishSizeLimit(), payload.length));
+        }
 
+        String formattedTopic = getFormattedTopic(topic);
+        LOGGER.debug("publishing message to '%s'", formattedTopic);
         try {
-            Topic destination = session.createTopic(topic);
+            Topic destination = session.createTopic(formattedTopic);
             BytesMessage message = session.createBytesMessage();
             message.writeBytes(payload);
+            // TODO should set this?
+            // message.setJMSCorrelationID();
             producer.send(destination, message);
         } catch (JMSException e) {
             throw new TTransportException(e);
         }
+        LOGGER.debug("published message to '%s'", formattedTopic);
+    }
 
+    private String getFormattedTopic(String subject) {
+        return FRUGAL_PREFIX + topicPrefix + subject;
     }
 }

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsPublisherTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsPublisherTransport.java
@@ -59,12 +59,12 @@ public class FJmsPublisherTransport implements FPublisherTransport {
     }
 
     @Override
-    public boolean isOpen() {
+    public synchronized boolean isOpen() {
         return session != null && producer != null;
     }
 
     @Override
-    public void open() throws TTransportException {
+    public synchronized void open() throws TTransportException {
         // TODO test
         if (isOpen()) {
             LOGGER.info("jms transport already open, returning");
@@ -83,7 +83,7 @@ public class FJmsPublisherTransport implements FPublisherTransport {
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
         if (!isOpen()) {
             LOGGER.info("jms transport already closed, returning");
             return;

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsPublisherTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsPublisherTransport.java
@@ -138,6 +138,6 @@ public class FJmsPublisherTransport implements FPublisherTransport {
     }
 
     private String getFormattedTopic(String subject) {
-        return FRUGAL_PREFIX + topicPrefix + subject;
+        return topicPrefix + FRUGAL_PREFIX + subject;
     }
 }

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsPublisherTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsPublisherTransport.java
@@ -1,0 +1,113 @@
+package com.workiva.frugal.transport;
+
+import org.apache.thrift.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jms.BytesMessage;
+import javax.jms.JMSException;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.Topic;
+
+/**
+ * TODO.
+ */
+public class FJmsPublisherTransport implements FPublisherTransport {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FJmsPublisherTransport.class);
+
+    // TODO frugal prefixing of topics
+
+    // TODO session or connection?
+    private final Session session;
+    private MessageProducer producer;
+    // TODO useTopics flag?
+
+    protected FJmsPublisherTransport(Session session) {
+        this.session = session;
+    }
+
+    /**
+     * TODO.
+     */
+    public static class Factory implements FPublisherTransportFactory {
+
+        private final Session session;
+
+        public Factory(Session session) {
+            this.session = session;
+        }
+
+        public FPublisherTransport getTransport() {
+            return new FJmsPublisherTransport(session);
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        return producer != null;
+    }
+
+    @Override
+    public void open() throws TTransportException {
+        // TODO test
+        // TODO right defaults?
+        if (isOpen()) {
+            LOGGER.debug("jms transport already open, returning");
+            return;
+        }
+
+        try {
+            producer = session.createProducer(null);
+        } catch (JMSException e) {
+            throw new TTransportException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (!isOpen()) {
+            LOGGER.debug("jms transport already closed, returning");
+            return;
+        }
+        // TODO preconditions
+        // TODO test
+        try {
+            producer.close();
+        } catch (JMSException e) {
+            LOGGER.error("failed to close jms producer", e);
+        } finally {
+            producer = null;
+        }
+    }
+
+    @Override
+    public int getPublishSizeLimit() {
+        // TODO check this number
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public void publish(String topic, byte[] payload) throws TTransportException {
+        // TODO test
+        if (!isOpen()) {
+            throw new TTransportException(TTransportException.NOT_OPEN, "failed to publish, jms client not open");
+        }
+
+        if (topic == null || "".equals(topic)) {
+            throw new TTransportException("publish topic cannot be empty");
+        }
+
+        // TODO size check?
+
+        try {
+            Topic destination = session.createTopic(topic);
+            BytesMessage message = session.createBytesMessage();
+            message.writeBytes(payload);
+            producer.send(destination, message);
+        } catch (JMSException e) {
+            throw new TTransportException(e);
+        }
+
+    }
+}

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsPublisherTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsPublisherTransport.java
@@ -88,10 +88,9 @@ public class FJmsPublisherTransport implements FPublisherTransport {
             LOGGER.info("jms transport already closed, returning");
             return;
         }
-        // TODO test
-        try {
+
+        try (Session closeSession = session) {
             producer.close();
-            session.close();
         } catch (JMSException e) {
             LOGGER.error("failed to close jms producer", e);
         } finally {

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
@@ -8,53 +8,57 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jms.BytesMessage;
+import javax.jms.Connection;
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
 import javax.jms.Session;
 import java.util.Arrays;
 
+import static com.workiva.frugal.transport.FNatsTransport.FRUGAL_PREFIX;
+
 /**
- * TODO.
+ * FJmsSubscriberTransport implements FSubscriberTransport by utilizing a JSM
+ * connection.
  */
 public class FJmsSubscriberTransport implements FSubscriberTransport {
     private static final Logger LOGGER = LoggerFactory.getLogger(FJmsSubscriberTransport.class);
 
-    // TODO frugal prefixing of topics
+    // TODO sessions aren't threadsafe, do we need to do more than sync on sub/unsub?
+    private final Connection connection;
+    private final String topicPrefix;
+    Session session;
+    MessageConsumer consumer;
 
-//    private String topic;
-    // TODO session or connection?
-    private final Session session;
-    private MessageConsumer consumer;
-    // TODO useTopics flag?
-
-    protected FJmsSubscriberTransport(Session session) {
-        this.session = session;
+    FJmsSubscriberTransport(Connection connection, String topicPrefix) {
+        this.connection = connection;
+        this.topicPrefix = topicPrefix;
     }
 
     /**
-     * TODO.
+     * An FSubscriberTransportFacory implementation which creates
+     * FSubscriberTransports backed by a JMS connection.
      */
     public static class Factory implements FSubscriberTransportFactory {
-        private final Session session;
+        private final Connection connection;
 
-        public Factory(Session session) {
-            this.session = session;
+        public Factory(Connection connection) {
+            this.connection = connection;
         }
 
         @Override
         public FSubscriberTransport getTransport() {
-            return new FJmsSubscriberTransport(session);
+            return new FJmsSubscriberTransport(connection, "");
         }
     }
 
     @Override
     public boolean isSubscribed() {
-        return consumer != null;
+        return session != null && consumer != null;
     }
 
     @Override
-    public void subscribe(String topic, FAsyncCallback callback) throws TException {
+    public synchronized void subscribe(String topic, FAsyncCallback callback) throws TException {
         // TODO test
         if (isSubscribed()) {
             throw new TTransportException(TTransportException.ALREADY_OPEN, "jms client already subscribed");
@@ -63,34 +67,51 @@ public class FJmsSubscriberTransport implements FSubscriberTransport {
         if (topic == null || "".equals(topic)) {
             throw new TTransportException("subscribe subject cannot be empty");
         }
+        String formattedTopic = getFormattedTopic(topic);
 
         try {
-            Destination destination = session.createTopic(topic);
+            // TODO I think these are the defaults we want
+            session = connection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+            Destination destination = session.createTopic(formattedTopic);
             consumer = session.createConsumer(destination);
             consumer.setMessageListener(message -> {
-                // TODO this cast is janky af
-                BytesMessage bytesMessage = (BytesMessage) message;
+                LOGGER.debug("received a message on topic '%s'", formattedTopic);
+
+                // TODO do we need to handle other message types?
                 byte[] payload;
-                try {
-                    payload = new byte[(int) bytesMessage.getBodyLength()];
-                    bytesMessage.readBytes(payload);
-                } catch (JMSException e) {
-                    LOGGER.error("failed to get bytes from message", e);
+                if (message instanceof BytesMessage) {
+                    BytesMessage bytesMessage = (BytesMessage) message;
+                    try {
+                        payload = new byte[(int) bytesMessage.getBodyLength()];
+                        bytesMessage.readBytes(payload);
+                    } catch (JMSException e) {
+                        LOGGER.error("failed to get bytes from message", e);
+                        return;
+                    }
+                } else {
+                    LOGGER.error("unhandled message type '%s'", message.getClass().getName());
                     return;
                 }
 
                 if (payload.length < 4) {
-                    LOGGER.warn("discarding invalid scope message frame");
+                    LOGGER.warn("discarding invalid message frame, length less than four");
                     return;
                 }
                 try {
-                    // TODO better way than copying?
+                    // TODO better way than copying? what we do for other transports
                     callback.onMessage(
                             new TMemoryInputTransport(Arrays.copyOfRange(payload, 4, payload.length))
                     );
                 } catch (TException ignored) {
                     // TODO is this right?
                 }
+
+                try {
+                    message.acknowledge();
+                } catch (JMSException e) {
+                    LOGGER.error("unable to ack message", e);
+                }
+                LOGGER.debug("finished processing message from topic '%s'", formattedTopic);
             });
         } catch (JMSException e) {
             throw new TException(e);
@@ -98,18 +119,24 @@ public class FJmsSubscriberTransport implements FSubscriberTransport {
     }
 
     @Override
-    public void unsubscribe() {
+    public synchronized void unsubscribe() {
         if (!isSubscribed()) {
-            LOGGER.debug("jms transport already unsubscribed, returning");
+            LOGGER.info("jms transport already unsubscribed, returning");
             return;
         }
 
         try {
             consumer.close();
+            session.close();
         } catch (JMSException e) {
             LOGGER.error("failed to close jms consumer", e);
         } finally {
             consumer = null;
+            session = null;
         }
+    }
+
+    private String getFormattedTopic(String subject) {
+        return FRUGAL_PREFIX + topicPrefix + subject;
     }
 }

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
@@ -1,0 +1,115 @@
+package com.workiva.frugal.transport;
+
+import com.workiva.frugal.protocol.FAsyncCallback;
+import org.apache.thrift.TException;
+import org.apache.thrift.transport.TMemoryInputTransport;
+import org.apache.thrift.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jms.BytesMessage;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+import java.util.Arrays;
+
+/**
+ * TODO.
+ */
+public class FJmsSubscriberTransport implements FSubscriberTransport {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FJmsSubscriberTransport.class);
+
+    // TODO frugal prefixing of topics
+
+//    private String topic;
+    // TODO session or connection?
+    private final Session session;
+    private MessageConsumer consumer;
+    // TODO useTopics flag?
+
+    protected FJmsSubscriberTransport(Session session) {
+        this.session = session;
+    }
+
+    /**
+     * TODO.
+     */
+    public static class Factory implements FSubscriberTransportFactory {
+        private final Session session;
+
+        public Factory(Session session) {
+            this.session = session;
+        }
+
+        @Override
+        public FSubscriberTransport getTransport() {
+            return new FJmsSubscriberTransport(session);
+        }
+    }
+
+    @Override
+    public boolean isSubscribed() {
+        return consumer != null;
+    }
+
+    @Override
+    public void subscribe(String topic, FAsyncCallback callback) throws TException {
+        // TODO test
+        if (isSubscribed()) {
+            throw new TTransportException(TTransportException.ALREADY_OPEN, "jms client already subscribed");
+        }
+
+        if (topic == null || "".equals(topic)) {
+            throw new TTransportException("subscribe subject cannot be empty");
+        }
+
+        try {
+            Destination destination = session.createTopic(topic);
+            consumer = session.createConsumer(destination);
+            consumer.setMessageListener(message -> {
+                // TODO this cast is janky af
+                BytesMessage bytesMessage = (BytesMessage) message;
+                byte[] payload;
+                try {
+                    payload = new byte[(int) bytesMessage.getBodyLength()];
+                    bytesMessage.readBytes(payload);
+                } catch (JMSException e) {
+                    LOGGER.error("failed to get bytes from message", e);
+                    return;
+                }
+
+                if (payload.length < 4) {
+                    LOGGER.warn("discarding invalid scope message frame");
+                    return;
+                }
+                try {
+                    // TODO better way than copying?
+                    callback.onMessage(
+                            new TMemoryInputTransport(Arrays.copyOfRange(payload, 4, payload.length))
+                    );
+                } catch (TException ignored) {
+                    // TODO is this right?
+                }
+            });
+        } catch (JMSException e) {
+            throw new TException(e);
+        }
+    }
+
+    @Override
+    public void unsubscribe() {
+        if (!isSubscribed()) {
+            LOGGER.debug("jms transport already unsubscribed, returning");
+            return;
+        }
+
+        try {
+            consumer.close();
+        } catch (JMSException e) {
+            LOGGER.error("failed to close jms consumer", e);
+        } finally {
+            consumer = null;
+        }
+    }
+}

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
@@ -105,6 +105,7 @@ public class FJmsSubscriberTransport implements FSubscriberTransport {
                     );
                 } catch (TException e) {
                     LOGGER.error("error executing user provided callback", e);
+                    return;
                 }
 
                 try {

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
@@ -56,7 +56,7 @@ public class FJmsSubscriberTransport implements FSubscriberTransport {
     }
 
     @Override
-    public boolean isSubscribed() {
+    public synchronized boolean isSubscribed() {
         return session != null && consumer != null;
     }
 

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
@@ -41,14 +41,17 @@ public class FJmsSubscriberTransport implements FSubscriberTransport {
      */
     public static class Factory implements FSubscriberTransportFactory {
         private final Connection connection;
+        private final String topicPrefix;
 
-        public Factory(Connection connection) {
+        // TODO should we make a builder for this?
+        public Factory(Connection connection, String topicPrefix) {
             this.connection = connection;
+            this.topicPrefix = topicPrefix;
         }
 
         @Override
         public FSubscriberTransport getTransport() {
-            return new FJmsSubscriberTransport(connection, "");
+            return new FJmsSubscriberTransport(connection, topicPrefix);
         }
     }
 

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
@@ -12,9 +12,7 @@ import javax.jms.Connection;
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
-import javax.jms.MessageProducer;
 import javax.jms.Session;
-import java.util.Arrays;
 
 import static com.workiva.frugal.transport.FNatsTransport.FRUGAL_PREFIX;
 

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
@@ -137,6 +137,6 @@ public class FJmsSubscriberTransport implements FSubscriberTransport {
     }
 
     private String getFormattedTopic(String subject) {
-        return FRUGAL_PREFIX + topicPrefix + subject;
+        return topicPrefix + FRUGAL_PREFIX + subject;
     }
 }

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
@@ -64,7 +64,7 @@ public class FJmsSubscriberTransport implements FSubscriberTransport {
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      *
      * If an exception is raised by the provided callback, the message will
      * not be acked with the broker. This behaviour allows the message to be

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
@@ -63,6 +63,16 @@ public class FJmsSubscriberTransport implements FSubscriberTransport {
         return session != null && consumer != null;
     }
 
+    /**
+     * @inheritDoc
+     *
+     * If an exception is raised by the provided callback, the message will
+     * not be acked with the broker. This behaviour allows the message to be
+     * redelivered and processing to be attempted again. If an exception is
+     * not raised by the provided callback, the message will be acked. This is
+     * used if processing succeeded, or if it's apparent processing will never
+     * succeed, as the message won't continue to be redelivered.
+     */
     @Override
     public synchronized void subscribe(String topic, FAsyncCallback callback) throws TException {
         // TODO test

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
@@ -105,8 +105,8 @@ public class FJmsSubscriberTransport implements FSubscriberTransport {
                     callback.onMessage(
                             new TMemoryInputTransport(Arrays.copyOfRange(payload, 4, payload.length))
                     );
-                } catch (TException ignored) {
-                    // TODO is this right?
+                } catch (TException e) {
+                    LOGGER.error("error executing user provided callback", e);
                 }
 
                 try {

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FJmsSubscriberTransport.java
@@ -12,6 +12,7 @@ import javax.jms.Connection;
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
 import javax.jms.Session;
 import java.util.Arrays;
 
@@ -101,9 +102,8 @@ public class FJmsSubscriberTransport implements FSubscriberTransport {
                     return;
                 }
                 try {
-                    // TODO better way than copying? what we do for other transports
                     callback.onMessage(
-                            new TMemoryInputTransport(Arrays.copyOfRange(payload, 4, payload.length))
+                            new TMemoryInputTransport(payload, 4, payload.length - 4)
                     );
                 } catch (TException e) {
                     LOGGER.error("error executing user provided callback", e);
@@ -128,9 +128,8 @@ public class FJmsSubscriberTransport implements FSubscriberTransport {
             return;
         }
 
-        try {
+        try (Session closeSession = session) {
             consumer.close();
-            session.close();
         } catch (JMSException e) {
             LOGGER.error("failed to close jms consumer", e);
         } finally {

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FNatsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FNatsSubscriberTransport.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import static com.workiva.frugal.transport.FNatsTransport.FRUGAL_PREFIX;
 

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FNatsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FNatsSubscriberTransport.java
@@ -120,7 +120,7 @@ public class FNatsSubscriberTransport implements FSubscriberTransport {
             }
             try {
                 callback.onMessage(
-                        new TMemoryInputTransport(Arrays.copyOfRange(msg.getData(), 4, msg.getData().length))
+                        new TMemoryInputTransport(msg.getData(), 4, msg.getData().length - 4)
                 );
             } catch (TException ignored) {
             }

--- a/lib/java/src/test/java/com/workiva/frugal/transport/FJmsPublisherTransportTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/transport/FJmsPublisherTransportTest.java
@@ -1,0 +1,99 @@
+package com.workiva.frugal.transport;
+
+
+import org.apache.thrift.transport.TTransportException;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.BytesMessage;
+import javax.jms.Connection;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.Topic;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link FJmsPublisherTransport}.
+ */
+public class FJmsPublisherTransportTest {
+
+    private FJmsPublisherTransport transport;
+    private Connection connection;
+    private Session session;
+    private byte[] payload = new byte[]{1, 2, 3, 4};
+
+    @Before
+    public void setUp() throws Exception {
+        connection = mock(Connection.class);
+        session = mock(Session.class);
+        when(connection.createSession(false, Session.CLIENT_ACKNOWLEDGE)).thenReturn(session);
+        transport = new FJmsPublisherTransport(connection, "", true);
+    }
+
+    @Test
+    public void testOpen() throws Exception {
+        assertFalse(transport.isOpen());
+        MessageProducer producer = mock(MessageProducer.class);
+        when(session.createProducer(null)).thenReturn(producer);
+        transport.open();
+        assertTrue(transport.isOpen());
+        transport.open();
+        assertTrue(transport.isOpen());
+        verify(session, times(1)).createProducer(null);
+    }
+
+    @Test
+    public void testClose() throws Exception {
+        MessageProducer producer = mock(MessageProducer.class);
+        transport.session = session;
+        transport.producer = producer;
+        assertTrue(transport.isOpen());
+        transport.close();
+        assertFalse(transport.isOpen());
+        transport.close();
+        assertFalse(transport.isOpen());
+        verify(producer, times(1)).close();
+    }
+
+    @Test(expected = TTransportException.class)
+    public void testPublishNotOpen() throws Exception {
+        transport.publish("some-topic", payload);
+    }
+
+    @Test(expected = TTransportException.class)
+    public void testPublishNoTopic() throws Exception {
+        MessageProducer producer = mock(MessageProducer.class);
+        transport.producer = producer;
+        transport.publish("", payload);
+    }
+
+    @Test(expected = TTransportException.class)
+    public void testPublishTooBig() throws Exception {
+        MessageProducer producer = mock(MessageProducer.class);
+        transport.producer = producer;
+        byte[] bigPayload = new byte[32 * 1024 * 1024 + 1];
+        transport.publish("some-topic", bigPayload);
+    }
+
+    @Test
+    public void testPublish() throws Exception {
+        MessageProducer producer = mock(MessageProducer.class);
+        transport.session = session;
+        transport.producer = producer;
+        Topic destination = mock(Topic.class);
+        when(session.createTopic("frugal.some-topic")).thenReturn(destination);
+        BytesMessage message = mock(BytesMessage.class);
+        when(session.createBytesMessage()).thenReturn(message);
+
+        transport.publish("some-topic", payload);
+        verify(session, times(1)).createTopic("frugal.some-topic");
+        verify(message, times(1)).writeBytes(payload);
+        verify(producer, times(1)).send(destination, message);
+    }
+}

--- a/lib/java/src/test/java/com/workiva/frugal/transport/FJmsSubscriberTransportTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/transport/FJmsSubscriberTransportTest.java
@@ -1,0 +1,64 @@
+package com.workiva.frugal.transport;
+
+import com.workiva.frugal.protocol.FAsyncCallback;
+import org.apache.thrift.transport.TTransportException;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.Connection;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+import javax.jms.Topic;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link FJmsSubscriberTransport}.
+ */
+public class FJmsSubscriberTransportTest {
+
+    private FJmsSubscriberTransport transport;
+    private Connection connection;
+    private Session session;
+
+    @Before
+    public void setUp() throws Exception {
+        connection = mock(Connection.class);
+        session = mock(Session.class);
+        when(connection.createSession(false, Session.CLIENT_ACKNOWLEDGE)).thenReturn(session);
+        transport = new FJmsSubscriberTransport(connection, "");
+    }
+
+    @Test(expected = TTransportException.class)
+    public void testAlreadySubscribedThrowsException() throws Exception {
+        MessageConsumer consumer = mock(MessageConsumer.class);
+        transport.session = session;
+        transport.consumer = consumer;
+        FAsyncCallback callback = mock(FAsyncCallback.class);
+        transport.subscribe("some-topic", callback);
+    }
+
+    @Test(expected = TTransportException.class)
+    public void testEmptyTopicThrowsException() throws Exception {
+        FAsyncCallback callback = mock(FAsyncCallback.class);
+        transport.subscribe("", callback);
+    }
+
+    @Test
+    public void testSubscribe() throws Exception {
+        FAsyncCallback callback = mock(FAsyncCallback.class);
+        Topic destination = mock(Topic.class);
+        when(session.createTopic("frugal.some-topic")).thenReturn(destination);
+        MessageConsumer consumer = mock(MessageConsumer.class);
+        when(session.createConsumer(destination)).thenReturn(consumer);
+
+        transport.subscribe("some-topic", callback);
+        verify(session, times(1)).createTopic("frugal.some-topic");
+        verify(session, times(1)).createConsumer(destination);
+        verify(consumer, times(1)).setMessageListener(any());
+    }
+}

--- a/lib/java/src/test/java/com/workiva/frugal/transport/FJmsSubscriberTransportTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/transport/FJmsSubscriberTransportTest.java
@@ -7,8 +7,8 @@ import org.junit.Test;
 
 import javax.jms.Connection;
 import javax.jms.MessageConsumer;
+import javax.jms.Queue;
 import javax.jms.Session;
-import javax.jms.Topic;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -51,13 +51,13 @@ public class FJmsSubscriberTransportTest {
     @Test
     public void testSubscribe() throws Exception {
         FAsyncCallback callback = mock(FAsyncCallback.class);
-        Topic destination = mock(Topic.class);
-        when(session.createTopic("frugal.some-topic")).thenReturn(destination);
+        Queue destination = mock(Queue.class);
+        when(session.createQueue("frugal.some-topic")).thenReturn(destination);
         MessageConsumer consumer = mock(MessageConsumer.class);
         when(session.createConsumer(destination)).thenReturn(consumer);
 
         transport.subscribe("some-topic", callback);
-        verify(session, times(1)).createTopic("frugal.some-topic");
+        verify(session, times(1)).createQueue("frugal.some-topic");
         verify(session, times(1)).createConsumer(destination);
         verify(consumer, times(1)).setMessageListener(any());
     }

--- a/lib/java/src/test/java/com/workiva/frugal/transport/FJmsSubscriberTransportTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/transport/FJmsSubscriberTransportTest.java
@@ -7,8 +7,8 @@ import org.junit.Test;
 
 import javax.jms.Connection;
 import javax.jms.MessageConsumer;
-import javax.jms.Queue;
 import javax.jms.Session;
+import javax.jms.Topic;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -30,7 +30,7 @@ public class FJmsSubscriberTransportTest {
         connection = mock(Connection.class);
         session = mock(Session.class);
         when(connection.createSession(false, Session.CLIENT_ACKNOWLEDGE)).thenReturn(session);
-        transport = new FJmsSubscriberTransport(connection, "");
+        transport = new FJmsSubscriberTransport(connection, "", false);
     }
 
     @Test(expected = TTransportException.class)
@@ -51,13 +51,13 @@ public class FJmsSubscriberTransportTest {
     @Test
     public void testSubscribe() throws Exception {
         FAsyncCallback callback = mock(FAsyncCallback.class);
-        Queue destination = mock(Queue.class);
-        when(session.createQueue("frugal.some-topic")).thenReturn(destination);
+        Topic destination = mock(Topic.class);
+        when(session.createTopic("frugal.some-topic")).thenReturn(destination);
         MessageConsumer consumer = mock(MessageConsumer.class);
         when(session.createConsumer(destination)).thenReturn(consumer);
 
         transport.subscribe("some-topic", callback);
-        verify(session, times(1)).createQueue("frugal.some-topic");
+        verify(session, times(1)).createTopic("frugal.some-topic");
         verify(session, times(1)).createConsumer(destination);
         verify(consumer, times(1)).setMessageListener(any());
     }

--- a/scripts/skynet/cross/setup_java.sh
+++ b/scripts/skynet/cross/setup_java.sh
@@ -9,7 +9,8 @@ if [ -z "${IN_SKYNET_CLI+yes}" ]; then
 else
     cd ${FRUGAL_HOME}/lib/java
     mvn clean verify -q
-    mv target/frugal-2.20.0.jar ${FRUGAL_HOME}/test/integration/java/frugal-integration-test/frugal.jar
+    ls target
+    mv target/frugal-LOCAL.jar ${FRUGAL_HOME}/test/integration/java/frugal-integration-test/frugal.jar
 fi
 
 cd ${FRUGAL_HOME}/test/integration/java/frugal-integration-test

--- a/scripts/skynet/cross/setup_java.sh
+++ b/scripts/skynet/cross/setup_java.sh
@@ -9,7 +9,6 @@ if [ -z "${IN_SKYNET_CLI+yes}" ]; then
 else
     cd ${FRUGAL_HOME}/lib/java
     mvn clean verify -q
-    ls target
     mv target/frugal-LOCAL.jar ${FRUGAL_HOME}/test/integration/java/frugal-integration-test/frugal.jar
 fi
 

--- a/scripts/skynet/skynet_setup.sh
+++ b/scripts/skynet/skynet_setup.sh
@@ -16,3 +16,7 @@ cd $GOPATH/src/github.com/Workiva/frugal && go install
 
 # Start gnatsd
 gnatsd &
+
+# TODO this install should be in messaging-docker-images
+wget https://archive.apache.org/dist/activemq/5.15.2/apache-activemq-5.15.2-bin.tar.gz
+

--- a/scripts/skynet/skynet_setup.sh
+++ b/scripts/skynet/skynet_setup.sh
@@ -19,4 +19,7 @@ gnatsd &
 
 # TODO this install should be in messaging-docker-images
 wget https://archive.apache.org/dist/activemq/5.15.2/apache-activemq-5.15.2-bin.tar.gz
-
+tar -xzf apache-activemq-5.15.2-bin.tar.gz
+cd apache-activemq-5.15.2/bin
+./activemq start
+cd $GOPATH/src/github.com/Workiva/frugal

--- a/scripts/skynet/skynet_setup.sh
+++ b/scripts/skynet/skynet_setup.sh
@@ -18,7 +18,7 @@ cd $GOPATH/src/github.com/Workiva/frugal && go install
 gnatsd &
 
 # TODO this install should be in messaging-docker-images
-wget https://archive.apache.org/dist/activemq/5.15.2/apache-activemq-5.15.2-bin.tar.gz
+wget http://archive.apache.org/dist/activemq/5.15.6/apache-activemq-5.15.6-bin.tar.gz
 tar -xzf apache-activemq-5.15.2-bin.tar.gz
 cd apache-activemq-5.15.2/bin
 ./activemq start

--- a/scripts/skynet/skynet_setup.sh
+++ b/scripts/skynet/skynet_setup.sh
@@ -19,7 +19,7 @@ gnatsd &
 
 # TODO this install should be in messaging-docker-images
 wget http://archive.apache.org/dist/activemq/5.15.6/apache-activemq-5.15.6-bin.tar.gz
-tar -xzf apache-activemq-5.15.2-bin.tar.gz
-cd apache-activemq-5.15.2/bin
+tar -xzf apache-activemq-5.15.6-bin.tar.gz
+cd apache-activemq-5.15.6/bin
 ./activemq start
 cd $GOPATH/src/github.com/Workiva/frugal

--- a/test/integration/crossrunner/load.go
+++ b/test/integration/crossrunner/load.go
@@ -15,10 +15,10 @@ package crossrunner
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"time"
-	"fmt"
 )
 
 const (

--- a/test/integration/crossrunner/run.go
+++ b/test/integration/crossrunner/run.go
@@ -71,7 +71,7 @@ func RunConfig(pair *Pair, port int, getCommand func(config Config, port int) (c
 	// Poll the server healthcheck until it returns a valid status code or exceeds the timeout
 	for total <= stimeout {
 		// If the server hasn't started within the specified timeout, fail the test
-		resp, err := (http.Get(fmt.Sprintf("http://localhost:%d", port)))
+		resp, err := http.Get(fmt.Sprintf("http://localhost:%d", port))
 		if err != nil {
 			time.Sleep(time.Millisecond * 250)
 			total += (time.Millisecond * 250)

--- a/test/integration/java/frugal-integration-test/pom.xml
+++ b/test/integration/java/frugal-integration-test/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.workiva</groupId>
             <artifactId>frugal</artifactId>
-            <version>LOCAL</version>
+            <version>2.23.0</version>
         </dependency>
         <dependency>
             <groupId>io.nats</groupId>

--- a/test/integration/java/frugal-integration-test/pom.xml
+++ b/test/integration/java/frugal-integration-test/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.workiva</groupId>
             <artifactId>frugal</artifactId>
-            <version>2.23.0</version>
+            <version>LOCAL</version>
         </dependency>
         <dependency>
             <groupId>io.nats</groupId>
@@ -40,6 +40,11 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-client</artifactId>
+            <version>5.15.7</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/test/integration/java/frugal-integration-test/pom.xml
+++ b/test/integration/java/frugal-integration-test/pom.xml
@@ -7,6 +7,10 @@
     <name>frugal-integration-test</name>
     <url>http://maven.apache.org</url>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <repositories>
         <repository>
             <id>workiva-release</id>

--- a/test/integration/java/frugal-integration-test/src/main/java/com/workiva/TestPublisher.java
+++ b/test/integration/java/frugal-integration-test/src/main/java/com/workiva/TestPublisher.java
@@ -43,12 +43,9 @@ public class TestPublisher {
                 Connection connection = connectionFactory.createConnection();
                 connection.start();
 
-                // Create a Session
-                Session publisherSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-                publisherFactory = new FJmsPublisherTransport.Factory(publisherSession);
+                publisherFactory = new FJmsPublisherTransport.Factory(connection, "", true);
 
-                Session subscriberSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-                subscriberFactory = new FJmsSubscriberTransport.Factory(subscriberSession);
+                subscriberFactory = new FJmsSubscriberTransport.Factory(connection, "");
                 break;
             default:
                 throw new IllegalArgumentException("Unknown transport type " + transportType);

--- a/test/integration/java/frugal-integration-test/src/main/java/com/workiva/TestPublisher.java
+++ b/test/integration/java/frugal-integration-test/src/main/java/com/workiva/TestPublisher.java
@@ -1,0 +1,91 @@
+package com.workiva;
+
+
+import com.workiva.frugal.FContext;
+import com.workiva.frugal.protocol.FProtocolFactory;
+import com.workiva.frugal.provider.FScopeProvider;
+import com.workiva.frugal.transport.FJmsPublisherTransport;
+import com.workiva.frugal.transport.FJmsSubscriberTransport;
+import com.workiva.frugal.transport.FPublisherTransportFactory;
+import com.workiva.frugal.transport.FSubscriberTransportFactory;
+import frugal.test.Event;
+import frugal.test.EventsPublisher;
+import frugal.test.EventsSubscriber;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.thrift.protocol.TProtocolFactory;
+
+import javax.jms.Connection;
+import javax.jms.Session;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.workiva.Utils.whichProtocolFactory;
+
+public class TestPublisher {
+    public static void main(String[] args) throws Exception {
+        CrossTestsArgParser parser = new CrossTestsArgParser(args);
+        String host = parser.getHost();
+        int port = parser.getPort();
+        String protocolType = parser.getProtocolType();
+        String transportType = parser.getTransportType();
+
+        TProtocolFactory protocolFactory = whichProtocolFactory(protocolType);
+        FPublisherTransportFactory publisherFactory;
+        FSubscriberTransportFactory subscriberFactory;
+
+        switch (transportType) {
+            case Utils.activemqName:
+                // TODO
+                ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("tcp://localhost:61616");
+
+                // Create a Connection
+                Connection connection = connectionFactory.createConnection();
+                connection.start();
+
+                // Create a Session
+                Session publisherSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                publisherFactory = new FJmsPublisherTransport.Factory(publisherSession);
+
+                Session subscriberSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                subscriberFactory = new FJmsSubscriberTransport.Factory(subscriberSession);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown transport type " + transportType);
+        }
+
+
+        /*
+         * PUB/SUB TEST
+         * Publish a message, verify that a subscriber receives the message and publishes a response.
+         * Verifies that scopes are correctly generated.
+         */
+        CountDownLatch messageReceived = new CountDownLatch(1);
+        FScopeProvider provider = new FScopeProvider(publisherFactory, subscriberFactory, new FProtocolFactory(protocolFactory));
+
+        String preamble = "foo";
+        String ramble = "bar";
+        EventsSubscriber.Iface subscriber = new EventsSubscriber.Client(provider);
+        subscriber.subscribeEventCreated(preamble, ramble, "response", Integer.toString(port), (ctx, event) -> {
+            System.out.println("Response received " + event);
+            messageReceived.countDown();
+        });
+
+        EventsPublisher.Iface publisher = new EventsPublisher.Client(provider);
+        publisher.open();
+        Event event = new Event(1, "Sending Call");
+        FContext ctx = new FContext("Call");
+        ctx.addRequestHeader(Utils.PREAMBLE_HEADER, preamble);
+        ctx.addRequestHeader(Utils.RAMBLE_HEADER, ramble);
+        publisher.publishEventCreated(ctx, preamble, ramble, "call", Integer.toString(port), event);
+        System.out.print("Publishing...    ");
+
+        if (messageReceived.await(15, TimeUnit.SECONDS)) {
+            System.out.println("received message from subscriber");
+        } else {
+            throw new RuntimeException("did not receive message from subscriber");
+        }
+
+        System.exit(0);
+    }
+}

--- a/test/integration/java/frugal-integration-test/src/main/java/com/workiva/TestPublisher.java
+++ b/test/integration/java/frugal-integration-test/src/main/java/com/workiva/TestPublisher.java
@@ -44,8 +44,7 @@ public class TestPublisher {
                 connection.start();
 
                 publisherFactory = new FJmsPublisherTransport.Factory(connection, "", true);
-
-                subscriberFactory = new FJmsSubscriberTransport.Factory(connection, "");
+                subscriberFactory = new FJmsSubscriberTransport.Factory(connection, "", false);
                 break;
             default:
                 throw new IllegalArgumentException("Unknown transport type " + transportType);

--- a/test/integration/java/frugal-integration-test/src/main/java/com/workiva/TestSubscriber.java
+++ b/test/integration/java/frugal-integration-test/src/main/java/com/workiva/TestSubscriber.java
@@ -44,12 +44,8 @@ public class TestSubscriber {
                 javax.jms.Connection connection = connectionFactory.createConnection();
                 connection.start();
 
-                // Create a Session
-                Session publisherSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-                publisherFactory = new FJmsPublisherTransport.Factory(publisherSession);
-
-                Session subscriberSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-                subscriberFactory = new FJmsSubscriberTransport.Factory(subscriberSession);
+                publisherFactory = new FJmsPublisherTransport.Factory(connection, "", true);
+                subscriberFactory = new FJmsSubscriberTransport.Factory(connection, "");
                 break;
             default:
                 throw new IllegalArgumentException("Unknown transport type " + transportType);

--- a/test/integration/java/frugal-integration-test/src/main/java/com/workiva/TestSubscriber.java
+++ b/test/integration/java/frugal-integration-test/src/main/java/com/workiva/TestSubscriber.java
@@ -1,0 +1,97 @@
+package com.workiva;
+
+import com.workiva.frugal.FContext;
+import com.workiva.frugal.protocol.FProtocolFactory;
+import com.workiva.frugal.provider.FScopeProvider;
+import com.workiva.frugal.transport.FJmsPublisherTransport;
+import com.workiva.frugal.transport.FJmsSubscriberTransport;
+import com.workiva.frugal.transport.FPublisherTransportFactory;
+import com.workiva.frugal.transport.FSubscriberTransportFactory;
+import frugal.test.Event;
+import frugal.test.EventsPublisher;
+import frugal.test.EventsSubscriber;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TProtocolFactory;
+
+import javax.jms.Session;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.workiva.Utils.PREAMBLE_HEADER;
+import static com.workiva.Utils.RAMBLE_HEADER;
+import static com.workiva.Utils.whichProtocolFactory;
+
+public class TestSubscriber {
+
+    public static void main(String[] args) throws Exception {
+        CrossTestsArgParser parser = new CrossTestsArgParser(args);
+        String host = parser.getHost();
+        int port = parser.getPort();
+        String protocolType = parser.getProtocolType();
+        String transportType = parser.getTransportType();
+
+        TProtocolFactory protocolFactory = whichProtocolFactory(protocolType);
+        FPublisherTransportFactory publisherFactory;
+        FSubscriberTransportFactory subscriberFactory;
+
+        switch (transportType) {
+            case Utils.activemqName:
+                // TODO
+                ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory("tcp://localhost:61616");
+
+                // Create a Connection
+                javax.jms.Connection connection = connectionFactory.createConnection();
+                connection.start();
+
+                // Create a Session
+                Session publisherSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                publisherFactory = new FJmsPublisherTransport.Factory(publisherSession);
+
+                Session subscriberSession = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+                subscriberFactory = new FJmsSubscriberTransport.Factory(subscriberSession);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown transport type " + transportType);
+        }
+
+        FScopeProvider provider = new FScopeProvider(publisherFactory, subscriberFactory, new FProtocolFactory(protocolFactory));
+        EventsSubscriber.Iface subscriber = new EventsSubscriber.Client(provider);
+
+        CountDownLatch messageReceived = new CountDownLatch(1);
+
+        subscriber.subscribeEventCreated("*", "*", "call", Integer.toString(port), (context, event) -> {
+            System.out.println("received " + context + " : " + event);
+            EventsPublisher.Iface publisher = new EventsPublisher.Client(provider);
+            try {
+                publisher.open();
+                String preamble = context.getRequestHeader(PREAMBLE_HEADER);
+                if (preamble == null || "".equals(preamble)) {
+                    System.out.println("Client did not provide preamble header");
+                    return;
+                }
+                String ramble = context.getRequestHeader(RAMBLE_HEADER);
+                if (ramble == null || "".equals(ramble)) {
+                    System.out.println("Client did not provide ramble header");
+                    return;
+                }
+                event = new Event(1, "received call");
+                publisher.publishEventCreated(new FContext("Call"), preamble, ramble, "response", Integer.toString(port), event);
+                messageReceived.countDown();
+            } catch (TException e) {
+                System.out.println("Error opening publisher to respond" + e.getMessage());
+            }
+        });
+
+        new com.workiva.HealthCheck(port);
+
+        System.out.println("Subscriber started...");
+        if (messageReceived.await(15, TimeUnit.SECONDS)) {
+            System.out.println("received message from publisher");
+        } else {
+            throw new RuntimeException("did not receive message from publisher");
+        }
+
+        System.exit(0);
+    }
+}

--- a/test/integration/java/frugal-integration-test/src/main/java/com/workiva/TestSubscriber.java
+++ b/test/integration/java/frugal-integration-test/src/main/java/com/workiva/TestSubscriber.java
@@ -45,7 +45,7 @@ public class TestSubscriber {
                 connection.start();
 
                 publisherFactory = new FJmsPublisherTransport.Factory(connection, "", true);
-                subscriberFactory = new FJmsSubscriberTransport.Factory(connection, "");
+                subscriberFactory = new FJmsSubscriberTransport.Factory(connection, "", false);
                 break;
             default:
                 throw new IllegalArgumentException("Unknown transport type " + transportType);

--- a/test/integration/java/frugal-integration-test/src/main/java/com/workiva/Utils.java
+++ b/test/integration/java/frugal-integration-test/src/main/java/com/workiva/Utils.java
@@ -12,6 +12,7 @@ import java.util.List;
 public class Utils {
     public static final String natsName = "nats";
     public static final String httpName = "http";
+    public static final String activemqName = "activemq";
 
     public static String PREAMBLE_HEADER = "preamble";
     public static String RAMBLE_HEADER = "ramble";

--- a/test/integration/tests.json
+++ b/test/integration/tests.json
@@ -1,9 +1,9 @@
 [
-    {
+  {
     "name": "dart",
     "client": {
       "timeout": 15,
-      "transports": [ "http" ],
+      "rpcTransports": [ "http" ],
       "protocols": [ "binary", "compact", "json" ],
       "command": [ "dart", "test_client/bin/main.dart" ]
     },
@@ -23,7 +23,7 @@
         "go/bin/testclient"
       ]
     },
-    "transports": ["nats", "http"],
+    "rpcTransports": ["nats", "http"],
     "protocols": ["binary", "compact", "json"]
   },
   {
@@ -31,12 +31,22 @@
     "client": {
       "timeout": 20,
       "command": [ "/usr/bin/java", "-Djava.security.egd=file:///dev/urandom", "-cp", "cross.jar", "com.workiva.TestClient" ],
-      "transports": [ "nats", "http" ]
+      "transports": [ "nats", "http", "activemq" ]
     },
     "server": {
       "timeout": 15,
       "command": [ "/usr/bin/java", "-Djava.security.egd=file:///dev/urandom", "-cp", "cross.jar", "com.workiva.TestServer" ],
       "transports": [ "nats", "http" ]
+    },
+    "publisher": {
+      "timeout": 20,
+      "command": [ "/usr/bin/java", "-Djava.security.egd=file:///dev/urandom", "-cp", "cross.jar", "com.workiva.TestPublisher" ],
+      "transports": ["activemq"]
+    },
+    "subscriber": {
+      "timeout": 20,
+      "command": [ "/usr/bin/java", "-Djava.security.egd=file:///dev/urandom", "-cp", "cross.jar", "com.workiva.TestSubscriber" ],
+      "transports": ["activemq"]
     },
     "protocols": [ "binary", "compact", "json" ],
     "workdir": "java/frugal-integration-test"
@@ -61,7 +71,7 @@
       "timeout": 7,
       "command": [ "python", "-u", "tornado_server.py" ]
     },
-    "transports": [ "nats", "http" ],
+    "rpcTransports": [ "nats", "http" ],
     "protocols": [ "binary", "compact", "json" ],
     "workdir": "python/tornado"
   },
@@ -75,7 +85,7 @@
       "timeout": 7,
       "command": [ "python3.5", "-u", "server.py" ]
     },
-    "transports": [ "nats", "http" ],
+    "rpcTransports": [ "nats", "http" ],
     "protocols": [ "binary", "compact", "json" ],
     "workdir": "python/aio"
   },
@@ -89,7 +99,7 @@
       "timeout": 7,
       "command": [ "python", "-u", "vanilla_server.py" ]
     },
-    "transports": [ "http" ], 
+    "rpcTransports": [ "http" ],
     "protocols": [ "binary", "compact", "json" ],
     "workdir": "python/tornado"
   }


### PR DESCRIPTION
Implements a JMS transport for frugal that could be used to communicate with active mq. I think all the major functionality exists, but might make some small changes. Some points
- Not super happy about how I ended up using the JMS session and producer/consumer in almost the same way (creating a session then immediately creating a producer, and also closing at the same time). The other possibility I see is sharing a session across multiple publishers/subscribers, but I was a little concerned as the documentation said sessions are not threadsafe, and I didn't want to coordinate that between transports. But I might have misunderstood how that API is supposed to work.
- The frugal transport API doesn't expose a good way to specify a message group per publish (for ordering), and I'm not sure how helpful providing one at transport construction time is going to be.
- Having a `topicPrefix` option makes using virtual topics in active mq much easier by specifying a topic prefix of `VirtualTopic.` for publishers and `Consumer.<me>.VirtualTopic` for subscribers.
- I tried to make this general enough so not to shoe horn ourselves into one thing.
- If I missed any major features you guys think would be useful, let me know.

@Workiva/messaging-pp @Workiva/product2
@kevinsookocheff-wf @brettkail-wk @chadknight-wf if interested feedback is appreciated, enterprisey java isn't my strong suit
