### PR TITLE
bump nats core pool size

### DIFF
--- a/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
@@ -194,7 +194,7 @@ public class FNatsServer implements FServer {
         public FNatsServer build() {
             if (executorService == null) {
                 this.executorService = new ThreadPoolExecutor(
-                        1, workerCount, 30, TimeUnit.SECONDS,
+                        workerCount, workerCount, 30, TimeUnit.SECONDS,
                         new ArrayBlockingQueue<>(queueLength),
                         new BlockingRejectedExecutionHandler());
             }

--- a/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
@@ -157,14 +157,18 @@ public class FNatsServer implements FServer {
          * Defaults to:
          * <pre>
          * {@code
-         * new ThreadPoolExecutor(1,
+         * new ThreadPoolExecutor(workerCount,
          *                        workerCount,
-         *                        30,
-         *                        TimeUnit.SECONDS,
+         *                        0,
+         *                        TimeUnit.MILLISECONDS,
          *                        new ArrayBlockingQueue<>(queueLength),
          *                        new BlockingRejectedExecutionHandler());
          * }
          * </pre>
+         *
+         * This is similar to {@link java.util.concurrent.Executors#newFixedThreadPool},
+         * but with a different {@link java.util.concurrent.RejectedExecutionHandler},
+         * which will block until the task can be processed.
          *
          * @param executorService ExecutorService to run tasks
          * @return Builder
@@ -193,8 +197,9 @@ public class FNatsServer implements FServer {
          */
         public FNatsServer build() {
             if (executorService == null) {
+                //
                 this.executorService = new ThreadPoolExecutor(
-                        workerCount, workerCount, 30, TimeUnit.SECONDS,
+                        workerCount, workerCount, 0, TimeUnit.MILLISECONDS,
                         new ArrayBlockingQueue<>(queueLength),
                         new BlockingRejectedExecutionHandler());
             }


### PR DESCRIPTION
Bump the core thread pool size for the default executor service for a FNatsServer. This means the default executor service will always have the maximum number of threads, but this trade off seems worth it given how thread pool executors scale threads. The executor service doesn't scale up threads until there are `queueLength` items waiting to be processed, which is very undesirable. I don't think there are many cases where having less than the maximum number of threads is desired.

A lot of teams currently supply their own executor service, but this should help teams who use the default one.

@Workiva/product2 @brettkail-wk 