### PR TITLE
Wait for unsubscribes to finish before shutting down executor service.

### DIFF
--- a/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
@@ -273,14 +273,8 @@ public class FNatsServer implements FServer {
             }
             LOGGER.info("Frugal server stopping...");
 
-            for (String subject : subjects) {
-                try {
-                    dispatcher.unsubscribe(subject);
-                } catch (IllegalStateException e) {
-                    LOGGER.warn("Frugal server failed to unsubscribe from " + subject + ": " + e
-                          .getMessage());
-                }
-            }
+            // Closing the dispatcher will unsubscribe from all current subscriptions for that
+            // dispatcher
             conn.closeDispatcher(dispatcher);
             // If serving stopped due to stop being called, we want to give the signal the stop method
             // that this serve has completed its actions and the stop method can move on to the next

--- a/lib/java/src/test/java/com/workiva/frugal/server/FNatsServerTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/server/FNatsServerTest.java
@@ -102,7 +102,7 @@ public class FNatsServerTest {
         assertEquals(subject, subjectCaptor.getValue());
         assertEquals(queue, queueCaptor.getValue());
         assertNotNull(handlerCaptor.getValue());
-        verify(mockDispatcher).unsubscribe(subjectCaptor.capture());
+        verify(mockConn).closeDispatcher(mockDispatcher);
         assertEquals(subject, subjectCaptor.getValue());
     }
 


### PR DESCRIPTION
### Story:
Previously, if a stop signal came in, the executor service was shutdown
prior to unsubscribing to the nats messages for the server. This would
lead to nats messages still being delivered to the server despite that
the messages will never be executed / acted upon because the executor
service was shutdown.

This changes the stop / shutdown process to first wait for the
unsubscriptions to finish prior to shutting down the executor service.
Thus, no new messages should be received from the nats server while
this frugal server is shutting down.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
While it may be intended that people only call `serve` once and `stop` once on a FServer instance, I tried to design this so that if someone had a bug where they were calling these methods multiple times that this change should still work (blocking and not blocking the calls as before). An example of this is two serve calls executing in parallel where one of the threads is interrupted but not the other. As before, this change unsubscribes the interrupted server and closes its dispatcher before exiting the serve method. The other parallel serve method should remain unaffected.

### How To Test:
Added some unit tests to cover the existing behavior.

### My Test Results:
Unit testing passed locally.

#### Reviewers:
@Workiva/product2