### PR TITLE
INFENG-6670 java: catch throwable rather than TException in nats subscriber

### DIFF
--- a/lib/java/src/main/java/com/workiva/frugal/transport/FNatsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FNatsSubscriberTransport.java
@@ -122,8 +122,8 @@ public class FNatsSubscriberTransport implements FSubscriberTransport {
                 callback.onMessage(
                         new TMemoryInputTransport(Arrays.copyOfRange(msg.getData(), 4, msg.getData().length))
                 );
-            } catch (TException e) {
-                LOGGER.error("error executing user provided callback", e);
+            } catch (Throwable t) {
+                LOGGER.error("error executing user provided callback", t);
             }
         });
     }


### PR DESCRIPTION
I think this will fix the problem of RuntimeExceptions not being logged.

@Workiva/messaging-pp @Workiva/product2 @brettkail-wk 
