### PR TITLE
Allow setting the stop timeout for stopping a FNatsServer

### DIFF
--- a/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
@@ -45,7 +45,7 @@ public class FNatsServer implements FServer {
     private static final Logger LOGGER = LoggerFactory.getLogger(FNatsServer.class);
     public static final int DEFAULT_WORK_QUEUE_LEN = 64;
     public static final int DEFAULT_WATERMARK = 5000;
-    public static final int DEFAULT_STOP_TIMEOUT = 30;
+    public static final long DEFAULT_STOP_TIMEOUT_NS = TimeUnit.SECONDS.toNanos(30);
 
     private final Connection conn;
     private final FProcessor processor;
@@ -54,7 +54,7 @@ public class FNatsServer implements FServer {
     private final String[] subjects;
     private final String queue;
     private final long highWatermark;
-    private final long stopTimeout;
+    private final long stopTimeoutNS;
 
     private final CountDownLatch shutdownSignal = new CountDownLatch(1);
     private final ExecutorService executorService;
@@ -72,11 +72,11 @@ public class FNatsServer implements FServer {
      * @param subjects        NATS subjects to receive requests on
      * @param queue           NATS queue group to receive requests on
      * @param highWatermark   Milliseconds when high watermark logic is triggered
-     * @param stopTimeout Seconds to await current requests to finish when stopping server
+     * @param stopTimeoutNS Nanoseconds to await current requests to finish when stopping server
      * @param executorService Custom executor service for processing messages
      */
     private FNatsServer(Connection conn, FProcessor processor, FProtocolFactory protoFactory,
-          String[] subjects, String queue, long highWatermark, long stopTimeout,
+          String[] subjects, String queue, long highWatermark, long stopTimeoutNS,
           ExecutorService executorService) {
         this.conn = conn;
         this.processor = processor;
@@ -86,7 +86,7 @@ public class FNatsServer implements FServer {
         this.queue = queue;
         this.highWatermark = highWatermark;
         this.executorService = executorService;
-        this.stopTimeout = stopTimeout;
+        this.stopTimeoutNS = stopTimeoutNS;
     }
 
     /**
@@ -104,7 +104,7 @@ public class FNatsServer implements FServer {
         private int queueLength = DEFAULT_WORK_QUEUE_LEN;
         private long highWatermark = DEFAULT_WATERMARK;
         private ExecutorService executorService;
-        private long stopTimeout = DEFAULT_STOP_TIMEOUT;
+        private long stopTimeoutNS = DEFAULT_STOP_TIMEOUT_NS;
 
         /**
          * Creates a new Builder which creates FStatelessNatsServers that subscribe to the given NATS subjects.
@@ -195,14 +195,15 @@ public class FNatsServer implements FServer {
         }
 
         /**
-         * Controls how many seconds to attempt wait for existing tasks to complete when stopping
+         * Controls how long to attempt wait for existing tasks to complete when stopping
          * the server via {@link FNatsServer#stop()}.
          *
-         * @param stopTimeout duration in seconds
+         * @param timeout max duration to wait when stopping
+         * @param unit unit of time for timeout
          * @return Builder
          */
-        public Builder withStopTimeout(long stopTimeout) {
-            this.stopTimeout = stopTimeout;
+        public Builder withStopTimeout(long timeout, TimeUnit unit) {
+            this.stopTimeoutNS = unit.toNanos(timeout);
             return this;
         }
 
@@ -220,7 +221,7 @@ public class FNatsServer implements FServer {
                         new BlockingRejectedExecutionHandler());
             }
             return new FNatsServer(conn, processor, protoFactory, subjects, queue, highWatermark,
-                stopTimeout, executorService);
+                stopTimeoutNS, executorService);
         }
 
     }
@@ -268,7 +269,7 @@ public class FNatsServer implements FServer {
         // Attempt to perform an orderly shutdown of the worker pool by trying to complete any in-flight requests.
         executorService.shutdown();
         try {
-            if (!executorService.awaitTermination(this.stopTimeout, TimeUnit.SECONDS)) {
+            if (!executorService.awaitTermination(this.stopTimeoutNS, TimeUnit.NANOSECONDS)) {
                 executorService.shutdownNow();
             }
         } catch (InterruptedException e) {

--- a/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
@@ -66,7 +66,8 @@ public class FNatsServer implements FServer {
      * length. If the queue fills up, newly received requests will block to be placed on the queue. If requests wait for
      * too long based on the high watermark, the server will log that it is backed up. Clients must connect with the
      * FNatsTransport.
-     *  @param conn            NATS connection
+     *
+     * @param conn            NATS connection
      * @param processor       FProcessor used to process requests
      * @param protoFactory    FProtocolFactory used for input and output protocols
      * @param subjects        NATS subjects to receive requests on

--- a/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
@@ -265,22 +265,10 @@ public class FNatsServer implements FServer {
      */
     @Override
     public void stop() throws TException {
-        stop(this.stopTimeout, TimeUnit.SECONDS);
-    }
-
-    /**
-     * Stops the server by shutting down the executor service processing tasks. Attempts to await
-     * existing tasks completing by up to the given timeout.
-     *
-     * @param timeout the maximum time to wait
-     * @param unit the time unit of the timeout argument
-     * @throws TException if the server fails to stop
-     */
-    public void stop(long timeout, TimeUnit unit) throws TException {
         // Attempt to perform an orderly shutdown of the worker pool by trying to complete any in-flight requests.
         executorService.shutdown();
         try {
-            if (!executorService.awaitTermination(timeout, unit)) {
+            if (!executorService.awaitTermination(this.stopTimeout, TimeUnit.SECONDS)) {
                 executorService.shutdownNow();
             }
         } catch (InterruptedException e) {

--- a/lib/java/src/test/java/com/workiva/frugal/server/FNatsServerTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/server/FNatsServerTest.java
@@ -115,7 +115,8 @@ public class FNatsServerTest {
             .build();
         server.stop();
         verify(mockExecutorService, times(1)).shutdown();
-        verify(mockExecutorService, times(1)).awaitTermination(30, TimeUnit.SECONDS);
+        verify(mockExecutorService, times(1))
+            .awaitTermination(FNatsServer.DEFAULT_STOP_TIMEOUT_NS, TimeUnit.NANOSECONDS);
     }
 
     @Test
@@ -124,11 +125,11 @@ public class FNatsServerTest {
         server = new FNatsServer.Builder(mockConn, mockProcessor, mockProtocolFactory, new String[]{subject})
             .withQueueGroup(queue)
             .withExecutorService(mockExecutorService)
-            .withStopTimeout(1)
+            .withStopTimeout(1, TimeUnit.SECONDS)
             .build();
         server.stop();
         verify(mockExecutorService, times(1)).shutdown();
-        verify(mockExecutorService, times(1)).awaitTermination(1, TimeUnit.SECONDS);
+        verify(mockExecutorService, times(1)).awaitTermination(TimeUnit.SECONDS.toNanos(1), TimeUnit.NANOSECONDS);
     }
 
     @Test

--- a/lib/java/src/test/java/com/workiva/frugal/server/FNatsServerTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/server/FNatsServerTest.java
@@ -132,18 +132,6 @@ public class FNatsServerTest {
     }
 
     @Test
-    public void testStopWithTimeout() throws Exception {
-        ExecutorService mockExecutorService = mock(ExecutorService.class);
-        server = new FNatsServer.Builder(mockConn, mockProcessor, mockProtocolFactory, new String[]{subject})
-            .withQueueGroup(queue)
-            .withExecutorService(mockExecutorService)
-            .build();
-        server.stop(1, TimeUnit.SECONDS);
-        verify(mockExecutorService, times(1)).shutdown();
-        verify(mockExecutorService, times(1)).awaitTermination(1, TimeUnit.SECONDS);
-    }
-
-    @Test
     public void testRequestHandler() throws InterruptedException  {
         ExecutorService executor = mock(ExecutorService.class);
         FNatsServer server =


### PR DESCRIPTION
### Story:
When stopping a FNatsServer, the stop method awaits the server's
configured executor service for up to a defined number of seconds.
This is to give the server time to finish processing current tasks.

This time use to be hard coded to 30 seconds. Different servers may
have different needs, however. Allowing callers to both configure
the stop timeout for the server or to specify a timeout while calling
stop will enable additional use cases where a timeout other than the
default is desired.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
Existing behavior should not change.

### How To Test:
Unit testing added.

### My Test Results:
Passed locally.

#### Reviewers:
@Workiva/product2