### PR TITLE
Update to messaging-docker-images 0.0.30

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/messaging-docker-images:1568389 as build
+FROM drydock-prod.workiva.net/workiva/messaging-docker-images:1571180 as build
 
 ARG GIT_BRANCH
 ARG GIT_MERGE_BRANCH

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -8,7 +8,7 @@ run:  # local tests only, never run in Skynet
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:1568389
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:1571180
 
 env:
   - IN_SKYNET_CLI=true
@@ -41,7 +41,7 @@ requires:
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:1568389
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:1571180
 
 env:
   - PYTHONIOENCODING=utf-8


### PR DESCRIPTION
### Story:
Remove dartium and content-shell from messaging-docker-images.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
None

### How To Test:
Tests pass

### My Test Results:
Pass

#### Reviewers:
@Workiva/product2