### PR TITLE
Python: Use file logger for processor exceptions

### DIFF
--- a/lib/python/frugal/aio/processor.py
+++ b/lib/python/frugal/aio/processor.py
@@ -165,7 +165,7 @@ class FBaseProcessor(FProcessor):
             except Exception:
                 # Don't raise an exception because the server should still send
                 # a response to the client.
-                logging.exception(
+                logger.exception(
                     "frugal: exception occurred while processing request with "
                     "correlation id %s", context.correlation_id)
             return

--- a/lib/python/frugal/processor.py
+++ b/lib/python/frugal/processor.py
@@ -165,12 +165,12 @@ class FBaseProcessor(FProcessor):
             except Exception:
                 # Don't raise an exception because the server should still send
                 # a response to the client.
-                logging.exception(
+                logger.exception(
                     "frugal: exception occurred while processing request with "
                     "correlation id %s", context.correlation_id)
             return
 
-        logging.warn("frugal: client invoked unknown method %s on request " +
+        logger.warn("frugal: client invoked unknown method %s on request " +
                      "with correlation id %s", name, context.correlation_id)
         iprot.skip(TType.STRUCT)
         iprot.readMessageEnd()

--- a/lib/python/frugal/processor.py
+++ b/lib/python/frugal/processor.py
@@ -171,7 +171,7 @@ class FBaseProcessor(FProcessor):
             return
 
         logger.warn("frugal: client invoked unknown method %s on request " +
-                     "with correlation id %s", name, context.correlation_id)
+                    "with correlation id %s", name, context.correlation_id)
         iprot.skip(TType.STRUCT)
         iprot.readMessageEnd()
 

--- a/lib/python/frugal/tornado/processor.py
+++ b/lib/python/frugal/tornado/processor.py
@@ -169,7 +169,7 @@ class FBaseProcessor(FProcessor):
             except Exception:
                 # Don't raise an exception because the server should still send
                 # a response to the client.
-                logging.exception(
+                logger.exception(
                     "frugal: exception occurred while processing request with "
                     "correlation id %s", context.correlation_id)
             return


### PR DESCRIPTION
I want to be able to mute the "frugal: exception occurred while processing request with..." error log and raise it myself within my logging middleware so that it includes application metadata. 

I noticed there was a logger already setup in these files that wasn't always being used which will allow me to easily mute these.

@Workiva/messaging-pp @Workiva/product2
