### PR TITLE
Consume jnats 2.4.6

### DIFF
--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>io.nats</groupId>
             <artifactId>jnats</artifactId>
-            <version>2.4.3</version>
+            <version>2.4.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/test/integration/java/frugal-integration-test/pom.xml
+++ b/test/integration/java/frugal-integration-test/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>io.nats</groupId>
             <artifactId>jnats</artifactId>
-            <version>2.4.3</version>
+            <version>2.4.6</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
### Story:
jnats [released](https://github.com/nats-io/nats.java/releases) new patch versions with a few bug fixes.

### My Test Results:
Pulled jnats 2.4.6 into java-nats-load-app, deployed to squad2, confirmed everything works. Bounced nats a few times, confirmed all connections were able to reconnect. 

#### Reviewers:
@Workiva/product2