### PR TITLE
INFENG-8047 Remove pypi url env variable, as twine defaults to the correct one.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ git:
 env:
   - TWINE_USERNAME=messaging
   - TWINE_REPOSITORY=pypi
-  - TWINE_REPOSITORY_URL=https://upload.pypi.org/latest/
 
 before_install:
   - mkdir -p $GOPATH/src/github.com/Workiva/frugal


### PR DESCRIPTION
Fixes pypi timeout

#### Reviewers:
@Workiva/product2