### PR TITLE
CPLAT-5534: Cast inner types on returned futures

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1707,17 +1707,20 @@ func (g *Generator) generateClientMethod(service *parser.Service, method *parser
 
 	// Generate wrapper method
 	contents += tab + "@override\n"
-	contents += fmt.Sprintf(tab+"Future%s %s(frugal.FContext ctx%s) async {\n",
+	contents += fmt.Sprintf(tab+"Future%s %s(frugal.FContext ctx%s) {\n",
 		g.generateReturnArg(method), nameLower, g.generateInputArgs(method.Arguments))
 
 	if method.Annotations.IsDeprecated() {
 		contents += fmt.Sprintf(tabtab+"_frugalLog.warning(\"Call to deprecated function '%s.%s'\");\n", service.Name, nameLower)
 	}
 
-	returnType := g.generateReturnArg(method)
+	innerTypeCast := ""
+	if method.ReturnType != nil {
+	    innerTypeCast = fmt.Sprintf(".then((value) => value as %s)", g.getDartTypeFromThriftType(method.ReturnType))
+	}
 
-	contents += fmt.Sprintf(tabtab+"return new Future%s.value(await this._methods['%s']([ctx%s]));\n",
-		returnType, nameLower, g.generateInputArgsWithoutTypes(method.Arguments))
+	contents += fmt.Sprintf(tabtab+"return this._methods['%s']([ctx%s])%s;\n",
+		nameLower, g.generateInputArgsWithoutTypes(method.Arguments), innerTypeCast)
 
 	contents += fmt.Sprintf(tab + "}\n\n")
 

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1707,20 +1707,18 @@ func (g *Generator) generateClientMethod(service *parser.Service, method *parser
 
 	// Generate wrapper method
 	contents += tab + "@override\n"
-	contents += fmt.Sprintf(tab+"Future%s %s(frugal.FContext ctx%s) {\n",
+	contents += fmt.Sprintf(tab+"Future%s %s(frugal.FContext ctx%s) async {\n",
 		g.generateReturnArg(method), nameLower, g.generateInputArgs(method.Arguments))
 
 	if method.Annotations.IsDeprecated() {
 		contents += fmt.Sprintf(tabtab+"_frugalLog.warning(\"Call to deprecated function '%s.%s'\");\n", service.Name, nameLower)
 	}
 
-	typeCast := ""
-	if returnType := g.generateReturnArg(method); returnType != "" {
-		typeCast = fmt.Sprintf(" as Future%s", returnType)
-	}
+	returnType := g.generateReturnArg(method)
 
-	contents += fmt.Sprintf(tabtab+"return this._methods['%s']([ctx%s])%s;\n",
-		nameLower, g.generateInputArgsWithoutTypes(method.Arguments), typeCast)
+	contents += fmt.Sprintf(tabtab+"return new Future%s.value(await this._methods['%s']([ctx%s]));\n",
+		returnType, nameLower, g.generateInputArgsWithoutTypes(method.Arguments))
+
 	contents += fmt.Sprintf(tab + "}\n\n")
 
 	// Generate the calling method

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -44,7 +44,7 @@ class FStoreClient implements FStore {
 
   @override
   Future<t_v1_music.Album> buyAlbum(frugal.FContext ctx, String aSIN, String acct) {
-    return this._methods['buyAlbum']([ctx, aSIN, acct]) as Future<t_v1_music.Album>;
+    return new Future<t_v1_music.Album>.value(await this._methods['buyAlbum']([ctx, aSIN, acct]));
   }
 
   Future<t_v1_music.Album> _buyAlbum(frugal.FContext ctx, String aSIN, String acct) async {
@@ -91,7 +91,7 @@ class FStoreClient implements FStore {
   @override
   Future<bool> enterAlbumGiveaway(frugal.FContext ctx, String email, String name) {
     _frugalLog.warning("Call to deprecated function 'Store.enterAlbumGiveaway'");
-    return this._methods['enterAlbumGiveaway']([ctx, email, name]) as Future<bool>;
+    return new Future<bool>.value(await this._methods['enterAlbumGiveaway']([ctx, email, name]));
   }
 
   Future<bool> _enterAlbumGiveaway(frugal.FContext ctx, String email, String name) async {

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -44,7 +44,7 @@ class FStoreClient implements FStore {
 
   @override
   Future<t_v1_music.Album> buyAlbum(frugal.FContext ctx, String aSIN, String acct) {
-    return new Future<t_v1_music.Album>.value(await this._methods['buyAlbum']([ctx, aSIN, acct]));
+    return this._methods['buyAlbum']([ctx, aSIN, acct]).then((value) => value as t_v1_music.Album);
   }
 
   Future<t_v1_music.Album> _buyAlbum(frugal.FContext ctx, String aSIN, String acct) async {
@@ -91,7 +91,7 @@ class FStoreClient implements FStore {
   @override
   Future<bool> enterAlbumGiveaway(frugal.FContext ctx, String email, String name) {
     _frugalLog.warning("Call to deprecated function 'Store.enterAlbumGiveaway'");
-    return new Future<bool>.value(await this._methods['enterAlbumGiveaway']([ctx, email, name]));
+    return this._methods['enterAlbumGiveaway']([ctx, email, name]).then((value) => value as bool);
   }
 
   Future<bool> _enterAlbumGiveaway(frugal.FContext ctx, String email, String name) async {

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -34,8 +34,8 @@ class FBaseFooClient implements FBaseFoo {
   frugal.FProtocolFactory _protocolFactory;
 
   @override
-  Future basePing(frugal.FContext ctx) {
-    return this._methods['basePing']([ctx]);
+  Future basePing(frugal.FContext ctx) async {
+    return new Future.value(await this._methods['basePing']([ctx]));
   }
 
   Future _basePing(frugal.FContext ctx) async {

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -34,8 +34,8 @@ class FBaseFooClient implements FBaseFoo {
   frugal.FProtocolFactory _protocolFactory;
 
   @override
-  Future basePing(frugal.FContext ctx) async {
-    return new Future.value(await this._methods['basePing']([ctx]));
+  Future basePing(frugal.FContext ctx) {
+    return this._methods['basePing']([ctx]);
   }
 
   Future _basePing(frugal.FContext ctx) async {

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -37,8 +37,8 @@ class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient implements
   frugal.FProtocolFactory _protocolFactory;
 
   @override
-  Future<t_vendor_namespace.Item> getItem(frugal.FContext ctx) async {
-    return new Future<t_vendor_namespace.Item>.value(await this._methods['getItem']([ctx]));
+  Future<t_vendor_namespace.Item> getItem(frugal.FContext ctx) {
+    return this._methods['getItem']([ctx]).then((value) => value as t_vendor_namespace.Item);
   }
 
   Future<t_vendor_namespace.Item> _getItem(frugal.FContext ctx) async {

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -37,8 +37,8 @@ class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient implements
   frugal.FProtocolFactory _protocolFactory;
 
   @override
-  Future<t_vendor_namespace.Item> getItem(frugal.FContext ctx) {
-    return this._methods['getItem']([ctx]) as Future<t_vendor_namespace.Item>;
+  Future<t_vendor_namespace.Item> getItem(frugal.FContext ctx) async {
+    return new Future<t_vendor_namespace.Item>.value(await this._methods['getItem']([ctx]));
   }
 
   Future<t_vendor_namespace.Item> _getItem(frugal.FContext ctx) async {

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -84,9 +84,9 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
   /// Deprecated: don't use this; use "something else"
   @deprecated
   @override
-  Future ping(frugal.FContext ctx) {
+  Future ping(frugal.FContext ctx) async {
     _frugalLog.warning("Call to deprecated function 'Foo.ping'");
-    return this._methods['ping']([ctx]);
+    return new Future.value(await this._methods['ping']([ctx]));
   }
 
   Future _ping(frugal.FContext ctx) async {
@@ -118,8 +118,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
   }
   /// Blah the server.
   @override
-  Future<int> blah(frugal.FContext ctx, int num, String str, t_variety.Event event) {
-    return this._methods['blah']([ctx, num, str, event]) as Future<int>;
+  Future<int> blah(frugal.FContext ctx, int num, String str, t_variety.Event event) async {
+    return new Future<int>.value(await this._methods['blah']([ctx, num, str, event]));
   }
 
   Future<int> _blah(frugal.FContext ctx, int num, String str, t_variety.Event event) async {
@@ -167,8 +167,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
   }
   /// oneway methods don't receive a response from the server.
   @override
-  Future oneWay(frugal.FContext ctx, int id, Map<int, String> req) {
-    return this._methods['oneWay']([ctx, id, req]);
+  Future oneWay(frugal.FContext ctx, int id, Map<int, String> req) async {
+    return new Future.value(await this._methods['oneWay']([ctx, id, req]));
   }
 
   Future _oneWay(frugal.FContext ctx, int id, Map<int, String> req) async {
@@ -185,8 +185,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
   }
 
   @override
-  Future<Uint8List> bin_method(frugal.FContext ctx, Uint8List bin, String str) {
-    return this._methods['bin_method']([ctx, bin, str]) as Future<Uint8List>;
+  Future<Uint8List> bin_method(frugal.FContext ctx, Uint8List bin, String str) async {
+    return new Future<Uint8List>.value(await this._methods['bin_method']([ctx, bin, str]));
   }
 
   Future<Uint8List> _bin_method(frugal.FContext ctx, Uint8List bin, String str) async {
@@ -229,8 +229,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<int> param_modifiers(frugal.FContext ctx, int opt_num, int default_num, int req_num) {
-    return this._methods['param_modifiers']([ctx, opt_num, default_num, req_num]) as Future<int>;
+  Future<int> param_modifiers(frugal.FContext ctx, int opt_num, int default_num, int req_num) async {
+    return new Future<int>.value(await this._methods['param_modifiers']([ctx, opt_num, default_num, req_num]));
   }
 
   Future<int> _param_modifiers(frugal.FContext ctx, int opt_num, int default_num, int req_num) async {
@@ -271,8 +271,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<List<int>> underlying_types_test(frugal.FContext ctx, List<int> list_type, Set<int> set_type) {
-    return this._methods['underlying_types_test']([ctx, list_type, set_type]) as Future<List<int>>;
+  Future<List<int>> underlying_types_test(frugal.FContext ctx, List<int> list_type, Set<int> set_type) async {
+    return new Future<List<int>>.value(await this._methods['underlying_types_test']([ctx, list_type, set_type]));
   }
 
   Future<List<int>> _underlying_types_test(frugal.FContext ctx, List<int> list_type, Set<int> set_type) async {
@@ -312,8 +312,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<t_validStructs.Thing> getThing(frugal.FContext ctx) {
-    return this._methods['getThing']([ctx]) as Future<t_validStructs.Thing>;
+  Future<t_validStructs.Thing> getThing(frugal.FContext ctx) async {
+    return new Future<t_validStructs.Thing>.value(await this._methods['getThing']([ctx]));
   }
 
   Future<t_validStructs.Thing> _getThing(frugal.FContext ctx) async {
@@ -351,8 +351,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<int> getMyInt(frugal.FContext ctx) {
-    return this._methods['getMyInt']([ctx]) as Future<int>;
+  Future<int> getMyInt(frugal.FContext ctx) async {
+    return new Future<int>.value(await this._methods['getMyInt']([ctx]));
   }
 
   Future<int> _getMyInt(frugal.FContext ctx) async {
@@ -390,8 +390,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<t_subdir_include_ns.A> use_subdir_struct(frugal.FContext ctx, t_subdir_include_ns.A a) {
-    return this._methods['use_subdir_struct']([ctx, a]) as Future<t_subdir_include_ns.A>;
+  Future<t_subdir_include_ns.A> use_subdir_struct(frugal.FContext ctx, t_subdir_include_ns.A a) async {
+    return new Future<t_subdir_include_ns.A>.value(await this._methods['use_subdir_struct']([ctx, a]));
   }
 
   Future<t_subdir_include_ns.A> _use_subdir_struct(frugal.FContext ctx, t_subdir_include_ns.A a) async {
@@ -430,8 +430,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<String> sayHelloWith(frugal.FContext ctx, String newMessage) {
-    return this._methods['sayHelloWith']([ctx, newMessage]) as Future<String>;
+  Future<String> sayHelloWith(frugal.FContext ctx, String newMessage) async {
+    return new Future<String>.value(await this._methods['sayHelloWith']([ctx, newMessage]));
   }
 
   Future<String> _sayHelloWith(frugal.FContext ctx, String newMessage) async {
@@ -470,8 +470,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<String> whatDoYouSay(frugal.FContext ctx, String messageArgs) {
-    return this._methods['whatDoYouSay']([ctx, messageArgs]) as Future<String>;
+  Future<String> whatDoYouSay(frugal.FContext ctx, String messageArgs) async {
+    return new Future<String>.value(await this._methods['whatDoYouSay']([ctx, messageArgs]));
   }
 
   Future<String> _whatDoYouSay(frugal.FContext ctx, String messageArgs) async {
@@ -510,8 +510,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<String> sayAgain(frugal.FContext ctx, String messageResult) {
-    return this._methods['sayAgain']([ctx, messageResult]) as Future<String>;
+  Future<String> sayAgain(frugal.FContext ctx, String messageResult) async {
+    return new Future<String>.value(await this._methods['sayAgain']([ctx, messageResult]));
   }
 
   Future<String> _sayAgain(frugal.FContext ctx, String messageResult) async {

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -84,9 +84,9 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
   /// Deprecated: don't use this; use "something else"
   @deprecated
   @override
-  Future ping(frugal.FContext ctx) async {
+  Future ping(frugal.FContext ctx) {
     _frugalLog.warning("Call to deprecated function 'Foo.ping'");
-    return new Future.value(await this._methods['ping']([ctx]));
+    return this._methods['ping']([ctx]);
   }
 
   Future _ping(frugal.FContext ctx) async {
@@ -118,8 +118,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
   }
   /// Blah the server.
   @override
-  Future<int> blah(frugal.FContext ctx, int num, String str, t_variety.Event event) async {
-    return new Future<int>.value(await this._methods['blah']([ctx, num, str, event]));
+  Future<int> blah(frugal.FContext ctx, int num, String str, t_variety.Event event) {
+    return this._methods['blah']([ctx, num, str, event]).then((value) => value as int);
   }
 
   Future<int> _blah(frugal.FContext ctx, int num, String str, t_variety.Event event) async {
@@ -167,8 +167,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
   }
   /// oneway methods don't receive a response from the server.
   @override
-  Future oneWay(frugal.FContext ctx, int id, Map<int, String> req) async {
-    return new Future.value(await this._methods['oneWay']([ctx, id, req]));
+  Future oneWay(frugal.FContext ctx, int id, Map<int, String> req) {
+    return this._methods['oneWay']([ctx, id, req]);
   }
 
   Future _oneWay(frugal.FContext ctx, int id, Map<int, String> req) async {
@@ -185,8 +185,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
   }
 
   @override
-  Future<Uint8List> bin_method(frugal.FContext ctx, Uint8List bin, String str) async {
-    return new Future<Uint8List>.value(await this._methods['bin_method']([ctx, bin, str]));
+  Future<Uint8List> bin_method(frugal.FContext ctx, Uint8List bin, String str) {
+    return this._methods['bin_method']([ctx, bin, str]).then((value) => value as Uint8List);
   }
 
   Future<Uint8List> _bin_method(frugal.FContext ctx, Uint8List bin, String str) async {
@@ -229,8 +229,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<int> param_modifiers(frugal.FContext ctx, int opt_num, int default_num, int req_num) async {
-    return new Future<int>.value(await this._methods['param_modifiers']([ctx, opt_num, default_num, req_num]));
+  Future<int> param_modifiers(frugal.FContext ctx, int opt_num, int default_num, int req_num) {
+    return this._methods['param_modifiers']([ctx, opt_num, default_num, req_num]).then((value) => value as int);
   }
 
   Future<int> _param_modifiers(frugal.FContext ctx, int opt_num, int default_num, int req_num) async {
@@ -271,8 +271,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<List<int>> underlying_types_test(frugal.FContext ctx, List<int> list_type, Set<int> set_type) async {
-    return new Future<List<int>>.value(await this._methods['underlying_types_test']([ctx, list_type, set_type]));
+  Future<List<int>> underlying_types_test(frugal.FContext ctx, List<int> list_type, Set<int> set_type) {
+    return this._methods['underlying_types_test']([ctx, list_type, set_type]).then((value) => value as List<int>);
   }
 
   Future<List<int>> _underlying_types_test(frugal.FContext ctx, List<int> list_type, Set<int> set_type) async {
@@ -312,8 +312,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<t_validStructs.Thing> getThing(frugal.FContext ctx) async {
-    return new Future<t_validStructs.Thing>.value(await this._methods['getThing']([ctx]));
+  Future<t_validStructs.Thing> getThing(frugal.FContext ctx) {
+    return this._methods['getThing']([ctx]).then((value) => value as t_validStructs.Thing);
   }
 
   Future<t_validStructs.Thing> _getThing(frugal.FContext ctx) async {
@@ -351,8 +351,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<int> getMyInt(frugal.FContext ctx) async {
-    return new Future<int>.value(await this._methods['getMyInt']([ctx]));
+  Future<int> getMyInt(frugal.FContext ctx) {
+    return this._methods['getMyInt']([ctx]).then((value) => value as int);
   }
 
   Future<int> _getMyInt(frugal.FContext ctx) async {
@@ -390,8 +390,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<t_subdir_include_ns.A> use_subdir_struct(frugal.FContext ctx, t_subdir_include_ns.A a) async {
-    return new Future<t_subdir_include_ns.A>.value(await this._methods['use_subdir_struct']([ctx, a]));
+  Future<t_subdir_include_ns.A> use_subdir_struct(frugal.FContext ctx, t_subdir_include_ns.A a) {
+    return this._methods['use_subdir_struct']([ctx, a]).then((value) => value as t_subdir_include_ns.A);
   }
 
   Future<t_subdir_include_ns.A> _use_subdir_struct(frugal.FContext ctx, t_subdir_include_ns.A a) async {
@@ -430,8 +430,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<String> sayHelloWith(frugal.FContext ctx, String newMessage) async {
-    return new Future<String>.value(await this._methods['sayHelloWith']([ctx, newMessage]));
+  Future<String> sayHelloWith(frugal.FContext ctx, String newMessage) {
+    return this._methods['sayHelloWith']([ctx, newMessage]).then((value) => value as String);
   }
 
   Future<String> _sayHelloWith(frugal.FContext ctx, String newMessage) async {
@@ -470,8 +470,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<String> whatDoYouSay(frugal.FContext ctx, String messageArgs) async {
-    return new Future<String>.value(await this._methods['whatDoYouSay']([ctx, messageArgs]));
+  Future<String> whatDoYouSay(frugal.FContext ctx, String messageArgs) {
+    return this._methods['whatDoYouSay']([ctx, messageArgs]).then((value) => value as String);
   }
 
   Future<String> _whatDoYouSay(frugal.FContext ctx, String messageArgs) async {
@@ -510,8 +510,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
     );
   }
   @override
-  Future<String> sayAgain(frugal.FContext ctx, String messageResult) async {
-    return new Future<String>.value(await this._methods['sayAgain']([ctx, messageResult]));
+  Future<String> sayAgain(frugal.FContext ctx, String messageResult) {
+    return this._methods['sayAgain']([ctx, messageResult]).then((value) => value as String);
   }
 
   Future<String> _sayAgain(frugal.FContext ctx, String messageResult) async {


### PR DESCRIPTION
### Story:
Frugal's dart generation generates accessor methods which return Future's containing some requested data. Here's a typical example:
```
Future<List<t_comments.UserData>> getUserDataForAccount(frugal.FContext ctx) {
    return this._methods['getUserDataForAccount']([ctx]) as Future<List<t_comments.UserData>>;
}
```

Unfortunately, the cast can only infer the wrapping type (`Future`) and not the underlying type parameter. This causes the returned type to be inferred as `Future<dynamic>`, regardless of the actual type parameter, leading to runtime errors like this on Dart 2:
```
error: Type '_Future<dynamic>' should be '_Future<List<t_comments.UserData>>' to implement expected type 'Future<List<t_comments.UserData>>'.
```
To fix this, we add a `.then` and explicitly cast the type parameter in a supplied callback. This does not affect async timing, and provides the correct typing.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:

### How To Test:
* Generate `comments_frugal` using this branch's generator, and smoke test examples on Dart 1 on master, and Dart 1 & Dart 2 on [this](https://github.com/Workiva/w_comments/tree/dart2) branch.

### My Test Results:
TODO

#### Reviewers:
@Workiva/product2