### PR TITLE
Update jnats to 2.4.3

### DIFF
--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>io.nats</groupId>
             <artifactId>jnats</artifactId>
-            <version>2.4.2</version>
+            <version>2.4.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/test/integration/java/frugal-integration-test/pom.xml
+++ b/test/integration/java/frugal-integration-test/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>io.nats</groupId>
             <artifactId>jnats</artifactId>
-            <version>2.4.2</version>
+            <version>2.4.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
### Story:
https://github.com/nats-io/java-nats/releases/tag/2.4.3 is released which contains our fixes for reconnects.

#### Reviewers:
@Workiva/product2