### PR TITLE
Add support for additional include directories to Compiler

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -59,7 +59,6 @@ func Compile(options Options) error {
 		return err
 	}
 
-	println("*****", options.IncludeDirs)
 	frugal, err := parseFrugal(absFile, options.IncludeDirs)
 	if err != nil {
 		return err

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -38,6 +38,7 @@ type Options struct {
 	DryRun  bool   // Do not generate code
 	Recurse bool   // Generate includes
 	Verbose bool   // Verbose mode
+	IncludeDirs []string // Additional Include file
 }
 
 // Compile parses the Frugal IDL and generates code for it, returning an error
@@ -58,7 +59,8 @@ func Compile(options Options) error {
 		return err
 	}
 
-	frugal, err := parseFrugal(absFile)
+	println("*****", options.IncludeDirs)
+	frugal, err := parseFrugal(absFile, options.IncludeDirs)
 	if err != nil {
 		return err
 	}
@@ -67,12 +69,12 @@ func Compile(options Options) error {
 }
 
 // parseFrugal parses a frugal file.
-func parseFrugal(file string) (*parser.Frugal, error) {
+func parseFrugal(file string, includeDir []string) (*parser.Frugal, error) {
 	if !exists(file) {
 		return nil, fmt.Errorf("Frugal file not found: %s\n", file)
 	}
 	logv(fmt.Sprintf("Parsing %s", file))
-	return parser.ParseFrugal(file)
+	return parser.ParseFrugal(file, includeDir)
 }
 
 // generateFrugal generates code for a frugal struct.

--- a/compiler/parser/audit.go
+++ b/compiler/parser/audit.go
@@ -75,13 +75,13 @@ func NewAuditorWithLogger(logger ValidationLogger) *Auditor {
 
 // Compare checks the contents of newFile for breaking changes with respect to
 // oldFile
-func (a *Auditor) Audit(oldFile, newFile string) error {
-	newFrugal, err := ParseFrugal(newFile, nil)
+func (a *Auditor) Audit(oldFile, newFile string, includeDirs []string) error {
+	newFrugal, err := ParseFrugal(newFile, includeDirs)
 	if err != nil {
 		return err
 	}
 
-	oldFrugal, err := ParseFrugal(oldFile, nil)
+	oldFrugal, err := ParseFrugal(oldFile, includeDirs)
 	if err != nil {
 		return err
 	}

--- a/compiler/parser/audit.go
+++ b/compiler/parser/audit.go
@@ -76,12 +76,12 @@ func NewAuditorWithLogger(logger ValidationLogger) *Auditor {
 // Compare checks the contents of newFile for breaking changes with respect to
 // oldFile
 func (a *Auditor) Audit(oldFile, newFile string) error {
-	newFrugal, err := ParseFrugal(newFile)
+	newFrugal, err := ParseFrugal(newFile, nil)
 	if err != nil {
 		return err
 	}
 
-	oldFrugal, err := ParseFrugal(oldFile)
+	oldFrugal, err := ParseFrugal(oldFile, nil)
 	if err != nil {
 		return err
 	}

--- a/compiler/parser/parser.go
+++ b/compiler/parser/parser.go
@@ -80,7 +80,7 @@ func parseFrugal(filePath string, visitedIncludes []string, includeDirs []string
 		}
 
 		inc := include
-		if include[0] != '/' {
+		if !filepath.IsAbs(inc) {
 			inc = filepath.Join(frugal.Dir, include)
 		}
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/Workiva/frugal/compiler"
 	"github.com/Workiva/frugal/compiler/generator"
@@ -23,6 +24,7 @@ var (
 	recurse bool
 	verbose bool
 	version bool
+	include string
 )
 
 func main() {
@@ -73,6 +75,10 @@ func main() {
 			Name:        "audit",
 			Usage:       "frugal file to run audit against",
 			Destination: &audit,
+		}, cli.StringFlag{
+			Name:		"include, i",
+			Usage:		"additional include directory",
+			Destination: &include,
 		},
 	}
 
@@ -106,6 +112,7 @@ func main() {
 			Delim:   delim,
 			Recurse: recurse,
 			Verbose: verbose,
+			IncludeDirs: strings.Split(include, ","),
 		}
 
 		// Handle panics for graceful error messages.

--- a/main.go
+++ b/main.go
@@ -129,7 +129,7 @@ func main() {
 			if audit == "" {
 				err = compiler.Compile(options)
 			} else {
-				err = auditor.Audit(audit, options.File)
+				err = auditor.Audit(audit, options.File, []string{include})
 			}
 			if err != nil {
 				fmt.Printf("Failed to generate %s:\n\t%s\n", options.File, err.Error())

--- a/test/audit_test.go
+++ b/test/audit_test.go
@@ -47,7 +47,7 @@ func (m *MockValidationLogger) ErrorsLogged() bool {
 
 func TestPassingAudit(t *testing.T) {
 	auditor := parser.NewAuditorWithLogger(&MockValidationLogger{})
-	if err := auditor.Audit(validFile, validFile); err != nil {
+	if err := auditor.Audit(validFile, validFile, nil); err != nil {
 		t.Fatal("unexpected error", err)
 	}
 }
@@ -93,7 +93,7 @@ func TestBreakingChanges(t *testing.T) {
 		badFile := fmt.Sprintf("idl/breaking_changes/break%d.thrift", i+1)
 		logger := &MockValidationLogger{}
 		auditor := parser.NewAuditorWithLogger(logger)
-		err := auditor.Audit(testFileThrift, badFile)
+		err := auditor.Audit(testFileThrift, badFile, nil)
 		if err != nil {
 			if logger.errors[0] != expected[i] {
 				t.Fatalf("checking %s\nExpected: %s\nBut got : %s\n", badFile, expected[i], logger.errors[0])
@@ -108,7 +108,7 @@ func TestBreakingChanges(t *testing.T) {
 
 func TestWarningChanges(t *testing.T) {
 	auditor := parser.NewAuditorWithLogger(&MockValidationLogger{})
-	err := auditor.Audit(testFileThrift, testWarning)
+	err := auditor.Audit(testFileThrift, testWarning, nil)
 	if err != nil {
 		t.Fatalf("\nExpected no errors, but got: %s", err.Error())
 	}
@@ -128,7 +128,7 @@ func TestScopeBreakingChanges(t *testing.T) {
 		badFile := fmt.Sprintf("idl/breaking_changes/scope%d.frugal", i+1)
 		logger := &MockValidationLogger{}
 		auditor := parser.NewAuditorWithLogger(logger)
-		err := auditor.Audit(scopeFile, badFile)
+		err := auditor.Audit(scopeFile, badFile, nil)
 		if err != nil {
 			if logger.errors[0] != expected[i] {
 				t.Fatalf("checking %s\nExpected: %s\nBut got : %s\n", badFile, expected[i], logger.errors[0])


### PR DESCRIPTION
Add '-i' flag that can take a comma separated list of additional directories to search for include files
The current behavior of looking in the directory containing the frugal file still takes precedent

@Workiva/messaging-pp @Workiva/product2
