### PR TITLE
INFENG-6986 update docker image and use nobody user in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,13 +40,6 @@ ARG BUILD_ARTIFACTS_ARTIFACTORY=/go/src/github.com/Workiva/frugal/frugal-*.jar
 ARG BUILD_ARTIFACTS_PUB=/go/src/github.com/Workiva/frugal/frugal.pub.tgz
 ARG BUILD_ARTIFACTS_TEST_RESULTS=/go/src/github.com/Workiva/frugal/test_results/*
 
-RUN mkdir /veracode && \
-	tar czf /veracode/dart.tar.gz /go/src/github.com/Workiva/frugal/lib/dart && \
-	tar czf /veracode/go.tar.gz /go/src/github.com/Workiva/frugal/lib/go && \
-	tar czf /veracode/java.tar.gz /go/src/github.com/Workiva/frugal/lib/java && \
-	tar czf /veracode/python.tar.gz /go/src/github.com/Workiva/frugal/lib/python
-ARG BUILD_ARTIFACTS_VERACODE=/veracode/*
-
 # make a simple etc/passwd file so the scratch image can run as nobody (not root)
 RUN echo "nobody:x:65534:65534:Nobody:/:" > /passwd.minimal
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ RUN mkdir /root/.ssh && \
     umask 0077 && echo "$GIT_SSH_KEY" >/root/.ssh/id_rsa && \
     eval "$(ssh-agent -s)" && ssh-add /root/.ssh/id_rsa
 
+RUN apt update && \
+    apt full-upgrade -y && \
+    apt autoremove -y && \
+    apt clean all
+
 ARG GOPATH=/go/
 ENV PATH $GOPATH/bin:$PATH
 RUN git config --global url.git@github.com:.insteadOf https://github.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,18 @@ ARG BUILD_ARTIFACTS_ARTIFACTORY=/go/src/github.com/Workiva/frugal/frugal-*.jar
 ARG BUILD_ARTIFACTS_PUB=/go/src/github.com/Workiva/frugal/frugal.pub.tgz
 ARG BUILD_ARTIFACTS_TEST_RESULTS=/go/src/github.com/Workiva/frugal/test_results/*
 
+RUN mkdir /veracode && \
+	tar czf /veracode/dart.tar.gz /go/src/github.com/Workiva/frugal/lib/dart && \
+	tar czf /veracode/go.tar.gz /go/src/github.com/Workiva/frugal/lib/go && \
+	tar czf /veracode/java.tar.gz /go/src/github.com/Workiva/frugal/lib/java && \
+	tar czf /veracode/python.tar.gz /go/src/github.com/Workiva/frugal/lib/python
+ARG BUILD_ARTIFACTS_VERACODE=/veracode/*
+
+# make a simple etc/passwd file so the scratch image can run as nobody (not root)
+RUN echo "nobody:x:65534:65534:Nobody:/:" > /passwd.minimal
+
 FROM scratch
 COPY --from=build /go/src/github.com/Workiva/frugal/frugal /bin/frugal
+COPY --from=build /passwd.minimal /etc/passwd
+USER nobody
 ENTRYPOINT ["frugal"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/messaging-docker-images:1571180 as build
+FROM drydock-prod.workiva.net/workiva/messaging-docker-images:1578341 as build
 
 ARG GIT_BRANCH
 ARG GIT_MERGE_BRANCH

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -8,7 +8,7 @@ run:  # local tests only, never run in Skynet
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:1571180
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:1578341
 
 env:
   - IN_SKYNET_CLI=true
@@ -41,7 +41,7 @@ requires:
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:1571180
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:1578341
 
 env:
   - PYTHONIOENCODING=utf-8


### PR DESCRIPTION
### Story:
We need to give aviary what he ... err ... she ... wants!

### Acceptance Criteria:
- [x] At least one InfRe Squad 2 member has reviewed and +1'd
- [x] Code has been tested and results documented
- [x] Unit tests have been updated
- [x] Updates to documentation if necessary
- [x] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
I went with a stateless pub/sub server/client dependency injection model to refactor the docker scratch image to support the nobody *nix user.

### How To Test:
```bash
docker run -it drydock.workiva.net/workiva/frugal:1575160 --help
```

### My Test Results:
```
$ docker run -it drydock.workiva.net/workiva/frugal:1575160 --help
Unable to find image 'drydock.workiva.net/workiva/frugal:1575160' locally
1575160: Pulling from workiva/frugal
a217dc0ab271: Already exists
8532ff613d02: Already exists
Digest: sha256:5d311e1d546e92037062d29ee8369ccba4fdc86beaf3bd43cd065128ba75ec4c
Status: Downloaded newer image for drydock.workiva.net/workiva/frugal:1575160
NAME:
   frugal - a tool for code generation

USAGE:
   frugal [global options] [arguments...]

GLOBAL OPTIONS:
   --help, -h     show help
   --gen value    generate code with a registered generator and optional parameters (lang[:key1=val1[,key2[,key3=val3]]])
                      dart:
                          library_prefix:  Generate code that can be used within an existing library. Use a dot-separated string, e.g. "my_parent_lib.src.gen"
                          use_enums:       Generate enums as enums rather than a class with numerical constants
                          use_vendor:      Use specified import references for vendored includes and do not generate code for them
                      go:
                          async:           Generate async client code using channels
                          frugal_import:   Override Frugal package import path (default: github.com/Workiva/frugal/lib/go)
                          package_prefix:  Package prefix for generated files
                          slim:            Generate slim type definitions (WARNING: code generated by this may break code consumers, protocol logic should not change)
                          thrift_import:   Override Thrift package import path (default: git.apache.org/thrift.git/lib/go/thrift)
                          use_vendor:      Use specified import references for vendored includes and do not generate code for them
                      gopherjs:
                          package_prefix:  Package prefix for generated files
                          use_vendor:      Use specified import references for vendored includes and do not generate code for them
                      html:
                          standalone:  Self-contained mode, includes all CSS in the HTML files. Generates no style.css file, but HTML files will be larger
                      java:
                          async:                  Generate async client code using futures
                          boxed_primitives:       Generate primitives as the boxed equivalents
                          generated_annotations:  [undated|suppress] undated: suppress the date at @Generated annotations, suppress: suppress @Generated annotations entirely
                          use_vendor:             Use specified import references for vendored includes and do not generate code for them
                      py:
                          asyncio:         Generate code for use with asyncio (compatible with Python 3.5 or above)
                          package_prefix:  Package prefix for generated files
                          tornado:         Generate code for use with Tornado (compatible with Python 2.7)
   --out value    set the output location for generated files (no gen-* folder will be created)
   --delim value  set the delimiter for pub/sub topic tokens (default: ".")
   --recurse, -r  generate included files
   --verbose, -v  verbose mode
   --version      print the version
   --audit value  frugal file to run audit against
```

#### Reviewers:
@Workiva/product2