### PR TITLE
java: Explicitly handle NoHttpResponseException

### DIFF
--- a/lib/java/src/main/java/com/workiva/frugal/transport/FHttpTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FHttpTransport.java
@@ -19,6 +19,7 @@ import com.workiva.frugal.exception.TTransportExceptionType;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
+import org.apache.http.NoHttpResponseException;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -262,6 +263,9 @@ public class FHttpTransport extends FTransport {
         } catch (SocketTimeoutException e) {
             throw new TTransportException(TTransportExceptionType.TIMED_OUT,
                     "http request socket timed out: " + e.getMessage(), e);
+        } catch (NoHttpResponseException e) {
+            throw new TTransportException(TTransportException.END_OF_FILE,
+                    "http request server closed: " + e.getMessage(), e);
         } catch (IOException e) {
             throw new TTransportException("http request failed: " + e.getMessage(), e);
         }


### PR DESCRIPTION
### Story:
For retry purposes, it would be helpful to have an explicit error code.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [x] Code has been tested and results documented
- [x] Unit tests have been updated
- [x] Updates to documentation if necessary
- [x] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
Apache HTTP client throws `NoHttpResponseException` when the server has closed the exception before sending any response, so `END_OF_FILE` felt most appropriate.

### How To Test:

### My Test Results:

#### Reviewers:
@Workiva/product2