### PR TITLE
Initialize ephemeralProperties in NewFContext

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/messaging-docker-images:1721483 as build
+FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.34 as build
 
 ARG GIT_BRANCH
 ARG GIT_MERGE_BRANCH

--- a/lib/go/context.go
+++ b/lib/go/context.go
@@ -162,6 +162,7 @@ func NewFContext(correlationID string) FContext {
 			timeoutHeader: strconv.FormatInt(int64(defaultTimeout/time.Millisecond), 10),
 		},
 		responseHeaders: make(map[string]string),
+		ephemeralProperties: make(map[interface{}]interface{}),
 	}
 
 	return ctx

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -8,7 +8,7 @@ run:  # local tests only, never run in Skynet
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:1721483
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.34
 
 env:
   - IN_SKYNET_CLI=true
@@ -41,7 +41,7 @@ requires:
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:1721483
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.34
 
 env:
   - PYTHONIOENCODING=utf-8


### PR DESCRIPTION
### Story:
While working on https://jira.atl.workiva.net/browse/INFENG-8048 I noticed this [unit test](https://github.com/Workiva/messaging-sdk/blob/master/lib/go/sdk/iam_test.go#L511) is failing because `ephemeralProperties` is initialized in [Clone](https://github.com/Workiva/frugal/blob/master/lib/go/context.go#L126-L130) but not in [NewFConext](https://github.com/Workiva/frugal/blob/master/lib/go/context.go#L158-L165).   

Workiva-build is failing for a different reason now, should be fixed after https://github.com/Workiva/messaging-docker-images/pull/56 is merged and released. 

### My Test Results:
Same unit test passes now after this change. 

#### Reviewers:
@Workiva/product2