### PR TITLE
Infeng-7476: Isset is wrong in frugal generated dart code

### DIFF
--- a/examples/dart/gen-dart/v1_music/lib/src/f_album.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_album.dart
@@ -13,34 +13,52 @@ class Album implements thrift.TBase {
   static final thrift.TField _DURATION_FIELD_DESC = new thrift.TField("duration", thrift.TType.DOUBLE, 2);
   static final thrift.TField _ASIN_FIELD_DESC = new thrift.TField("ASIN", thrift.TType.STRING, 3);
 
-  List<t_v1_music.Track> tracks;
+  List<t_v1_music.Track> _tracks;
   static const int TRACKS = 1;
-  double duration = 0.0;
+  double _duration = 0.0;
   static const int DURATION = 2;
-  String aSIN;
+  String _aSIN;
   static const int ASIN = 3;
 
 
   Album() {
   }
 
-  @deprecated
-  bool isSetTracks() => tracks != null;
+  List<t_v1_music.Track> get tracks => this._tracks;
+
+  set tracks(List<t_v1_music.Track> tracks) {
+    this._tracks = tracks;
+  }
 
   @deprecated
-  unsetTracks() => tracks = null;
+  bool isSetTracks() => _tracks != null;
 
   @deprecated
-  bool isSetDuration() => duration != null;
+  unsetTracks() => this._tracks = null;
+
+  double get duration => this._duration;
+
+  set duration(double duration) {
+    this._duration = duration;
+  }
 
   @deprecated
-  unsetDuration() => duration = null;
+  bool isSetDuration() => _duration != null;
 
   @deprecated
-  bool isSetASIN() => aSIN != null;
+  unsetDuration() => this._duration = null;
+
+  String get aSIN => this._aSIN;
+
+  set aSIN(String aSIN) {
+    this._aSIN = aSIN;
+  }
 
   @deprecated
-  unsetASIN() => aSIN = null;
+  bool isSetASIN() => _aSIN != null;
+
+  @deprecated
+  unsetASIN() => this._aSIN = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -60,15 +78,15 @@ class Album implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case TRACKS:
-        tracks = value as List<t_v1_music.Track>; // ignore: avoid_as
+        _tracks = value as List<t_v1_music.Track>; // ignore: avoid_as
         break;
 
       case DURATION:
-        duration = value as double; // ignore: avoid_as
+        _duration = value as double; // ignore: avoid_as
         break;
 
       case ASIN:
-        aSIN = value as String; // ignore: avoid_as
+        _aSIN = value as String; // ignore: avoid_as
         break;
 
       default:
@@ -81,13 +99,13 @@ class Album implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case TRACKS:
-        return tracks != null;
+        return _tracks != null;
 
       case DURATION:
-        return duration != null;
+        return _duration != null;
 
       case ASIN:
-        return aSIN != null;
+        return _aSIN != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/examples/dart/gen-dart/v1_music/lib/src/f_purchasing_error.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_purchasing_error.dart
@@ -12,26 +12,38 @@ class PurchasingError extends Error implements thrift.TBase {
   static final thrift.TField _MESSAGE_FIELD_DESC = new thrift.TField("message", thrift.TType.STRING, 1);
   static final thrift.TField _ERROR_CODE_FIELD_DESC = new thrift.TField("error_code", thrift.TType.I16, 2);
 
-  String message;
+  String _message;
   static const int MESSAGE = 1;
-  int error_code = 0;
+  int _error_code = 0;
   static const int ERROR_CODE = 2;
 
 
   PurchasingError() {
   }
 
-  @deprecated
-  bool isSetMessage() => message != null;
+  String get message => this._message;
+
+  set message(String message) {
+    this._message = message;
+  }
 
   @deprecated
-  unsetMessage() => message = null;
+  bool isSetMessage() => _message != null;
 
   @deprecated
-  bool isSetError_code() => error_code != null;
+  unsetMessage() => this._message = null;
+
+  int get error_code => this._error_code;
+
+  set error_code(int error_code) {
+    this._error_code = error_code;
+  }
 
   @deprecated
-  unsetError_code() => error_code = null;
+  bool isSetError_code() => _error_code != null;
+
+  @deprecated
+  unsetError_code() => this._error_code = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -49,11 +61,11 @@ class PurchasingError extends Error implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case MESSAGE:
-        message = value as String; // ignore: avoid_as
+        _message = value as String; // ignore: avoid_as
         break;
 
       case ERROR_CODE:
-        error_code = value as int; // ignore: avoid_as
+        _error_code = value as int; // ignore: avoid_as
         break;
 
       default:
@@ -66,10 +78,10 @@ class PurchasingError extends Error implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case MESSAGE:
-        return message != null;
+        return _message != null;
 
       case ERROR_CODE:
-        return error_code != null;
+        return _error_code != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -138,26 +138,38 @@ class buyAlbum_args implements thrift.TBase {
   static final thrift.TField _ASIN_FIELD_DESC = new thrift.TField("ASIN", thrift.TType.STRING, 1);
   static final thrift.TField _ACCT_FIELD_DESC = new thrift.TField("acct", thrift.TType.STRING, 2);
 
-  String aSIN;
+  String _aSIN;
   static const int ASIN = 1;
-  String acct;
+  String _acct;
   static const int ACCT = 2;
 
 
   buyAlbum_args() {
   }
 
-  @deprecated
-  bool isSetASIN() => aSIN != null;
+  String get aSIN => this._aSIN;
+
+  set aSIN(String aSIN) {
+    this._aSIN = aSIN;
+  }
 
   @deprecated
-  unsetASIN() => aSIN = null;
+  bool isSetASIN() => _aSIN != null;
 
   @deprecated
-  bool isSetAcct() => acct != null;
+  unsetASIN() => this._aSIN = null;
+
+  String get acct => this._acct;
+
+  set acct(String acct) {
+    this._acct = acct;
+  }
 
   @deprecated
-  unsetAcct() => acct = null;
+  bool isSetAcct() => _acct != null;
+
+  @deprecated
+  unsetAcct() => this._acct = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -175,11 +187,11 @@ class buyAlbum_args implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case ASIN:
-        aSIN = value as String; // ignore: avoid_as
+        _aSIN = value as String; // ignore: avoid_as
         break;
 
       case ACCT:
-        acct = value as String; // ignore: avoid_as
+        _acct = value as String; // ignore: avoid_as
         break;
 
       default:
@@ -192,10 +204,10 @@ class buyAlbum_args implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case ASIN:
-        return aSIN != null;
+        return _aSIN != null;
 
       case ACCT:
-        return acct != null;
+        return _acct != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -312,26 +324,38 @@ class buyAlbum_result implements thrift.TBase {
   static final thrift.TField _SUCCESS_FIELD_DESC = new thrift.TField("success", thrift.TType.STRUCT, 0);
   static final thrift.TField _ERROR_FIELD_DESC = new thrift.TField("error", thrift.TType.STRUCT, 1);
 
-  t_v1_music.Album success;
+  t_v1_music.Album _success;
   static const int SUCCESS = 0;
-  t_v1_music.PurchasingError error;
+  t_v1_music.PurchasingError _error;
   static const int ERROR = 1;
 
 
   buyAlbum_result() {
   }
 
-  @deprecated
-  bool isSetSuccess() => success != null;
+  t_v1_music.Album get success => this._success;
+
+  set success(t_v1_music.Album success) {
+    this._success = success;
+  }
 
   @deprecated
-  unsetSuccess() => success = null;
+  bool isSetSuccess() => _success != null;
 
   @deprecated
-  bool isSetError() => error != null;
+  unsetSuccess() => this._success = null;
+
+  t_v1_music.PurchasingError get error => this._error;
+
+  set error(t_v1_music.PurchasingError error) {
+    this._error = error;
+  }
 
   @deprecated
-  unsetError() => error = null;
+  bool isSetError() => _error != null;
+
+  @deprecated
+  unsetError() => this._error = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -349,11 +373,11 @@ class buyAlbum_result implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case SUCCESS:
-        success = value as t_v1_music.Album; // ignore: avoid_as
+        _success = value as t_v1_music.Album; // ignore: avoid_as
         break;
 
       case ERROR:
-        error = value as t_v1_music.PurchasingError; // ignore: avoid_as
+        _error = value as t_v1_music.PurchasingError; // ignore: avoid_as
         break;
 
       default:
@@ -366,10 +390,10 @@ class buyAlbum_result implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case SUCCESS:
-        return success != null;
+        return _success != null;
 
       case ERROR:
-        return error != null;
+        return _error != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -492,26 +516,38 @@ class enterAlbumGiveaway_args implements thrift.TBase {
   static final thrift.TField _EMAIL_FIELD_DESC = new thrift.TField("email", thrift.TType.STRING, 1);
   static final thrift.TField _NAME_FIELD_DESC = new thrift.TField("name", thrift.TType.STRING, 2);
 
-  String email;
+  String _email;
   static const int EMAIL = 1;
-  String name;
+  String _name;
   static const int NAME = 2;
 
 
   enterAlbumGiveaway_args() {
   }
 
-  @deprecated
-  bool isSetEmail() => email != null;
+  String get email => this._email;
+
+  set email(String email) {
+    this._email = email;
+  }
 
   @deprecated
-  unsetEmail() => email = null;
+  bool isSetEmail() => _email != null;
 
   @deprecated
-  bool isSetName() => name != null;
+  unsetEmail() => this._email = null;
+
+  String get name => this._name;
+
+  set name(String name) {
+    this._name = name;
+  }
 
   @deprecated
-  unsetName() => name = null;
+  bool isSetName() => _name != null;
+
+  @deprecated
+  unsetName() => this._name = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -529,11 +565,11 @@ class enterAlbumGiveaway_args implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case EMAIL:
-        email = value as String; // ignore: avoid_as
+        _email = value as String; // ignore: avoid_as
         break;
 
       case NAME:
-        name = value as String; // ignore: avoid_as
+        _name = value as String; // ignore: avoid_as
         break;
 
       default:
@@ -546,10 +582,10 @@ class enterAlbumGiveaway_args implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case EMAIL:
-        return email != null;
+        return _email != null;
 
       case NAME:
-        return name != null;
+        return _name != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -665,18 +701,24 @@ class enterAlbumGiveaway_result implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("enterAlbumGiveaway_result");
   static final thrift.TField _SUCCESS_FIELD_DESC = new thrift.TField("success", thrift.TType.BOOL, 0);
 
-  bool success;
+  bool _success;
   static const int SUCCESS = 0;
 
 
   enterAlbumGiveaway_result() {
   }
 
-  @deprecated
-  bool isSetSuccess() => success != null;
+  bool get success => this._success;
+
+  set success(bool success) {
+    this._success = success;
+  }
 
   @deprecated
-  unsetSuccess() => success = null;
+  bool isSetSuccess() => _success != null;
+
+  @deprecated
+  unsetSuccess() => this._success = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -692,7 +734,7 @@ class enterAlbumGiveaway_result implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case SUCCESS:
-        success = value as bool; // ignore: avoid_as
+        _success = value as bool; // ignore: avoid_as
         break;
 
       default:
@@ -705,7 +747,7 @@ class enterAlbumGiveaway_result implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case SUCCESS:
-        return success != null;
+        return _success != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/examples/dart/gen-dart/v1_music/lib/src/f_track.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_track.dart
@@ -15,58 +15,94 @@ class Track implements thrift.TBase {
   static final thrift.TField _DURATION_FIELD_DESC = new thrift.TField("duration", thrift.TType.DOUBLE, 5);
   static final thrift.TField _PRO_FIELD_DESC = new thrift.TField("pro", thrift.TType.I32, 6);
 
-  String title;
+  String _title;
   static const int TITLE = 1;
-  String artist;
+  String _artist;
   static const int ARTIST = 2;
-  String publisher;
+  String _publisher;
   static const int PUBLISHER = 3;
-  String composer;
+  String _composer;
   static const int COMPOSER = 4;
-  double duration = 0.0;
+  double _duration = 0.0;
   static const int DURATION = 5;
-  int pro;
+  int _pro;
   static const int PRO = 6;
 
 
   Track() {
   }
 
-  @deprecated
-  bool isSetTitle() => title != null;
+  String get title => this._title;
+
+  set title(String title) {
+    this._title = title;
+  }
 
   @deprecated
-  unsetTitle() => title = null;
+  bool isSetTitle() => _title != null;
 
   @deprecated
-  bool isSetArtist() => artist != null;
+  unsetTitle() => this._title = null;
+
+  String get artist => this._artist;
+
+  set artist(String artist) {
+    this._artist = artist;
+  }
 
   @deprecated
-  unsetArtist() => artist = null;
+  bool isSetArtist() => _artist != null;
 
   @deprecated
-  bool isSetPublisher() => publisher != null;
+  unsetArtist() => this._artist = null;
+
+  String get publisher => this._publisher;
+
+  set publisher(String publisher) {
+    this._publisher = publisher;
+  }
 
   @deprecated
-  unsetPublisher() => publisher = null;
+  bool isSetPublisher() => _publisher != null;
 
   @deprecated
-  bool isSetComposer() => composer != null;
+  unsetPublisher() => this._publisher = null;
+
+  String get composer => this._composer;
+
+  set composer(String composer) {
+    this._composer = composer;
+  }
 
   @deprecated
-  unsetComposer() => composer = null;
+  bool isSetComposer() => _composer != null;
 
   @deprecated
-  bool isSetDuration() => duration != null;
+  unsetComposer() => this._composer = null;
+
+  double get duration => this._duration;
+
+  set duration(double duration) {
+    this._duration = duration;
+  }
 
   @deprecated
-  unsetDuration() => duration = null;
+  bool isSetDuration() => _duration != null;
 
   @deprecated
-  bool isSetPro() => pro != null;
+  unsetDuration() => this._duration = null;
+
+  int get pro => this._pro;
+
+  set pro(int pro) {
+    this._pro = pro;
+  }
 
   @deprecated
-  unsetPro() => pro = null;
+  bool isSetPro() => _pro != null;
+
+  @deprecated
+  unsetPro() => this._pro = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -92,27 +128,27 @@ class Track implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case TITLE:
-        title = value as String; // ignore: avoid_as
+        _title = value as String; // ignore: avoid_as
         break;
 
       case ARTIST:
-        artist = value as String; // ignore: avoid_as
+        _artist = value as String; // ignore: avoid_as
         break;
 
       case PUBLISHER:
-        publisher = value as String; // ignore: avoid_as
+        _publisher = value as String; // ignore: avoid_as
         break;
 
       case COMPOSER:
-        composer = value as String; // ignore: avoid_as
+        _composer = value as String; // ignore: avoid_as
         break;
 
       case DURATION:
-        duration = value as double; // ignore: avoid_as
+        _duration = value as double; // ignore: avoid_as
         break;
 
       case PRO:
-        pro = value as int; // ignore: avoid_as
+        _pro = value as int; // ignore: avoid_as
         break;
 
       default:
@@ -125,22 +161,22 @@ class Track implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case TITLE:
-        return title != null;
+        return _title != null;
 
       case ARTIST:
-        return artist != null;
+        return _artist != null;
 
       case PUBLISHER:
-        return publisher != null;
+        return _publisher != null;
 
       case COMPOSER:
-        return composer != null;
+        return _composer != null;
 
       case DURATION:
-        return duration != null;
+        return _duration != null;
 
       case PRO:
-        return pro != null;
+        return _pro != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/test/expected/dart/actual_base/f_nested_thing.dart
+++ b/test/expected/dart/actual_base/f_nested_thing.dart
@@ -10,18 +10,24 @@ class nested_thing implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("nested_thing");
   static final thrift.TField _THINGS_FIELD_DESC = new thrift.TField("things", thrift.TType.LIST, 1);
 
-  List<t_actual_base_dart.thing> things;
+  List<t_actual_base_dart.thing> _things;
   static const int THINGS = 1;
 
 
   nested_thing() {
   }
 
-  @deprecated
-  bool isSetThings() => things != null;
+  List<t_actual_base_dart.thing> get things => this._things;
+
+  set things(List<t_actual_base_dart.thing> things) {
+    this._things = things;
+  }
 
   @deprecated
-  unsetThings() => things = null;
+  bool isSetThings() => _things != null;
+
+  @deprecated
+  unsetThings() => this._things = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -37,7 +43,7 @@ class nested_thing implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case THINGS:
-        things = value as List<t_actual_base_dart.thing>; // ignore: avoid_as
+        _things = value as List<t_actual_base_dart.thing>; // ignore: avoid_as
         break;
 
       default:
@@ -50,7 +56,7 @@ class nested_thing implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case THINGS:
-        return things != null;
+        return _things != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/test/expected/dart/actual_base/f_thing.dart
+++ b/test/expected/dart/actual_base/f_thing.dart
@@ -10,26 +10,38 @@ class thing implements thrift.TBase {
   static final thrift.TField _AN_ID_FIELD_DESC = new thrift.TField("an_id", thrift.TType.I32, 1);
   static final thrift.TField _A_STRING_FIELD_DESC = new thrift.TField("a_string", thrift.TType.STRING, 2);
 
-  int an_id = 0;
+  int _an_id = 0;
   static const int AN_ID = 1;
-  String a_string;
+  String _a_string;
   static const int A_STRING = 2;
 
 
   thing() {
   }
 
-  @deprecated
-  bool isSetAn_id() => an_id != null;
+  int get an_id => this._an_id;
+
+  set an_id(int an_id) {
+    this._an_id = an_id;
+  }
 
   @deprecated
-  unsetAn_id() => an_id = null;
+  bool isSetAn_id() => _an_id != null;
 
   @deprecated
-  bool isSetA_string() => a_string != null;
+  unsetAn_id() => this._an_id = null;
+
+  String get a_string => this._a_string;
+
+  set a_string(String a_string) {
+    this._a_string = a_string;
+  }
 
   @deprecated
-  unsetA_string() => a_string = null;
+  bool isSetA_string() => _a_string != null;
+
+  @deprecated
+  unsetA_string() => this._a_string = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -47,11 +59,11 @@ class thing implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case AN_ID:
-        an_id = value as int; // ignore: avoid_as
+        _an_id = value as int; // ignore: avoid_as
         break;
 
       case A_STRING:
-        a_string = value as String; // ignore: avoid_as
+        _a_string = value as String; // ignore: avoid_as
         break;
 
       default:
@@ -64,10 +76,10 @@ class thing implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case AN_ID:
-        return an_id != null;
+        return _an_id != null;
 
       case A_STRING:
-        return a_string != null;
+        return _a_string != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -173,26 +173,38 @@ class getItem_result implements thrift.TBase {
   static final thrift.TField _SUCCESS_FIELD_DESC = new thrift.TField("success", thrift.TType.STRUCT, 0);
   static final thrift.TField _D_FIELD_DESC = new thrift.TField("d", thrift.TType.STRUCT, 1);
 
-  t_vendor_namespace.Item success;
+  t_vendor_namespace.Item _success;
   static const int SUCCESS = 0;
-  t_excepts.InvalidData d;
+  t_excepts.InvalidData _d;
   static const int D = 1;
 
 
   getItem_result() {
   }
 
-  @deprecated
-  bool isSetSuccess() => success != null;
+  t_vendor_namespace.Item get success => this._success;
+
+  set success(t_vendor_namespace.Item success) {
+    this._success = success;
+  }
 
   @deprecated
-  unsetSuccess() => success = null;
+  bool isSetSuccess() => _success != null;
 
   @deprecated
-  bool isSetD() => d != null;
+  unsetSuccess() => this._success = null;
+
+  t_excepts.InvalidData get d => this._d;
+
+  set d(t_excepts.InvalidData d) {
+    this._d = d;
+  }
 
   @deprecated
-  unsetD() => d = null;
+  bool isSetD() => _d != null;
+
+  @deprecated
+  unsetD() => this._d = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -210,11 +222,11 @@ class getItem_result implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case SUCCESS:
-        success = value as t_vendor_namespace.Item; // ignore: avoid_as
+        _success = value as t_vendor_namespace.Item; // ignore: avoid_as
         break;
 
       case D:
-        d = value as t_excepts.InvalidData; // ignore: avoid_as
+        _d = value as t_excepts.InvalidData; // ignore: avoid_as
         break;
 
       default:
@@ -227,10 +239,10 @@ class getItem_result implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case SUCCESS:
-        return success != null;
+        return _success != null;
 
       case D:
-        return d != null;
+        return _d != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/test/expected/dart/include_vendor/f_vendored_references.dart
+++ b/test/expected/dart/include_vendor/f_vendored_references.dart
@@ -12,28 +12,38 @@ class VendoredReferences implements thrift.TBase {
   static final thrift.TField _REFERENCE_VENDORED_CONST_FIELD_DESC = new thrift.TField("reference_vendored_const", thrift.TType.I32, 1);
   static final thrift.TField _REFERENCE_VENDORED_ENUM_FIELD_DESC = new thrift.TField("reference_vendored_enum", thrift.TType.I32, 2);
 
-  int reference_vendored_const;
+  int _reference_vendored_const;
   static const int REFERENCE_VENDORED_CONST = 1;
-  int reference_vendored_enum;
+  int _reference_vendored_enum;
   static const int REFERENCE_VENDORED_ENUM = 2;
 
 
   VendoredReferences() {
-    this.reference_vendored_const = t_vendor_namespace.VendorNamespaceConstants.a_const;
-    this.reference_vendored_enum = t_vendor_namespace.MyEnum.TWO;
+  }
+
+  int get reference_vendored_const => this._reference_vendored_const ?? t_vendor_namespace.VendorNamespaceConstants.a_const;
+
+  set reference_vendored_const(int reference_vendored_const) {
+    this._reference_vendored_const = reference_vendored_const;
   }
 
   @deprecated
-  bool isSetReference_vendored_const() => reference_vendored_const != null && reference_vendored_const != t_vendor_namespace.VendorNamespaceConstants.a_const;
+  bool isSetReference_vendored_const() => _reference_vendored_const != null;
 
   @deprecated
-  unsetReference_vendored_const() => reference_vendored_const = null;
+  unsetReference_vendored_const() => this._reference_vendored_const = null;
+
+  int get reference_vendored_enum => this._reference_vendored_enum ?? t_vendor_namespace.MyEnum.TWO;
+
+  set reference_vendored_enum(int reference_vendored_enum) {
+    this._reference_vendored_enum = reference_vendored_enum;
+  }
 
   @deprecated
-  bool isSetReference_vendored_enum() => reference_vendored_enum != null && reference_vendored_enum != t_vendor_namespace.MyEnum.TWO;
+  bool isSetReference_vendored_enum() => _reference_vendored_enum != null;
 
   @deprecated
-  unsetReference_vendored_enum() => reference_vendored_enum = null;
+  unsetReference_vendored_enum() => this._reference_vendored_enum = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -51,11 +61,11 @@ class VendoredReferences implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case REFERENCE_VENDORED_CONST:
-        reference_vendored_const = value as int; // ignore: avoid_as
+        _reference_vendored_const = value as int; // ignore: avoid_as
         break;
 
       case REFERENCE_VENDORED_ENUM:
-        reference_vendored_enum = value as int; // ignore: avoid_as
+        _reference_vendored_enum = value as int; // ignore: avoid_as
         break;
 
       default:
@@ -68,10 +78,10 @@ class VendoredReferences implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case REFERENCE_VENDORED_CONST:
-        return reference_vendored_const != null && reference_vendored_const != t_vendor_namespace.VendorNamespaceConstants.a_const;
+        return _reference_vendored_const != null;
 
       case REFERENCE_VENDORED_ENUM:
-        return reference_vendored_enum != null && reference_vendored_enum != t_vendor_namespace.MyEnum.TWO;
+        return _reference_vendored_enum != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/test/expected/dart/variety/f_awesome_exception.dart
+++ b/test/expected/dart/variety/f_awesome_exception.dart
@@ -17,37 +17,55 @@ class AwesomeException extends Error implements thrift.TBase {
   static final thrift.TField _DEPR_FIELD_DESC = new thrift.TField("depr", thrift.TType.BOOL, 3);
 
   /// ID is a unique identifier for an awesome exception.
-  int iD = 0;
+  int _iD = 0;
   static const int ID = 1;
   /// Reason contains the error message.
-  String reason;
+  String _reason;
   static const int REASON = 2;
   /// Deprecated: use something else
   @deprecated
-  bool depr = false;
+  bool _depr = false;
   static const int DEPR = 3;
 
 
   AwesomeException() {
   }
 
-  @deprecated
-  bool isSetID() => iD != null;
+  int get iD => this._iD;
+
+  set iD(int iD) {
+    this._iD = iD;
+  }
 
   @deprecated
-  unsetID() => iD = null;
+  bool isSetID() => _iD != null;
 
   @deprecated
-  bool isSetReason() => reason != null;
+  unsetID() => this._iD = null;
+
+  String get reason => this._reason;
+
+  set reason(String reason) {
+    this._reason = reason;
+  }
 
   @deprecated
-  unsetReason() => reason = null;
+  bool isSetReason() => _reason != null;
 
   @deprecated
-  bool isSetDepr() => depr != null;
+  unsetReason() => this._reason = null;
+
+  bool get depr => this._depr;
+
+  set depr(bool depr) {
+    this._depr = depr;
+  }
 
   @deprecated
-  unsetDepr() => depr = null;
+  bool isSetDepr() => _depr != null;
+
+  @deprecated
+  unsetDepr() => this._depr = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -68,15 +86,15 @@ class AwesomeException extends Error implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case ID:
-        iD = value as int; // ignore: avoid_as
+        _iD = value as int; // ignore: avoid_as
         break;
 
       case REASON:
-        reason = value as String; // ignore: avoid_as
+        _reason = value as String; // ignore: avoid_as
         break;
 
       case DEPR:
-        depr = value as bool; // ignore: avoid_as
+        _depr = value as bool; // ignore: avoid_as
         break;
 
       default:
@@ -89,14 +107,14 @@ class AwesomeException extends Error implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case ID:
-        return iD != null;
+        return _iD != null;
 
       case REASON:
-        return reason != null;
+        return _reason != null;
 
       case DEPR:
         // ignore: deprecated_member_use
-        return depr != null;
+        return _depr != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/test/expected/dart/variety/f_event.dart
+++ b/test/expected/dart/variety/f_event.dart
@@ -18,28 +18,39 @@ class Event implements thrift.TBase {
   static final thrift.TField _MESSAGE_FIELD_DESC = new thrift.TField("Message", thrift.TType.STRING, 2);
 
   /// ID is a unique identifier for an event.
-  int iD = 0;
+  int _iD = 0;
   static const int ID = 1;
   /// Message contains the event payload.
-  String message;
+  String _message;
   static const int MESSAGE = 2;
 
 
   Event() {
-    this.iD = t_variety.VarietyConstants.DEFAULT_ID;
+  }
+
+  int get iD => this._iD ?? t_variety.VarietyConstants.DEFAULT_ID;
+
+  set iD(int iD) {
+    this._iD = iD;
   }
 
   @deprecated
-  bool isSetID() => iD != null && iD != t_variety.VarietyConstants.DEFAULT_ID;
+  bool isSetID() => _iD != null;
 
   @deprecated
-  unsetID() => iD = null;
+  unsetID() => this._iD = null;
+
+  String get message => this._message;
+
+  set message(String message) {
+    this._message = message;
+  }
 
   @deprecated
-  bool isSetMessage() => message != null;
+  bool isSetMessage() => _message != null;
 
   @deprecated
-  unsetMessage() => message = null;
+  unsetMessage() => this._message = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -57,11 +68,11 @@ class Event implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case ID:
-        iD = value as int; // ignore: avoid_as
+        _iD = value as int; // ignore: avoid_as
         break;
 
       case MESSAGE:
-        message = value as String; // ignore: avoid_as
+        _message = value as String; // ignore: avoid_as
         break;
 
       default:
@@ -74,10 +85,10 @@ class Event implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case ID:
-        return iD != null && iD != t_variety.VarietyConstants.DEFAULT_ID;
+        return _iD != null;
 
       case MESSAGE:
-        return message != null;
+        return _message != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/test/expected/dart/variety/f_event_wrapper.dart
+++ b/test/expected/dart/variety/f_event_wrapper.dart
@@ -26,122 +26,200 @@ class EventWrapper implements thrift.TBase {
   static final thrift.TField _DEPR_BINARY_FIELD_DESC = new thrift.TField("deprBinary", thrift.TType.STRING, 12);
   static final thrift.TField _DEPR_LIST_FIELD_DESC = new thrift.TField("deprList", thrift.TType.LIST, 13);
 
-  int iD;
+  int _iD;
   static const int ID = 1;
-  t_variety.Event ev;
+  t_variety.Event _ev;
   static const int EV = 2;
-  List<t_variety.Event> events;
+  List<t_variety.Event> _events;
   static const int EVENTS = 3;
-  Set<t_variety.Event> events2;
+  Set<t_variety.Event> _events2;
   static const int EVENTS2 = 4;
-  Map<int, t_variety.Event> eventMap;
+  Map<int, t_variety.Event> _eventMap;
   static const int EVENTMAP = 5;
-  List<List<int>> nums;
+  List<List<int>> _nums;
   static const int NUMS = 6;
-  List<int> enums;
+  List<int> _enums;
   static const int ENUMS = 7;
-  bool aBoolField = false;
+  bool _aBoolField = false;
   static const int ABOOLFIELD = 8;
-  t_variety.TestingUnions a_union;
+  t_variety.TestingUnions _a_union;
   static const int A_UNION = 9;
-  String typedefOfTypedef;
+  String _typedefOfTypedef;
   static const int TYPEDEFOFTYPEDEF = 10;
   /// This is a docstring comment for a deprecated field that has been spread
   /// across two lines.
   /// Deprecated: use something else
   @deprecated
-  bool depr = false;
+  bool _depr = false;
   static const int DEPR = 11;
   /// Deprecated: use something else
   @deprecated
-  Uint8List deprBinary;
+  Uint8List _deprBinary;
   static const int DEPRBINARY = 12;
   /// Deprecated: use something else
   @deprecated
-  List<bool> deprList;
+  List<bool> _deprList;
   static const int DEPRLIST = 13;
 
 
   EventWrapper() {
   }
 
-  @deprecated
-  bool isSetID() => iD != null;
+  int get iD => this._iD;
+
+  set iD(int iD) {
+    this._iD = iD;
+  }
 
   @deprecated
-  unsetID() => iD = null;
+  bool isSetID() => _iD != null;
 
   @deprecated
-  bool isSetEv() => ev != null;
+  unsetID() => this._iD = null;
+
+  t_variety.Event get ev => this._ev;
+
+  set ev(t_variety.Event ev) {
+    this._ev = ev;
+  }
 
   @deprecated
-  unsetEv() => ev = null;
+  bool isSetEv() => _ev != null;
 
   @deprecated
-  bool isSetEvents() => events != null;
+  unsetEv() => this._ev = null;
+
+  List<t_variety.Event> get events => this._events;
+
+  set events(List<t_variety.Event> events) {
+    this._events = events;
+  }
 
   @deprecated
-  unsetEvents() => events = null;
+  bool isSetEvents() => _events != null;
 
   @deprecated
-  bool isSetEvents2() => events2 != null;
+  unsetEvents() => this._events = null;
+
+  Set<t_variety.Event> get events2 => this._events2;
+
+  set events2(Set<t_variety.Event> events2) {
+    this._events2 = events2;
+  }
 
   @deprecated
-  unsetEvents2() => events2 = null;
+  bool isSetEvents2() => _events2 != null;
 
   @deprecated
-  bool isSetEventMap() => eventMap != null;
+  unsetEvents2() => this._events2 = null;
+
+  Map<int, t_variety.Event> get eventMap => this._eventMap;
+
+  set eventMap(Map<int, t_variety.Event> eventMap) {
+    this._eventMap = eventMap;
+  }
 
   @deprecated
-  unsetEventMap() => eventMap = null;
+  bool isSetEventMap() => _eventMap != null;
 
   @deprecated
-  bool isSetNums() => nums != null;
+  unsetEventMap() => this._eventMap = null;
+
+  List<List<int>> get nums => this._nums;
+
+  set nums(List<List<int>> nums) {
+    this._nums = nums;
+  }
 
   @deprecated
-  unsetNums() => nums = null;
+  bool isSetNums() => _nums != null;
 
   @deprecated
-  bool isSetEnums() => enums != null;
+  unsetNums() => this._nums = null;
+
+  List<int> get enums => this._enums;
+
+  set enums(List<int> enums) {
+    this._enums = enums;
+  }
 
   @deprecated
-  unsetEnums() => enums = null;
+  bool isSetEnums() => _enums != null;
 
   @deprecated
-  bool isSetABoolField() => aBoolField != null;
+  unsetEnums() => this._enums = null;
+
+  bool get aBoolField => this._aBoolField;
+
+  set aBoolField(bool aBoolField) {
+    this._aBoolField = aBoolField;
+  }
 
   @deprecated
-  unsetABoolField() => aBoolField = null;
+  bool isSetABoolField() => _aBoolField != null;
 
   @deprecated
-  bool isSetA_union() => a_union != null;
+  unsetABoolField() => this._aBoolField = null;
+
+  t_variety.TestingUnions get a_union => this._a_union;
+
+  set a_union(t_variety.TestingUnions a_union) {
+    this._a_union = a_union;
+  }
 
   @deprecated
-  unsetA_union() => a_union = null;
+  bool isSetA_union() => _a_union != null;
 
   @deprecated
-  bool isSetTypedefOfTypedef() => typedefOfTypedef != null;
+  unsetA_union() => this._a_union = null;
+
+  String get typedefOfTypedef => this._typedefOfTypedef;
+
+  set typedefOfTypedef(String typedefOfTypedef) {
+    this._typedefOfTypedef = typedefOfTypedef;
+  }
 
   @deprecated
-  unsetTypedefOfTypedef() => typedefOfTypedef = null;
+  bool isSetTypedefOfTypedef() => _typedefOfTypedef != null;
 
   @deprecated
-  bool isSetDepr() => depr != null;
+  unsetTypedefOfTypedef() => this._typedefOfTypedef = null;
+
+  bool get depr => this._depr;
+
+  set depr(bool depr) {
+    this._depr = depr;
+  }
 
   @deprecated
-  unsetDepr() => depr = null;
+  bool isSetDepr() => _depr != null;
 
   @deprecated
-  bool isSetDeprBinary() => deprBinary != null;
+  unsetDepr() => this._depr = null;
+
+  Uint8List get deprBinary => this._deprBinary;
+
+  set deprBinary(Uint8List deprBinary) {
+    this._deprBinary = deprBinary;
+  }
 
   @deprecated
-  unsetDeprBinary() => deprBinary = null;
+  bool isSetDeprBinary() => _deprBinary != null;
 
   @deprecated
-  bool isSetDeprList() => deprList != null;
+  unsetDeprBinary() => this._deprBinary = null;
+
+  List<bool> get deprList => this._deprList;
+
+  set deprList(List<bool> deprList) {
+    this._deprList = deprList;
+  }
 
   @deprecated
-  unsetDeprList() => deprList = null;
+  bool isSetDeprList() => _deprList != null;
+
+  @deprecated
+  unsetDeprList() => this._deprList = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -184,55 +262,55 @@ class EventWrapper implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case ID:
-        iD = value as int; // ignore: avoid_as
+        _iD = value as int; // ignore: avoid_as
         break;
 
       case EV:
-        ev = value as t_variety.Event; // ignore: avoid_as
+        _ev = value as t_variety.Event; // ignore: avoid_as
         break;
 
       case EVENTS:
-        events = value as List<t_variety.Event>; // ignore: avoid_as
+        _events = value as List<t_variety.Event>; // ignore: avoid_as
         break;
 
       case EVENTS2:
-        events2 = value as Set<t_variety.Event>; // ignore: avoid_as
+        _events2 = value as Set<t_variety.Event>; // ignore: avoid_as
         break;
 
       case EVENTMAP:
-        eventMap = value as Map<int, t_variety.Event>; // ignore: avoid_as
+        _eventMap = value as Map<int, t_variety.Event>; // ignore: avoid_as
         break;
 
       case NUMS:
-        nums = value as List<List<int>>; // ignore: avoid_as
+        _nums = value as List<List<int>>; // ignore: avoid_as
         break;
 
       case ENUMS:
-        enums = value as List<int>; // ignore: avoid_as
+        _enums = value as List<int>; // ignore: avoid_as
         break;
 
       case ABOOLFIELD:
-        aBoolField = value as bool; // ignore: avoid_as
+        _aBoolField = value as bool; // ignore: avoid_as
         break;
 
       case A_UNION:
-        a_union = value as t_variety.TestingUnions; // ignore: avoid_as
+        _a_union = value as t_variety.TestingUnions; // ignore: avoid_as
         break;
 
       case TYPEDEFOFTYPEDEF:
-        typedefOfTypedef = value as String; // ignore: avoid_as
+        _typedefOfTypedef = value as String; // ignore: avoid_as
         break;
 
       case DEPR:
-        depr = value as bool; // ignore: avoid_as
+        _depr = value as bool; // ignore: avoid_as
         break;
 
       case DEPRBINARY:
-        deprBinary = value as Uint8List; // ignore: avoid_as
+        _deprBinary = value as Uint8List; // ignore: avoid_as
         break;
 
       case DEPRLIST:
-        deprList = value as List<bool>; // ignore: avoid_as
+        _deprList = value as List<bool>; // ignore: avoid_as
         break;
 
       default:
@@ -245,46 +323,46 @@ class EventWrapper implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case ID:
-        return iD != null;
+        return _iD != null;
 
       case EV:
-        return ev != null;
+        return _ev != null;
 
       case EVENTS:
-        return events != null;
+        return _events != null;
 
       case EVENTS2:
-        return events2 != null;
+        return _events2 != null;
 
       case EVENTMAP:
-        return eventMap != null;
+        return _eventMap != null;
 
       case NUMS:
-        return nums != null;
+        return _nums != null;
 
       case ENUMS:
-        return enums != null;
+        return _enums != null;
 
       case ABOOLFIELD:
-        return aBoolField != null;
+        return _aBoolField != null;
 
       case A_UNION:
-        return a_union != null;
+        return _a_union != null;
 
       case TYPEDEFOFTYPEDEF:
-        return typedefOfTypedef != null;
+        return _typedefOfTypedef != null;
 
       case DEPR:
         // ignore: deprecated_member_use
-        return depr != null;
+        return _depr != null;
 
       case DEPRBINARY:
         // ignore: deprecated_member_use
-        return deprBinary != null;
+        return _deprBinary != null;
 
       case DEPRLIST:
         // ignore: deprecated_member_use
-        return deprList != null;
+        return _deprList != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/test/expected/dart/variety/f_foo_args.dart
+++ b/test/expected/dart/variety/f_foo_args.dart
@@ -16,34 +16,52 @@ class FooArgs implements thrift.TBase {
   static final thrift.TField _MESSAGE_ARGS_FIELD_DESC = new thrift.TField("messageArgs", thrift.TType.STRING, 2);
   static final thrift.TField _MESSAGE_RESULT_FIELD_DESC = new thrift.TField("messageResult", thrift.TType.STRING, 3);
 
-  String newMessage;
+  String _newMessage;
   static const int NEWMESSAGE = 1;
-  String messageArgs;
+  String _messageArgs;
   static const int MESSAGEARGS = 2;
-  String messageResult;
+  String _messageResult;
   static const int MESSAGERESULT = 3;
 
 
   FooArgs() {
   }
 
-  @deprecated
-  bool isSetNewMessage() => newMessage != null;
+  String get newMessage => this._newMessage;
+
+  set newMessage(String newMessage) {
+    this._newMessage = newMessage;
+  }
 
   @deprecated
-  unsetNewMessage() => newMessage = null;
+  bool isSetNewMessage() => _newMessage != null;
 
   @deprecated
-  bool isSetMessageArgs() => messageArgs != null;
+  unsetNewMessage() => this._newMessage = null;
+
+  String get messageArgs => this._messageArgs;
+
+  set messageArgs(String messageArgs) {
+    this._messageArgs = messageArgs;
+  }
 
   @deprecated
-  unsetMessageArgs() => messageArgs = null;
+  bool isSetMessageArgs() => _messageArgs != null;
 
   @deprecated
-  bool isSetMessageResult() => messageResult != null;
+  unsetMessageArgs() => this._messageArgs = null;
+
+  String get messageResult => this._messageResult;
+
+  set messageResult(String messageResult) {
+    this._messageResult = messageResult;
+  }
 
   @deprecated
-  unsetMessageResult() => messageResult = null;
+  bool isSetMessageResult() => _messageResult != null;
+
+  @deprecated
+  unsetMessageResult() => this._messageResult = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -63,15 +81,15 @@ class FooArgs implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case NEWMESSAGE:
-        newMessage = value as String; // ignore: avoid_as
+        _newMessage = value as String; // ignore: avoid_as
         break;
 
       case MESSAGEARGS:
-        messageArgs = value as String; // ignore: avoid_as
+        _messageArgs = value as String; // ignore: avoid_as
         break;
 
       case MESSAGERESULT:
-        messageResult = value as String; // ignore: avoid_as
+        _messageResult = value as String; // ignore: avoid_as
         break;
 
       default:
@@ -84,13 +102,13 @@ class FooArgs implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case NEWMESSAGE:
-        return newMessage != null;
+        return _newMessage != null;
 
       case MESSAGEARGS:
-        return messageArgs != null;
+        return _messageArgs != null;
 
       case MESSAGERESULT:
-        return messageResult != null;
+        return _messageResult != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -732,34 +732,52 @@ class blah_args implements thrift.TBase {
   static final thrift.TField _STR_FIELD_DESC = new thrift.TField("Str", thrift.TType.STRING, 2);
   static final thrift.TField _EVENT_FIELD_DESC = new thrift.TField("event", thrift.TType.STRUCT, 3);
 
-  int num = 0;
+  int _num = 0;
   static const int NUM = 1;
-  String str;
+  String _str;
   static const int STR = 2;
-  t_variety.Event event;
+  t_variety.Event _event;
   static const int EVENT = 3;
 
 
   blah_args() {
   }
 
-  @deprecated
-  bool isSetNum() => num != null;
+  int get num => this._num;
+
+  set num(int num) {
+    this._num = num;
+  }
 
   @deprecated
-  unsetNum() => num = null;
+  bool isSetNum() => _num != null;
 
   @deprecated
-  bool isSetStr() => str != null;
+  unsetNum() => this._num = null;
+
+  String get str => this._str;
+
+  set str(String str) {
+    this._str = str;
+  }
 
   @deprecated
-  unsetStr() => str = null;
+  bool isSetStr() => _str != null;
 
   @deprecated
-  bool isSetEvent() => event != null;
+  unsetStr() => this._str = null;
+
+  t_variety.Event get event => this._event;
+
+  set event(t_variety.Event event) {
+    this._event = event;
+  }
 
   @deprecated
-  unsetEvent() => event = null;
+  bool isSetEvent() => _event != null;
+
+  @deprecated
+  unsetEvent() => this._event = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -779,15 +797,15 @@ class blah_args implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case NUM:
-        num = value as int; // ignore: avoid_as
+        _num = value as int; // ignore: avoid_as
         break;
 
       case STR:
-        str = value as String; // ignore: avoid_as
+        _str = value as String; // ignore: avoid_as
         break;
 
       case EVENT:
-        event = value as t_variety.Event; // ignore: avoid_as
+        _event = value as t_variety.Event; // ignore: avoid_as
         break;
 
       default:
@@ -800,13 +818,13 @@ class blah_args implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case NUM:
-        return num != null;
+        return _num != null;
 
       case STR:
-        return str != null;
+        return _str != null;
 
       case EVENT:
-        return event != null;
+        return _event != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -943,34 +961,52 @@ class blah_result implements thrift.TBase {
   static final thrift.TField _AWE_FIELD_DESC = new thrift.TField("awe", thrift.TType.STRUCT, 1);
   static final thrift.TField _API_FIELD_DESC = new thrift.TField("api", thrift.TType.STRUCT, 2);
 
-  int success;
+  int _success;
   static const int SUCCESS = 0;
-  t_variety.AwesomeException awe;
+  t_variety.AwesomeException _awe;
   static const int AWE = 1;
-  t_actual_base_dart.api_exception api;
+  t_actual_base_dart.api_exception _api;
   static const int API = 2;
 
 
   blah_result() {
   }
 
-  @deprecated
-  bool isSetSuccess() => success != null;
+  int get success => this._success;
+
+  set success(int success) {
+    this._success = success;
+  }
 
   @deprecated
-  unsetSuccess() => success = null;
+  bool isSetSuccess() => _success != null;
 
   @deprecated
-  bool isSetAwe() => awe != null;
+  unsetSuccess() => this._success = null;
+
+  t_variety.AwesomeException get awe => this._awe;
+
+  set awe(t_variety.AwesomeException awe) {
+    this._awe = awe;
+  }
 
   @deprecated
-  unsetAwe() => awe = null;
+  bool isSetAwe() => _awe != null;
 
   @deprecated
-  bool isSetApi() => api != null;
+  unsetAwe() => this._awe = null;
+
+  t_actual_base_dart.api_exception get api => this._api;
+
+  set api(t_actual_base_dart.api_exception api) {
+    this._api = api;
+  }
 
   @deprecated
-  unsetApi() => api = null;
+  bool isSetApi() => _api != null;
+
+  @deprecated
+  unsetApi() => this._api = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -990,15 +1026,15 @@ class blah_result implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case SUCCESS:
-        success = value as int; // ignore: avoid_as
+        _success = value as int; // ignore: avoid_as
         break;
 
       case AWE:
-        awe = value as t_variety.AwesomeException; // ignore: avoid_as
+        _awe = value as t_variety.AwesomeException; // ignore: avoid_as
         break;
 
       case API:
-        api = value as t_actual_base_dart.api_exception; // ignore: avoid_as
+        _api = value as t_actual_base_dart.api_exception; // ignore: avoid_as
         break;
 
       default:
@@ -1011,13 +1047,13 @@ class blah_result implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case SUCCESS:
-        return success != null;
+        return _success != null;
 
       case AWE:
-        return awe != null;
+        return _awe != null;
 
       case API:
-        return api != null;
+        return _api != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -1162,26 +1198,38 @@ class oneWay_args implements thrift.TBase {
   static final thrift.TField _ID_FIELD_DESC = new thrift.TField("id", thrift.TType.I64, 1);
   static final thrift.TField _REQ_FIELD_DESC = new thrift.TField("req", thrift.TType.MAP, 2);
 
-  int id = 0;
+  int _id = 0;
   static const int ID = 1;
-  Map<int, String> req;
+  Map<int, String> _req;
   static const int REQ = 2;
 
 
   oneWay_args() {
   }
 
-  @deprecated
-  bool isSetId() => id != null;
+  int get id => this._id;
+
+  set id(int id) {
+    this._id = id;
+  }
 
   @deprecated
-  unsetId() => id = null;
+  bool isSetId() => _id != null;
 
   @deprecated
-  bool isSetReq() => req != null;
+  unsetId() => this._id = null;
+
+  Map<int, String> get req => this._req;
+
+  set req(Map<int, String> req) {
+    this._req = req;
+  }
 
   @deprecated
-  unsetReq() => req = null;
+  bool isSetReq() => _req != null;
+
+  @deprecated
+  unsetReq() => this._req = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -1199,11 +1247,11 @@ class oneWay_args implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case ID:
-        id = value as int; // ignore: avoid_as
+        _id = value as int; // ignore: avoid_as
         break;
 
       case REQ:
-        req = value as Map<int, String>; // ignore: avoid_as
+        _req = value as Map<int, String>; // ignore: avoid_as
         break;
 
       default:
@@ -1216,10 +1264,10 @@ class oneWay_args implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case ID:
-        return id != null;
+        return _id != null;
 
       case REQ:
-        return req != null;
+        return _req != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -1342,26 +1390,38 @@ class bin_method_args implements thrift.TBase {
   static final thrift.TField _BIN_FIELD_DESC = new thrift.TField("bin", thrift.TType.STRING, 1);
   static final thrift.TField _STR_FIELD_DESC = new thrift.TField("Str", thrift.TType.STRING, 2);
 
-  Uint8List bin;
+  Uint8List _bin;
   static const int BIN = 1;
-  String str;
+  String _str;
   static const int STR = 2;
 
 
   bin_method_args() {
   }
 
-  @deprecated
-  bool isSetBin() => bin != null;
+  Uint8List get bin => this._bin;
+
+  set bin(Uint8List bin) {
+    this._bin = bin;
+  }
 
   @deprecated
-  unsetBin() => bin = null;
+  bool isSetBin() => _bin != null;
 
   @deprecated
-  bool isSetStr() => str != null;
+  unsetBin() => this._bin = null;
+
+  String get str => this._str;
+
+  set str(String str) {
+    this._str = str;
+  }
 
   @deprecated
-  unsetStr() => str = null;
+  bool isSetStr() => _str != null;
+
+  @deprecated
+  unsetStr() => this._str = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -1379,11 +1439,11 @@ class bin_method_args implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case BIN:
-        bin = value as Uint8List; // ignore: avoid_as
+        _bin = value as Uint8List; // ignore: avoid_as
         break;
 
       case STR:
-        str = value as String; // ignore: avoid_as
+        _str = value as String; // ignore: avoid_as
         break;
 
       default:
@@ -1396,10 +1456,10 @@ class bin_method_args implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case BIN:
-        return bin != null;
+        return _bin != null;
 
       case STR:
-        return str != null;
+        return _str != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -1516,26 +1576,38 @@ class bin_method_result implements thrift.TBase {
   static final thrift.TField _SUCCESS_FIELD_DESC = new thrift.TField("success", thrift.TType.STRING, 0);
   static final thrift.TField _API_FIELD_DESC = new thrift.TField("api", thrift.TType.STRUCT, 1);
 
-  Uint8List success;
+  Uint8List _success;
   static const int SUCCESS = 0;
-  t_actual_base_dart.api_exception api;
+  t_actual_base_dart.api_exception _api;
   static const int API = 1;
 
 
   bin_method_result() {
   }
 
-  @deprecated
-  bool isSetSuccess() => success != null;
+  Uint8List get success => this._success;
+
+  set success(Uint8List success) {
+    this._success = success;
+  }
 
   @deprecated
-  unsetSuccess() => success = null;
+  bool isSetSuccess() => _success != null;
 
   @deprecated
-  bool isSetApi() => api != null;
+  unsetSuccess() => this._success = null;
+
+  t_actual_base_dart.api_exception get api => this._api;
+
+  set api(t_actual_base_dart.api_exception api) {
+    this._api = api;
+  }
 
   @deprecated
-  unsetApi() => api = null;
+  bool isSetApi() => _api != null;
+
+  @deprecated
+  unsetApi() => this._api = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -1553,11 +1625,11 @@ class bin_method_result implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case SUCCESS:
-        success = value as Uint8List; // ignore: avoid_as
+        _success = value as Uint8List; // ignore: avoid_as
         break;
 
       case API:
-        api = value as t_actual_base_dart.api_exception; // ignore: avoid_as
+        _api = value as t_actual_base_dart.api_exception; // ignore: avoid_as
         break;
 
       default:
@@ -1570,10 +1642,10 @@ class bin_method_result implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case SUCCESS:
-        return success != null;
+        return _success != null;
 
       case API:
-        return api != null;
+        return _api != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -1696,34 +1768,52 @@ class param_modifiers_args implements thrift.TBase {
   static final thrift.TField _DEFAULT_NUM_FIELD_DESC = new thrift.TField("default_num", thrift.TType.I32, 2);
   static final thrift.TField _REQ_NUM_FIELD_DESC = new thrift.TField("req_num", thrift.TType.I32, 3);
 
-  int opt_num = 0;
+  int _opt_num = 0;
   static const int OPT_NUM = 1;
-  int default_num = 0;
+  int _default_num = 0;
   static const int DEFAULT_NUM = 2;
-  int req_num = 0;
+  int _req_num = 0;
   static const int REQ_NUM = 3;
 
 
   param_modifiers_args() {
   }
 
-  @deprecated
-  bool isSetOpt_num() => opt_num != null;
+  int get opt_num => this._opt_num;
+
+  set opt_num(int opt_num) {
+    this._opt_num = opt_num;
+  }
 
   @deprecated
-  unsetOpt_num() => opt_num = null;
+  bool isSetOpt_num() => _opt_num != null;
 
   @deprecated
-  bool isSetDefault_num() => default_num != null;
+  unsetOpt_num() => this._opt_num = null;
+
+  int get default_num => this._default_num;
+
+  set default_num(int default_num) {
+    this._default_num = default_num;
+  }
 
   @deprecated
-  unsetDefault_num() => default_num = null;
+  bool isSetDefault_num() => _default_num != null;
 
   @deprecated
-  bool isSetReq_num() => req_num != null;
+  unsetDefault_num() => this._default_num = null;
+
+  int get req_num => this._req_num;
+
+  set req_num(int req_num) {
+    this._req_num = req_num;
+  }
 
   @deprecated
-  unsetReq_num() => req_num = null;
+  bool isSetReq_num() => _req_num != null;
+
+  @deprecated
+  unsetReq_num() => this._req_num = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -1743,15 +1833,15 @@ class param_modifiers_args implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case OPT_NUM:
-        opt_num = value as int; // ignore: avoid_as
+        _opt_num = value as int; // ignore: avoid_as
         break;
 
       case DEFAULT_NUM:
-        default_num = value as int; // ignore: avoid_as
+        _default_num = value as int; // ignore: avoid_as
         break;
 
       case REQ_NUM:
-        req_num = value as int; // ignore: avoid_as
+        _req_num = value as int; // ignore: avoid_as
         break;
 
       default:
@@ -1764,13 +1854,13 @@ class param_modifiers_args implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case OPT_NUM:
-        return opt_num != null;
+        return _opt_num != null;
 
       case DEFAULT_NUM:
-        return default_num != null;
+        return _default_num != null;
 
       case REQ_NUM:
-        return req_num != null;
+        return _req_num != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -1897,18 +1987,24 @@ class param_modifiers_result implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("param_modifiers_result");
   static final thrift.TField _SUCCESS_FIELD_DESC = new thrift.TField("success", thrift.TType.I64, 0);
 
-  int success;
+  int _success;
   static const int SUCCESS = 0;
 
 
   param_modifiers_result() {
   }
 
-  @deprecated
-  bool isSetSuccess() => success != null;
+  int get success => this._success;
+
+  set success(int success) {
+    this._success = success;
+  }
 
   @deprecated
-  unsetSuccess() => success = null;
+  bool isSetSuccess() => _success != null;
+
+  @deprecated
+  unsetSuccess() => this._success = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -1924,7 +2020,7 @@ class param_modifiers_result implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case SUCCESS:
-        success = value as int; // ignore: avoid_as
+        _success = value as int; // ignore: avoid_as
         break;
 
       default:
@@ -1937,7 +2033,7 @@ class param_modifiers_result implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case SUCCESS:
-        return success != null;
+        return _success != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -2028,26 +2124,38 @@ class underlying_types_test_args implements thrift.TBase {
   static final thrift.TField _LIST_TYPE_FIELD_DESC = new thrift.TField("list_type", thrift.TType.LIST, 1);
   static final thrift.TField _SET_TYPE_FIELD_DESC = new thrift.TField("set_type", thrift.TType.SET, 2);
 
-  List<int> list_type;
+  List<int> _list_type;
   static const int LIST_TYPE = 1;
-  Set<int> set_type;
+  Set<int> _set_type;
   static const int SET_TYPE = 2;
 
 
   underlying_types_test_args() {
   }
 
-  @deprecated
-  bool isSetList_type() => list_type != null;
+  List<int> get list_type => this._list_type;
+
+  set list_type(List<int> list_type) {
+    this._list_type = list_type;
+  }
 
   @deprecated
-  unsetList_type() => list_type = null;
+  bool isSetList_type() => _list_type != null;
 
   @deprecated
-  bool isSetSet_type() => set_type != null;
+  unsetList_type() => this._list_type = null;
+
+  Set<int> get set_type => this._set_type;
+
+  set set_type(Set<int> set_type) {
+    this._set_type = set_type;
+  }
 
   @deprecated
-  unsetSet_type() => set_type = null;
+  bool isSetSet_type() => _set_type != null;
+
+  @deprecated
+  unsetSet_type() => this._set_type = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -2065,11 +2173,11 @@ class underlying_types_test_args implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case LIST_TYPE:
-        list_type = value as List<int>; // ignore: avoid_as
+        _list_type = value as List<int>; // ignore: avoid_as
         break;
 
       case SET_TYPE:
-        set_type = value as Set<int>; // ignore: avoid_as
+        _set_type = value as Set<int>; // ignore: avoid_as
         break;
 
       default:
@@ -2082,10 +2190,10 @@ class underlying_types_test_args implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case LIST_TYPE:
-        return list_type != null;
+        return _list_type != null;
 
       case SET_TYPE:
-        return set_type != null;
+        return _set_type != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -2221,18 +2329,24 @@ class underlying_types_test_result implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("underlying_types_test_result");
   static final thrift.TField _SUCCESS_FIELD_DESC = new thrift.TField("success", thrift.TType.LIST, 0);
 
-  List<int> success;
+  List<int> _success;
   static const int SUCCESS = 0;
 
 
   underlying_types_test_result() {
   }
 
-  @deprecated
-  bool isSetSuccess() => success != null;
+  List<int> get success => this._success;
+
+  set success(List<int> success) {
+    this._success = success;
+  }
 
   @deprecated
-  unsetSuccess() => success = null;
+  bool isSetSuccess() => _success != null;
+
+  @deprecated
+  unsetSuccess() => this._success = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -2248,7 +2362,7 @@ class underlying_types_test_result implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case SUCCESS:
-        success = value as List<int>; // ignore: avoid_as
+        _success = value as List<int>; // ignore: avoid_as
         break;
 
       default:
@@ -2261,7 +2375,7 @@ class underlying_types_test_result implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case SUCCESS:
-        return success != null;
+        return _success != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -2452,18 +2566,24 @@ class getThing_result implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("getThing_result");
   static final thrift.TField _SUCCESS_FIELD_DESC = new thrift.TField("success", thrift.TType.STRUCT, 0);
 
-  t_validStructs.Thing success;
+  t_validStructs.Thing _success;
   static const int SUCCESS = 0;
 
 
   getThing_result() {
   }
 
-  @deprecated
-  bool isSetSuccess() => success != null;
+  t_validStructs.Thing get success => this._success;
+
+  set success(t_validStructs.Thing success) {
+    this._success = success;
+  }
 
   @deprecated
-  unsetSuccess() => success = null;
+  bool isSetSuccess() => _success != null;
+
+  @deprecated
+  unsetSuccess() => this._success = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -2479,7 +2599,7 @@ class getThing_result implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case SUCCESS:
-        success = value as t_validStructs.Thing; // ignore: avoid_as
+        _success = value as t_validStructs.Thing; // ignore: avoid_as
         break;
 
       default:
@@ -2492,7 +2612,7 @@ class getThing_result implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case SUCCESS:
-        return success != null;
+        return _success != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -2674,18 +2794,24 @@ class getMyInt_result implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("getMyInt_result");
   static final thrift.TField _SUCCESS_FIELD_DESC = new thrift.TField("success", thrift.TType.I32, 0);
 
-  int success;
+  int _success;
   static const int SUCCESS = 0;
 
 
   getMyInt_result() {
   }
 
-  @deprecated
-  bool isSetSuccess() => success != null;
+  int get success => this._success;
+
+  set success(int success) {
+    this._success = success;
+  }
 
   @deprecated
-  unsetSuccess() => success = null;
+  bool isSetSuccess() => _success != null;
+
+  @deprecated
+  unsetSuccess() => this._success = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -2701,7 +2827,7 @@ class getMyInt_result implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case SUCCESS:
-        success = value as int; // ignore: avoid_as
+        _success = value as int; // ignore: avoid_as
         break;
 
       default:
@@ -2714,7 +2840,7 @@ class getMyInt_result implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case SUCCESS:
-        return success != null;
+        return _success != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -2804,18 +2930,24 @@ class use_subdir_struct_args implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("use_subdir_struct_args");
   static final thrift.TField _A_FIELD_DESC = new thrift.TField("a", thrift.TType.STRUCT, 1);
 
-  t_subdir_include_ns.A a;
+  t_subdir_include_ns.A _a;
   static const int A = 1;
 
 
   use_subdir_struct_args() {
   }
 
-  @deprecated
-  bool isSetA() => a != null;
+  t_subdir_include_ns.A get a => this._a;
+
+  set a(t_subdir_include_ns.A a) {
+    this._a = a;
+  }
 
   @deprecated
-  unsetA() => a = null;
+  bool isSetA() => _a != null;
+
+  @deprecated
+  unsetA() => this._a = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -2831,7 +2963,7 @@ class use_subdir_struct_args implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case A:
-        a = value as t_subdir_include_ns.A; // ignore: avoid_as
+        _a = value as t_subdir_include_ns.A; // ignore: avoid_as
         break;
 
       default:
@@ -2844,7 +2976,7 @@ class use_subdir_struct_args implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case A:
-        return a != null;
+        return _a != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -2937,18 +3069,24 @@ class use_subdir_struct_result implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("use_subdir_struct_result");
   static final thrift.TField _SUCCESS_FIELD_DESC = new thrift.TField("success", thrift.TType.STRUCT, 0);
 
-  t_subdir_include_ns.A success;
+  t_subdir_include_ns.A _success;
   static const int SUCCESS = 0;
 
 
   use_subdir_struct_result() {
   }
 
-  @deprecated
-  bool isSetSuccess() => success != null;
+  t_subdir_include_ns.A get success => this._success;
+
+  set success(t_subdir_include_ns.A success) {
+    this._success = success;
+  }
 
   @deprecated
-  unsetSuccess() => success = null;
+  bool isSetSuccess() => _success != null;
+
+  @deprecated
+  unsetSuccess() => this._success = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -2964,7 +3102,7 @@ class use_subdir_struct_result implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case SUCCESS:
-        success = value as t_subdir_include_ns.A; // ignore: avoid_as
+        _success = value as t_subdir_include_ns.A; // ignore: avoid_as
         break;
 
       default:
@@ -2977,7 +3115,7 @@ class use_subdir_struct_result implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case SUCCESS:
-        return success != null;
+        return _success != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -3072,18 +3210,24 @@ class sayHelloWith_args implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("sayHelloWith_args");
   static final thrift.TField _NEW_MESSAGE_FIELD_DESC = new thrift.TField("newMessage", thrift.TType.STRING, 1);
 
-  String newMessage;
+  String _newMessage;
   static const int NEWMESSAGE = 1;
 
 
   sayHelloWith_args() {
   }
 
-  @deprecated
-  bool isSetNewMessage() => newMessage != null;
+  String get newMessage => this._newMessage;
+
+  set newMessage(String newMessage) {
+    this._newMessage = newMessage;
+  }
 
   @deprecated
-  unsetNewMessage() => newMessage = null;
+  bool isSetNewMessage() => _newMessage != null;
+
+  @deprecated
+  unsetNewMessage() => this._newMessage = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -3099,7 +3243,7 @@ class sayHelloWith_args implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case NEWMESSAGE:
-        newMessage = value as String; // ignore: avoid_as
+        _newMessage = value as String; // ignore: avoid_as
         break;
 
       default:
@@ -3112,7 +3256,7 @@ class sayHelloWith_args implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case NEWMESSAGE:
-        return newMessage != null;
+        return _newMessage != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -3204,18 +3348,24 @@ class sayHelloWith_result implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("sayHelloWith_result");
   static final thrift.TField _SUCCESS_FIELD_DESC = new thrift.TField("success", thrift.TType.STRING, 0);
 
-  String success;
+  String _success;
   static const int SUCCESS = 0;
 
 
   sayHelloWith_result() {
   }
 
-  @deprecated
-  bool isSetSuccess() => success != null;
+  String get success => this._success;
+
+  set success(String success) {
+    this._success = success;
+  }
 
   @deprecated
-  unsetSuccess() => success = null;
+  bool isSetSuccess() => _success != null;
+
+  @deprecated
+  unsetSuccess() => this._success = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -3231,7 +3381,7 @@ class sayHelloWith_result implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case SUCCESS:
-        success = value as String; // ignore: avoid_as
+        _success = value as String; // ignore: avoid_as
         break;
 
       default:
@@ -3244,7 +3394,7 @@ class sayHelloWith_result implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case SUCCESS:
-        return success != null;
+        return _success != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -3338,18 +3488,24 @@ class whatDoYouSay_args implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("whatDoYouSay_args");
   static final thrift.TField _MESSAGE_ARGS_FIELD_DESC = new thrift.TField("messageArgs", thrift.TType.STRING, 1);
 
-  String messageArgs;
+  String _messageArgs;
   static const int MESSAGEARGS = 1;
 
 
   whatDoYouSay_args() {
   }
 
-  @deprecated
-  bool isSetMessageArgs() => messageArgs != null;
+  String get messageArgs => this._messageArgs;
+
+  set messageArgs(String messageArgs) {
+    this._messageArgs = messageArgs;
+  }
 
   @deprecated
-  unsetMessageArgs() => messageArgs = null;
+  bool isSetMessageArgs() => _messageArgs != null;
+
+  @deprecated
+  unsetMessageArgs() => this._messageArgs = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -3365,7 +3521,7 @@ class whatDoYouSay_args implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case MESSAGEARGS:
-        messageArgs = value as String; // ignore: avoid_as
+        _messageArgs = value as String; // ignore: avoid_as
         break;
 
       default:
@@ -3378,7 +3534,7 @@ class whatDoYouSay_args implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case MESSAGEARGS:
-        return messageArgs != null;
+        return _messageArgs != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -3470,18 +3626,24 @@ class whatDoYouSay_result implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("whatDoYouSay_result");
   static final thrift.TField _SUCCESS_FIELD_DESC = new thrift.TField("success", thrift.TType.STRING, 0);
 
-  String success;
+  String _success;
   static const int SUCCESS = 0;
 
 
   whatDoYouSay_result() {
   }
 
-  @deprecated
-  bool isSetSuccess() => success != null;
+  String get success => this._success;
+
+  set success(String success) {
+    this._success = success;
+  }
 
   @deprecated
-  unsetSuccess() => success = null;
+  bool isSetSuccess() => _success != null;
+
+  @deprecated
+  unsetSuccess() => this._success = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -3497,7 +3659,7 @@ class whatDoYouSay_result implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case SUCCESS:
-        success = value as String; // ignore: avoid_as
+        _success = value as String; // ignore: avoid_as
         break;
 
       default:
@@ -3510,7 +3672,7 @@ class whatDoYouSay_result implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case SUCCESS:
-        return success != null;
+        return _success != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -3604,18 +3766,24 @@ class sayAgain_args implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("sayAgain_args");
   static final thrift.TField _MESSAGE_RESULT_FIELD_DESC = new thrift.TField("messageResult", thrift.TType.STRING, 1);
 
-  String messageResult;
+  String _messageResult;
   static const int MESSAGERESULT = 1;
 
 
   sayAgain_args() {
   }
 
-  @deprecated
-  bool isSetMessageResult() => messageResult != null;
+  String get messageResult => this._messageResult;
+
+  set messageResult(String messageResult) {
+    this._messageResult = messageResult;
+  }
 
   @deprecated
-  unsetMessageResult() => messageResult = null;
+  bool isSetMessageResult() => _messageResult != null;
+
+  @deprecated
+  unsetMessageResult() => this._messageResult = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -3631,7 +3799,7 @@ class sayAgain_args implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case MESSAGERESULT:
-        messageResult = value as String; // ignore: avoid_as
+        _messageResult = value as String; // ignore: avoid_as
         break;
 
       default:
@@ -3644,7 +3812,7 @@ class sayAgain_args implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case MESSAGERESULT:
-        return messageResult != null;
+        return _messageResult != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
@@ -3736,18 +3904,24 @@ class sayAgain_result implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("sayAgain_result");
   static final thrift.TField _SUCCESS_FIELD_DESC = new thrift.TField("success", thrift.TType.STRING, 0);
 
-  String success;
+  String _success;
   static const int SUCCESS = 0;
 
 
   sayAgain_result() {
   }
 
-  @deprecated
-  bool isSetSuccess() => success != null;
+  String get success => this._success;
+
+  set success(String success) {
+    this._success = success;
+  }
 
   @deprecated
-  unsetSuccess() => success = null;
+  bool isSetSuccess() => _success != null;
+
+  @deprecated
+  unsetSuccess() => this._success = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -3763,7 +3937,7 @@ class sayAgain_result implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case SUCCESS:
-        success = value as String; // ignore: avoid_as
+        _success = value as String; // ignore: avoid_as
         break;
 
       default:
@@ -3776,7 +3950,7 @@ class sayAgain_result implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case SUCCESS:
-        return success != null;
+        return _success != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/test/expected/dart/variety/f_test_base.dart
+++ b/test/expected/dart/variety/f_test_base.dart
@@ -14,18 +14,24 @@ class TestBase implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("TestBase");
   static final thrift.TField _BASE_STRUCT_FIELD_DESC = new thrift.TField("base_struct", thrift.TType.STRUCT, 1);
 
-  t_actual_base_dart.thing base_struct;
+  t_actual_base_dart.thing _base_struct;
   static const int BASE_STRUCT = 1;
 
 
   TestBase() {
   }
 
-  @deprecated
-  bool isSetBase_struct() => base_struct != null;
+  t_actual_base_dart.thing get base_struct => this._base_struct;
+
+  set base_struct(t_actual_base_dart.thing base_struct) {
+    this._base_struct = base_struct;
+  }
 
   @deprecated
-  unsetBase_struct() => base_struct = null;
+  bool isSetBase_struct() => _base_struct != null;
+
+  @deprecated
+  unsetBase_struct() => this._base_struct = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -41,7 +47,7 @@ class TestBase implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case BASE_STRUCT:
-        base_struct = value as t_actual_base_dart.thing; // ignore: avoid_as
+        _base_struct = value as t_actual_base_dart.thing; // ignore: avoid_as
         break;
 
       default:
@@ -54,7 +60,7 @@ class TestBase implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case BASE_STRUCT:
-        return base_struct != null;
+        return _base_struct != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/test/expected/dart/variety/f_test_lowercase.dart
+++ b/test/expected/dart/variety/f_test_lowercase.dart
@@ -14,18 +14,24 @@ class TestLowercase implements thrift.TBase {
   static final thrift.TStruct _STRUCT_DESC = new thrift.TStruct("TestLowercase");
   static final thrift.TField _LOWERCASE_INT_FIELD_DESC = new thrift.TField("lowercaseInt", thrift.TType.I32, 1);
 
-  int lowercaseInt = 0;
+  int _lowercaseInt = 0;
   static const int LOWERCASEINT = 1;
 
 
   TestLowercase() {
   }
 
-  @deprecated
-  bool isSetLowercaseInt() => lowercaseInt != null;
+  int get lowercaseInt => this._lowercaseInt;
+
+  set lowercaseInt(int lowercaseInt) {
+    this._lowercaseInt = lowercaseInt;
+  }
 
   @deprecated
-  unsetLowercaseInt() => lowercaseInt = null;
+  bool isSetLowercaseInt() => _lowercaseInt != null;
+
+  @deprecated
+  unsetLowercaseInt() => this._lowercaseInt = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -41,7 +47,7 @@ class TestLowercase implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case LOWERCASEINT:
-        lowercaseInt = value as int; // ignore: avoid_as
+        _lowercaseInt = value as int; // ignore: avoid_as
         break;
 
       default:
@@ -54,7 +60,7 @@ class TestLowercase implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case LOWERCASEINT:
-        return lowercaseInt != null;
+        return _lowercaseInt != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/test/expected/dart/variety/f_testing_defaults.dart
+++ b/test/expected/dart/variety/f_testing_defaults.dart
@@ -31,192 +31,262 @@ class TestingDefaults implements thrift.TBase {
   static final thrift.TField _STATUS_FIELD_DESC = new thrift.TField("status", thrift.TType.I32, 17);
   static final thrift.TField _BASE_STATUS_FIELD_DESC = new thrift.TField("base_status", thrift.TType.I32, 18);
 
-  int iD2;
+  int _iD2;
   static const int ID2 = 1;
-  t_variety.Event ev1;
+  t_variety.Event _ev1;
   static const int EV1 = 2;
-  t_variety.Event ev2;
+  t_variety.Event _ev2;
   static const int EV2 = 3;
-  int iD = 0;
+  int _iD = 0;
   static const int ID = 4;
-  String thing;
+  String _thing;
   static const int THING = 5;
-  String thing2;
+  String _thing2;
   static const int THING2 = 6;
-  List<int> listfield;
+  List<int> _listfield;
   static const int LISTFIELD = 7;
-  int iD3 = 0;
+  int _iD3 = 0;
   static const int ID3 = 8;
-  Uint8List bin_field;
+  Uint8List _bin_field;
   static const int BIN_FIELD = 9;
-  Uint8List bin_field2;
+  Uint8List _bin_field2;
   static const int BIN_FIELD2 = 10;
-  Uint8List bin_field3;
+  Uint8List _bin_field3;
   static const int BIN_FIELD3 = 11;
-  Uint8List bin_field4;
+  Uint8List _bin_field4;
   static const int BIN_FIELD4 = 12;
-  List<int> list2;
+  List<int> _list2;
   static const int LIST2 = 13;
-  List<int> list3;
+  List<int> _list3;
   static const int LIST3 = 14;
-  List<int> list4;
+  List<int> _list4;
   static const int LIST4 = 15;
-  Map<String, String> a_map;
+  Map<String, String> _a_map;
   static const int A_MAP = 16;
-  int status;
+  int _status;
   static const int STATUS = 17;
-  int base_status;
+  int _base_status;
   static const int BASE_STATUS = 18;
 
 
   TestingDefaults() {
-    this.iD2 = t_variety.VarietyConstants.DEFAULT_ID;
-    this.ev1 = new t_variety.Event()
-      ..iD = t_variety.VarietyConstants.DEFAULT_ID
-      ..message = "a message";
-    this.ev2 = new t_variety.Event()
-      ..iD = 5
-      ..message = "a message2";
-    this.iD = -2;
-    this.thing = "a constant";
-    this.thing2 = "another constant";
-    this.listfield = [
-      1,
-      2,
-      3,
-      4,
-      5,
-    ];
-    this.iD3 = t_variety.VarietyConstants.other_default;
-    this.bin_field4 = t_variety.VarietyConstants.bin_const;
-    this.list2 = [
-      1,
-      3,
-      4,
-      5,
-      8,
-    ];
-    this.list4 = [
-      1,
-      2,
-      3,
-      6,
-    ];
-    this.a_map = {
-      "k1": "v1",
-      "k2": "v2",
-    };
-    this.status = t_variety.HealthCondition.PASS;
-    this.base_status = t_actual_base_dart.base_health_condition.FAIL;
+  }
+
+  int get iD2 => this._iD2 ?? t_variety.VarietyConstants.DEFAULT_ID;
+
+  set iD2(int iD2) {
+    this._iD2 = iD2;
   }
 
   @deprecated
-  bool isSetID2() => iD2 != null && iD2 != t_variety.VarietyConstants.DEFAULT_ID;
+  bool isSetID2() => _iD2 != null;
 
   @deprecated
-  unsetID2() => iD2 = null;
+  unsetID2() => this._iD2 = null;
+
+  t_variety.Event get ev1 => this._ev1;
+
+  set ev1(t_variety.Event ev1) {
+    this._ev1 = ev1;
+  }
 
   @deprecated
-  bool isSetEv1() => ev1 != null;
+  bool isSetEv1() => _ev1 != null;
 
   @deprecated
-  unsetEv1() => ev1 = null;
+  unsetEv1() => this._ev1 = null;
+
+  t_variety.Event get ev2 => this._ev2;
+
+  set ev2(t_variety.Event ev2) {
+    this._ev2 = ev2;
+  }
 
   @deprecated
-  bool isSetEv2() => ev2 != null;
+  bool isSetEv2() => _ev2 != null;
 
   @deprecated
-  unsetEv2() => ev2 = null;
+  unsetEv2() => this._ev2 = null;
+
+  int get iD => this._iD ?? -2;
+
+  set iD(int iD) {
+    this._iD = iD;
+  }
 
   @deprecated
-  bool isSetID() => iD != null && iD != -2;
+  bool isSetID() => _iD != null;
 
   @deprecated
-  unsetID() => iD = null;
+  unsetID() => this._iD = null;
+
+  String get thing => this._thing;
+
+  set thing(String thing) {
+    this._thing = thing;
+  }
 
   @deprecated
-  bool isSetThing() => thing != null;
+  bool isSetThing() => _thing != null;
 
   @deprecated
-  unsetThing() => thing = null;
+  unsetThing() => this._thing = null;
+
+  String get thing2 => this._thing2;
+
+  set thing2(String thing2) {
+    this._thing2 = thing2;
+  }
 
   @deprecated
-  bool isSetThing2() => thing2 != null;
+  bool isSetThing2() => _thing2 != null;
 
   @deprecated
-  unsetThing2() => thing2 = null;
+  unsetThing2() => this._thing2 = null;
+
+  List<int> get listfield => this._listfield;
+
+  set listfield(List<int> listfield) {
+    this._listfield = listfield;
+  }
 
   @deprecated
-  bool isSetListfield() => listfield != null;
+  bool isSetListfield() => _listfield != null;
 
   @deprecated
-  unsetListfield() => listfield = null;
+  unsetListfield() => this._listfield = null;
+
+  int get iD3 => this._iD3 ?? t_variety.VarietyConstants.other_default;
+
+  set iD3(int iD3) {
+    this._iD3 = iD3;
+  }
 
   @deprecated
-  bool isSetID3() => iD3 != null && iD3 != t_variety.VarietyConstants.other_default;
+  bool isSetID3() => _iD3 != null;
 
   @deprecated
-  unsetID3() => iD3 = null;
+  unsetID3() => this._iD3 = null;
+
+  Uint8List get bin_field => this._bin_field;
+
+  set bin_field(Uint8List bin_field) {
+    this._bin_field = bin_field;
+  }
 
   @deprecated
-  bool isSetBin_field() => bin_field != null;
+  bool isSetBin_field() => _bin_field != null;
 
   @deprecated
-  unsetBin_field() => bin_field = null;
+  unsetBin_field() => this._bin_field = null;
+
+  Uint8List get bin_field2 => this._bin_field2;
+
+  set bin_field2(Uint8List bin_field2) {
+    this._bin_field2 = bin_field2;
+  }
 
   @deprecated
-  bool isSetBin_field2() => bin_field2 != null;
+  bool isSetBin_field2() => _bin_field2 != null;
 
   @deprecated
-  unsetBin_field2() => bin_field2 = null;
+  unsetBin_field2() => this._bin_field2 = null;
+
+  Uint8List get bin_field3 => this._bin_field3;
+
+  set bin_field3(Uint8List bin_field3) {
+    this._bin_field3 = bin_field3;
+  }
 
   @deprecated
-  bool isSetBin_field3() => bin_field3 != null;
+  bool isSetBin_field3() => _bin_field3 != null;
 
   @deprecated
-  unsetBin_field3() => bin_field3 = null;
+  unsetBin_field3() => this._bin_field3 = null;
+
+  Uint8List get bin_field4 => this._bin_field4;
+
+  set bin_field4(Uint8List bin_field4) {
+    this._bin_field4 = bin_field4;
+  }
 
   @deprecated
-  bool isSetBin_field4() => bin_field4 != null;
+  bool isSetBin_field4() => _bin_field4 != null;
 
   @deprecated
-  unsetBin_field4() => bin_field4 = null;
+  unsetBin_field4() => this._bin_field4 = null;
+
+  List<int> get list2 => this._list2;
+
+  set list2(List<int> list2) {
+    this._list2 = list2;
+  }
 
   @deprecated
-  bool isSetList2() => list2 != null;
+  bool isSetList2() => _list2 != null;
 
   @deprecated
-  unsetList2() => list2 = null;
+  unsetList2() => this._list2 = null;
+
+  List<int> get list3 => this._list3;
+
+  set list3(List<int> list3) {
+    this._list3 = list3;
+  }
 
   @deprecated
-  bool isSetList3() => list3 != null;
+  bool isSetList3() => _list3 != null;
 
   @deprecated
-  unsetList3() => list3 = null;
+  unsetList3() => this._list3 = null;
+
+  List<int> get list4 => this._list4;
+
+  set list4(List<int> list4) {
+    this._list4 = list4;
+  }
 
   @deprecated
-  bool isSetList4() => list4 != null;
+  bool isSetList4() => _list4 != null;
 
   @deprecated
-  unsetList4() => list4 = null;
+  unsetList4() => this._list4 = null;
+
+  Map<String, String> get a_map => this._a_map;
+
+  set a_map(Map<String, String> a_map) {
+    this._a_map = a_map;
+  }
 
   @deprecated
-  bool isSetA_map() => a_map != null;
+  bool isSetA_map() => _a_map != null;
 
   @deprecated
-  unsetA_map() => a_map = null;
+  unsetA_map() => this._a_map = null;
+
+  int get status => this._status ?? t_variety.HealthCondition.PASS;
+
+  set status(int status) {
+    this._status = status;
+  }
 
   @deprecated
-  bool isSetStatus() => status != null && status != t_variety.HealthCondition.PASS;
+  bool isSetStatus() => _status != null;
 
   @deprecated
-  unsetStatus() => status = null;
+  unsetStatus() => this._status = null;
+
+  int get base_status => this._base_status ?? t_actual_base_dart.base_health_condition.FAIL;
+
+  set base_status(int base_status) {
+    this._base_status = base_status;
+  }
 
   @deprecated
-  bool isSetBase_status() => base_status != null && base_status != t_actual_base_dart.base_health_condition.FAIL;
+  bool isSetBase_status() => _base_status != null;
 
   @deprecated
-  unsetBase_status() => base_status = null;
+  unsetBase_status() => this._base_status = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -266,75 +336,75 @@ class TestingDefaults implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case ID2:
-        iD2 = value as int; // ignore: avoid_as
+        _iD2 = value as int; // ignore: avoid_as
         break;
 
       case EV1:
-        ev1 = value as t_variety.Event; // ignore: avoid_as
+        _ev1 = value as t_variety.Event; // ignore: avoid_as
         break;
 
       case EV2:
-        ev2 = value as t_variety.Event; // ignore: avoid_as
+        _ev2 = value as t_variety.Event; // ignore: avoid_as
         break;
 
       case ID:
-        iD = value as int; // ignore: avoid_as
+        _iD = value as int; // ignore: avoid_as
         break;
 
       case THING:
-        thing = value as String; // ignore: avoid_as
+        _thing = value as String; // ignore: avoid_as
         break;
 
       case THING2:
-        thing2 = value as String; // ignore: avoid_as
+        _thing2 = value as String; // ignore: avoid_as
         break;
 
       case LISTFIELD:
-        listfield = value as List<int>; // ignore: avoid_as
+        _listfield = value as List<int>; // ignore: avoid_as
         break;
 
       case ID3:
-        iD3 = value as int; // ignore: avoid_as
+        _iD3 = value as int; // ignore: avoid_as
         break;
 
       case BIN_FIELD:
-        bin_field = value as Uint8List; // ignore: avoid_as
+        _bin_field = value as Uint8List; // ignore: avoid_as
         break;
 
       case BIN_FIELD2:
-        bin_field2 = value as Uint8List; // ignore: avoid_as
+        _bin_field2 = value as Uint8List; // ignore: avoid_as
         break;
 
       case BIN_FIELD3:
-        bin_field3 = value as Uint8List; // ignore: avoid_as
+        _bin_field3 = value as Uint8List; // ignore: avoid_as
         break;
 
       case BIN_FIELD4:
-        bin_field4 = value as Uint8List; // ignore: avoid_as
+        _bin_field4 = value as Uint8List; // ignore: avoid_as
         break;
 
       case LIST2:
-        list2 = value as List<int>; // ignore: avoid_as
+        _list2 = value as List<int>; // ignore: avoid_as
         break;
 
       case LIST3:
-        list3 = value as List<int>; // ignore: avoid_as
+        _list3 = value as List<int>; // ignore: avoid_as
         break;
 
       case LIST4:
-        list4 = value as List<int>; // ignore: avoid_as
+        _list4 = value as List<int>; // ignore: avoid_as
         break;
 
       case A_MAP:
-        a_map = value as Map<String, String>; // ignore: avoid_as
+        _a_map = value as Map<String, String>; // ignore: avoid_as
         break;
 
       case STATUS:
-        status = value as int; // ignore: avoid_as
+        _status = value as int; // ignore: avoid_as
         break;
 
       case BASE_STATUS:
-        base_status = value as int; // ignore: avoid_as
+        _base_status = value as int; // ignore: avoid_as
         break;
 
       default:
@@ -347,58 +417,58 @@ class TestingDefaults implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case ID2:
-        return iD2 != null && iD2 != t_variety.VarietyConstants.DEFAULT_ID;
+        return _iD2 != null;
 
       case EV1:
-        return ev1 != null;
+        return _ev1 != null;
 
       case EV2:
-        return ev2 != null;
+        return _ev2 != null;
 
       case ID:
-        return iD != null && iD != -2;
+        return _iD != null;
 
       case THING:
-        return thing != null;
+        return _thing != null;
 
       case THING2:
-        return thing2 != null;
+        return _thing2 != null;
 
       case LISTFIELD:
-        return listfield != null;
+        return _listfield != null;
 
       case ID3:
-        return iD3 != null && iD3 != t_variety.VarietyConstants.other_default;
+        return _iD3 != null;
 
       case BIN_FIELD:
-        return bin_field != null;
+        return _bin_field != null;
 
       case BIN_FIELD2:
-        return bin_field2 != null;
+        return _bin_field2 != null;
 
       case BIN_FIELD3:
-        return bin_field3 != null;
+        return _bin_field3 != null;
 
       case BIN_FIELD4:
-        return bin_field4 != null;
+        return _bin_field4 != null;
 
       case LIST2:
-        return list2 != null;
+        return _list2 != null;
 
       case LIST3:
-        return list3 != null;
+        return _list3 != null;
 
       case LIST4:
-        return list4 != null;
+        return _list4 != null;
 
       case A_MAP:
-        return a_map != null;
+        return _a_map != null;
 
       case STATUS:
-        return status != null && status != t_variety.HealthCondition.PASS;
+        return _status != null;
 
       case BASE_STATUS:
-        return base_status != null && base_status != t_actual_base_dart.base_health_condition.FAIL;
+        return _base_status != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");

--- a/test/expected/dart/variety/f_testing_unions.dart
+++ b/test/expected/dart/variety/f_testing_unions.dart
@@ -20,68 +20,110 @@ class TestingUnions implements thrift.TBase {
   static final thrift.TField _BIN_FIELD_IN_UNION_FIELD_DESC = new thrift.TField("bin_field_in_union", thrift.TType.STRING, 6);
   static final thrift.TField _DEPR_FIELD_DESC = new thrift.TField("depr", thrift.TType.BOOL, 7);
 
-  int anID;
+  int _anID;
   static const int ANID = 1;
-  String aString;
+  String _aString;
   static const int ASTRING = 2;
-  int someotherthing;
+  int _someotherthing;
   static const int SOMEOTHERTHING = 3;
-  int anInt16;
+  int _anInt16;
   static const int ANINT16 = 4;
-  Map<int, String> requests;
+  Map<int, String> _requests;
   static const int REQUESTS = 5;
-  Uint8List bin_field_in_union;
+  Uint8List _bin_field_in_union;
   static const int BIN_FIELD_IN_UNION = 6;
   /// Deprecated: use something else
   @deprecated
-  bool depr;
+  bool _depr;
   static const int DEPR = 7;
 
 
   TestingUnions() {
   }
 
-  @deprecated
-  bool isSetAnID() => anID != null;
+  int get anID => this._anID;
+
+  set anID(int anID) {
+    this._anID = anID;
+  }
 
   @deprecated
-  unsetAnID() => anID = null;
+  bool isSetAnID() => _anID != null;
 
   @deprecated
-  bool isSetAString() => aString != null;
+  unsetAnID() => this._anID = null;
+
+  String get aString => this._aString;
+
+  set aString(String aString) {
+    this._aString = aString;
+  }
 
   @deprecated
-  unsetAString() => aString = null;
+  bool isSetAString() => _aString != null;
 
   @deprecated
-  bool isSetSomeotherthing() => someotherthing != null;
+  unsetAString() => this._aString = null;
+
+  int get someotherthing => this._someotherthing;
+
+  set someotherthing(int someotherthing) {
+    this._someotherthing = someotherthing;
+  }
 
   @deprecated
-  unsetSomeotherthing() => someotherthing = null;
+  bool isSetSomeotherthing() => _someotherthing != null;
 
   @deprecated
-  bool isSetAnInt16() => anInt16 != null;
+  unsetSomeotherthing() => this._someotherthing = null;
+
+  int get anInt16 => this._anInt16;
+
+  set anInt16(int anInt16) {
+    this._anInt16 = anInt16;
+  }
 
   @deprecated
-  unsetAnInt16() => anInt16 = null;
+  bool isSetAnInt16() => _anInt16 != null;
 
   @deprecated
-  bool isSetRequests() => requests != null;
+  unsetAnInt16() => this._anInt16 = null;
+
+  Map<int, String> get requests => this._requests;
+
+  set requests(Map<int, String> requests) {
+    this._requests = requests;
+  }
 
   @deprecated
-  unsetRequests() => requests = null;
+  bool isSetRequests() => _requests != null;
 
   @deprecated
-  bool isSetBin_field_in_union() => bin_field_in_union != null;
+  unsetRequests() => this._requests = null;
+
+  Uint8List get bin_field_in_union => this._bin_field_in_union;
+
+  set bin_field_in_union(Uint8List bin_field_in_union) {
+    this._bin_field_in_union = bin_field_in_union;
+  }
 
   @deprecated
-  unsetBin_field_in_union() => bin_field_in_union = null;
+  bool isSetBin_field_in_union() => _bin_field_in_union != null;
 
   @deprecated
-  bool isSetDepr() => depr != null;
+  unsetBin_field_in_union() => this._bin_field_in_union = null;
+
+  bool get depr => this._depr;
+
+  set depr(bool depr) {
+    this._depr = depr;
+  }
 
   @deprecated
-  unsetDepr() => depr = null;
+  bool isSetDepr() => _depr != null;
+
+  @deprecated
+  unsetDepr() => this._depr = null;
 
   @override
   getFieldValue(int fieldID) {
@@ -110,31 +152,31 @@ class TestingUnions implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case ANID:
-        anID = value as int; // ignore: avoid_as
+        _anID = value as int; // ignore: avoid_as
         break;
 
       case ASTRING:
-        aString = value as String; // ignore: avoid_as
+        _aString = value as String; // ignore: avoid_as
         break;
 
       case SOMEOTHERTHING:
-        someotherthing = value as int; // ignore: avoid_as
+        _someotherthing = value as int; // ignore: avoid_as
         break;
 
       case ANINT16:
-        anInt16 = value as int; // ignore: avoid_as
+        _anInt16 = value as int; // ignore: avoid_as
         break;
 
       case REQUESTS:
-        requests = value as Map<int, String>; // ignore: avoid_as
+        _requests = value as Map<int, String>; // ignore: avoid_as
         break;
 
       case BIN_FIELD_IN_UNION:
-        bin_field_in_union = value as Uint8List; // ignore: avoid_as
+        _bin_field_in_union = value as Uint8List; // ignore: avoid_as
         break;
 
       case DEPR:
-        depr = value as bool; // ignore: avoid_as
+        _depr = value as bool; // ignore: avoid_as
         break;
 
       default:
@@ -147,26 +189,26 @@ class TestingUnions implements thrift.TBase {
   bool isSet(int fieldID) {
     switch (fieldID) {
       case ANID:
-        return anID != null;
+        return _anID != null;
 
       case ASTRING:
-        return aString != null;
+        return _aString != null;
 
       case SOMEOTHERTHING:
-        return someotherthing != null;
+        return _someotherthing != null;
 
       case ANINT16:
-        return anInt16 != null;
+        return _anInt16 != null;
 
       case REQUESTS:
-        return requests != null;
+        return _requests != null;
 
       case BIN_FIELD_IN_UNION:
-        return bin_field_in_union != null;
+        return _bin_field_in_union != null;
 
       case DEPR:
         // ignore: deprecated_member_use
-        return depr != null;
+        return _depr != null;
 
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");


### PR DESCRIPTION
### Story:
Currently `isset` seems to be wrong in generated dart code. 

Implements this here:
>Brett Kail [1:58 PM]
>with my proposal, `isSetSerializationVersion() -> serializationVersion != null` and `get serializationVersion() => serializationVersion ?? -1`

For more info see discussion here: https://workiva.slack.com/archives/CEFTREXT8/p1550518577001400

#### Reviewers:
@Workiva/product2