### PR TITLE
dart: Fix default aggregate field initialization

### DIFF
--- a/test/expected/dart/actual_base/f_nested_thing.dart
+++ b/test/expected/dart/actual_base/f_nested_thing.dart
@@ -75,12 +75,12 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem81 = iprot.readListBegin();
+            thrift.TList elem94 = iprot.readListBegin();
             things = new List<t_actual_base_dart.thing>();
-            for(int elem83 = 0; elem83 < elem81.length; ++elem83) {
-              t_actual_base_dart.thing elem82 = new t_actual_base_dart.thing();
-              elem82.read(iprot);
-              things.add(elem82);
+            for(int elem96 = 0; elem96 < elem94.length; ++elem96) {
+              t_actual_base_dart.thing elem95 = new t_actual_base_dart.thing();
+              elem95.read(iprot);
+              things.add(elem95);
             }
             iprot.readListEnd();
           } else {
@@ -107,8 +107,8 @@ class nested_thing implements thrift.TBase {
     if (this.things != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
       oprot.writeListBegin(new thrift.TList(thrift.TType.STRUCT, things.length));
-      for(var elem84 in things) {
-        elem84.write(oprot);
+      for(var elem97 in things) {
+        elem97.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/test/expected/dart/variety/f_event_wrapper.dart
+++ b/test/expected/dart/variety/f_event_wrapper.dart
@@ -25,6 +25,9 @@ class EventWrapper implements thrift.TBase {
   static final thrift.TField _DEPR_FIELD_DESC = new thrift.TField("depr", thrift.TType.BOOL, 11);
   static final thrift.TField _DEPR_BINARY_FIELD_DESC = new thrift.TField("deprBinary", thrift.TType.STRING, 12);
   static final thrift.TField _DEPR_LIST_FIELD_DESC = new thrift.TField("deprList", thrift.TType.LIST, 13);
+  static final thrift.TField _EVENTS_DEFAULT_FIELD_DESC = new thrift.TField("EventsDefault", thrift.TType.LIST, 14);
+  static final thrift.TField _EVENT_MAP_DEFAULT_FIELD_DESC = new thrift.TField("EventMapDefault", thrift.TType.MAP, 15);
+  static final thrift.TField _EVENT_SET_DEFAULT_FIELD_DESC = new thrift.TField("EventSetDefault", thrift.TType.SET, 16);
 
   int _iD;
   static const int ID = 1;
@@ -60,12 +63,24 @@ class EventWrapper implements thrift.TBase {
   @deprecated
   List<bool> _deprList;
   static const int DEPRLIST = 13;
+  List<t_variety.Event> _eventsDefault;
+  static const int EVENTSDEFAULT = 14;
+  Map<int, t_variety.Event> _eventMapDefault;
+  static const int EVENTMAPDEFAULT = 15;
+  Set<t_variety.Event> _eventSetDefault;
+  static const int EVENTSETDEFAULT = 16;
 
   bool __isset_iD = false;
   bool __isset_aBoolField = false;
   bool __isset_depr = false;
 
   EventWrapper() {
+    this._eventsDefault = const [
+    ];
+    this._eventMapDefault = const {
+    };
+    this._eventSetDefault = new Set<t_variety.Event>.from([
+    ]);
   }
 
   int get iD => this._iD;
@@ -245,6 +260,42 @@ class EventWrapper implements thrift.TBase {
     this.deprList = null;
   }
 
+  List<t_variety.Event> get eventsDefault => this._eventsDefault;
+
+  set eventsDefault(List<t_variety.Event> eventsDefault) {
+    this._eventsDefault = eventsDefault;
+  }
+
+  bool isSetEventsDefault() => this.eventsDefault != null;
+
+  unsetEventsDefault() {
+    this.eventsDefault = null;
+  }
+
+  Map<int, t_variety.Event> get eventMapDefault => this._eventMapDefault;
+
+  set eventMapDefault(Map<int, t_variety.Event> eventMapDefault) {
+    this._eventMapDefault = eventMapDefault;
+  }
+
+  bool isSetEventMapDefault() => this.eventMapDefault != null;
+
+  unsetEventMapDefault() {
+    this.eventMapDefault = null;
+  }
+
+  Set<t_variety.Event> get eventSetDefault => this._eventSetDefault;
+
+  set eventSetDefault(Set<t_variety.Event> eventSetDefault) {
+    this._eventSetDefault = eventSetDefault;
+  }
+
+  bool isSetEventSetDefault() => this.eventSetDefault != null;
+
+  unsetEventSetDefault() {
+    this.eventSetDefault = null;
+  }
+
   @override
   getFieldValue(int fieldID) {
     switch (fieldID) {
@@ -277,6 +328,12 @@ class EventWrapper implements thrift.TBase {
       case DEPRLIST:
         // ignore: deprecated_member_use
         return this.deprList;
+      case EVENTSDEFAULT:
+        return this.eventsDefault;
+      case EVENTMAPDEFAULT:
+        return this.eventMapDefault;
+      case EVENTSETDEFAULT:
+        return this.eventSetDefault;
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
     }
@@ -392,6 +449,30 @@ class EventWrapper implements thrift.TBase {
         }
         break;
 
+      case EVENTSDEFAULT:
+        if (value == null) {
+          unsetEventsDefault();
+        } else {
+          this.eventsDefault = value as List<t_variety.Event>;
+        }
+        break;
+
+      case EVENTMAPDEFAULT:
+        if (value == null) {
+          unsetEventMapDefault();
+        } else {
+          this.eventMapDefault = value as Map<int, t_variety.Event>;
+        }
+        break;
+
+      case EVENTSETDEFAULT:
+        if (value == null) {
+          unsetEventSetDefault();
+        } else {
+          this.eventSetDefault = value as Set<t_variety.Event>;
+        }
+        break;
+
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
     }
@@ -430,6 +511,12 @@ class EventWrapper implements thrift.TBase {
       case DEPRLIST:
         // ignore: deprecated_member_use
         return isSetDeprList();
+      case EVENTSDEFAULT:
+        return isSetEventsDefault();
+      case EVENTMAPDEFAULT:
+        return isSetEventMapDefault();
+      case EVENTSETDEFAULT:
+        return isSetEventSetDefault();
       default:
         throw new ArgumentError("Field $fieldID doesn't exist!");
     }
@@ -588,6 +675,49 @@ class EventWrapper implements thrift.TBase {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
+        case EVENTSDEFAULT:
+          if (field.type == thrift.TType.LIST) {
+            thrift.TList elem43 = iprot.readListBegin();
+            eventsDefault = new List<t_variety.Event>();
+            for(int elem45 = 0; elem45 < elem43.length; ++elem45) {
+              t_variety.Event elem44 = new t_variety.Event();
+              elem44.read(iprot);
+              eventsDefault.add(elem44);
+            }
+            iprot.readListEnd();
+          } else {
+            thrift.TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
+        case EVENTMAPDEFAULT:
+          if (field.type == thrift.TType.MAP) {
+            thrift.TMap elem46 = iprot.readMapBegin();
+            eventMapDefault = new Map<int, t_variety.Event>();
+            for(int elem48 = 0; elem48 < elem46.length; ++elem48) {
+              int elem49 = iprot.readI64();
+              t_variety.Event elem47 = new t_variety.Event();
+              elem47.read(iprot);
+              eventMapDefault[elem49] = elem47;
+            }
+            iprot.readMapEnd();
+          } else {
+            thrift.TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
+        case EVENTSETDEFAULT:
+          if (field.type == thrift.TType.SET) {
+            thrift.TSet elem50 = iprot.readSetBegin();
+            eventSetDefault = new Set<t_variety.Event>();
+            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
+              t_variety.Event elem51 = new t_variety.Event();
+              elem51.read(iprot);
+              eventSetDefault.add(elem51);
+            }
+            iprot.readSetEnd();
+          } else {
+            thrift.TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
         default:
           thrift.TProtocolUtil.skip(iprot, field.type);
           break;
@@ -618,8 +748,8 @@ class EventWrapper implements thrift.TBase {
     if (this.events != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
       oprot.writeListBegin(new thrift.TList(thrift.TType.STRUCT, events.length));
-      for(var elem43 in events) {
-        elem43.write(oprot);
+      for(var elem53 in events) {
+        elem53.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
@@ -627,8 +757,8 @@ class EventWrapper implements thrift.TBase {
     if (this.events2 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
       oprot.writeSetBegin(new thrift.TSet(thrift.TType.STRUCT, events2.length));
-      for(var elem44 in events2) {
-        elem44.write(oprot);
+      for(var elem54 in events2) {
+        elem54.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -636,9 +766,9 @@ class EventWrapper implements thrift.TBase {
     if (this.eventMap != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
       oprot.writeMapBegin(new thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, eventMap.length));
-      for(var elem45 in eventMap.keys) {
-        oprot.writeI64(elem45);
-        eventMap[elem45].write(oprot);
+      for(var elem55 in eventMap.keys) {
+        oprot.writeI64(elem55);
+        eventMap[elem55].write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -646,10 +776,10 @@ class EventWrapper implements thrift.TBase {
     if (this.nums != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
       oprot.writeListBegin(new thrift.TList(thrift.TType.LIST, nums.length));
-      for(var elem46 in nums) {
-        oprot.writeListBegin(new thrift.TList(thrift.TType.I32, elem46.length));
-        for(var elem47 in elem46) {
-          oprot.writeI32(elem47);
+      for(var elem56 in nums) {
+        oprot.writeListBegin(new thrift.TList(thrift.TType.I32, elem56.length));
+        for(var elem57 in elem56) {
+          oprot.writeI32(elem57);
         }
         oprot.writeListEnd();
       }
@@ -659,8 +789,8 @@ class EventWrapper implements thrift.TBase {
     if (this.enums != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
       oprot.writeListBegin(new thrift.TList(thrift.TType.I32, enums.length));
-      for(var elem48 in enums) {
-        oprot.writeI32(elem48);
+      for(var elem58 in enums) {
+        oprot.writeI32(elem58);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
@@ -695,10 +825,38 @@ class EventWrapper implements thrift.TBase {
     // ignore: deprecated_member_use
       oprot.writeListBegin(new thrift.TList(thrift.TType.BOOL, deprList.length));
       // ignore: deprecated_member_use
-      for(var elem49 in deprList) {
-        oprot.writeBool(elem49);
+      for(var elem59 in deprList) {
+        oprot.writeBool(elem59);
       }
       oprot.writeListEnd();
+      oprot.writeFieldEnd();
+    }
+    if (isSetEventsDefault() && this.eventsDefault != null) {
+      oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
+      oprot.writeListBegin(new thrift.TList(thrift.TType.STRUCT, eventsDefault.length));
+      for(var elem60 in eventsDefault) {
+        elem60.write(oprot);
+      }
+      oprot.writeListEnd();
+      oprot.writeFieldEnd();
+    }
+    if (isSetEventMapDefault() && this.eventMapDefault != null) {
+      oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
+      oprot.writeMapBegin(new thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, eventMapDefault.length));
+      for(var elem61 in eventMapDefault.keys) {
+        oprot.writeI64(elem61);
+        eventMapDefault[elem61].write(oprot);
+      }
+      oprot.writeMapEnd();
+      oprot.writeFieldEnd();
+    }
+    if (isSetEventSetDefault() && this.eventSetDefault != null) {
+      oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
+      oprot.writeSetBegin(new thrift.TSet(thrift.TType.STRUCT, eventSetDefault.length));
+      for(var elem62 in eventSetDefault) {
+        elem62.write(oprot);
+      }
+      oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -806,6 +964,36 @@ class EventWrapper implements thrift.TBase {
       ret.write(this.deprList);
     }
 
+    if (isSetEventsDefault()) {
+      ret.write(", ");
+      ret.write("eventsDefault:");
+      if (this.eventsDefault == null) {
+        ret.write("null");
+      } else {
+        ret.write(this.eventsDefault);
+      }
+    }
+
+    if (isSetEventMapDefault()) {
+      ret.write(", ");
+      ret.write("eventMapDefault:");
+      if (this.eventMapDefault == null) {
+        ret.write("null");
+      } else {
+        ret.write(this.eventMapDefault);
+      }
+    }
+
+    if (isSetEventSetDefault()) {
+      ret.write(", ");
+      ret.write("eventSetDefault:");
+      if (this.eventSetDefault == null) {
+        ret.write("null");
+      } else {
+        ret.write(this.eventSetDefault);
+      }
+    }
+
     ret.write(")");
 
     return ret.toString();
@@ -829,7 +1017,10 @@ class EventWrapper implements thrift.TBase {
         // ignore: deprecated_member_use
         this.deprBinary == o.deprBinary &&
         // ignore: deprecated_member_use
-        this.deprList == o.deprList;
+        this.deprList == o.deprList &&
+        this.eventsDefault == o.eventsDefault &&
+        this.eventMapDefault == o.eventMapDefault &&
+        this.eventSetDefault == o.eventSetDefault;
     }
     return false;
   }
@@ -853,6 +1044,9 @@ class EventWrapper implements thrift.TBase {
     value = (value * 31) ^ deprBinary.hashCode;
     // ignore: deprecated_member_use
     value = (value * 31) ^ deprList.hashCode;
+    value = (value * 31) ^ eventsDefault.hashCode;
+    value = (value * 31) ^ eventMapDefault.hashCode;
+    value = (value * 31) ^ eventSetDefault.hashCode;
     return value;
   }
 
@@ -873,6 +1067,9 @@ class EventWrapper implements thrift.TBase {
     Uint8List deprBinary: null,
     // ignore: deprecated_member_use
     List<bool> deprList: null,
+    List<t_variety.Event> eventsDefault: null,
+    Map<int, t_variety.Event> eventMapDefault: null,
+    Set<t_variety.Event> eventSetDefault: null,
   }) {
     return new EventWrapper()
       ..iD = iD ?? this.iD
@@ -890,7 +1087,10 @@ class EventWrapper implements thrift.TBase {
       // ignore: deprecated_member_use
       ..deprBinary = deprBinary ?? this.deprBinary
       // ignore: deprecated_member_use
-      ..deprList = deprList ?? this.deprList;
+      ..deprList = deprList ?? this.deprList
+      ..eventsDefault = eventsDefault ?? this.eventsDefault
+      ..eventMapDefault = eventMapDefault ?? this.eventMapDefault
+      ..eventSetDefault = eventSetDefault ?? this.eventSetDefault;
   }
 
   validate() {

--- a/test/expected/dart/variety/f_event_wrapper.dart
+++ b/test/expected/dart/variety/f_event_wrapper.dart
@@ -75,9 +75,9 @@ class EventWrapper implements thrift.TBase {
   bool __isset_depr = false;
 
   EventWrapper() {
-    this._eventsDefault = const [
+    this._eventsDefault = [
     ];
-    this._eventMapDefault = const {
+    this._eventMapDefault = {
     };
     this._eventSetDefault = new Set<t_variety.Event>.from([
     ]);

--- a/test/expected/dart/variety/f_events_scope.dart
+++ b/test/expected/dart/variety/f_events_scope.dart
@@ -123,11 +123,11 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(new thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem72 in req) {
-      oprot.writeMapBegin(new thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem72.length));
-      for(var elem73 in elem72.keys) {
-        oprot.writeI64(elem73);
-        elem72[elem73].write(oprot);
+    for(var elem85 in req) {
+      oprot.writeMapBegin(new thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem85.length));
+      for(var elem86 in elem85.keys) {
+        oprot.writeI64(elem86);
+        elem85[elem86].write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -262,19 +262,19 @@ class EventsSubscriber {
         throw new thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem74 = iprot.readListBegin();
+      thrift.TList elem87 = iprot.readListBegin();
       List<Map<int, t_variety.Event>> req = new List<Map<int, t_variety.Event>>();
-      for(int elem80 = 0; elem80 < elem74.length; ++elem80) {
-        thrift.TMap elem76 = iprot.readMapBegin();
-        Map<int, t_variety.Event> elem75 = new Map<int, t_variety.Event>();
-        for(int elem78 = 0; elem78 < elem76.length; ++elem78) {
-          int elem79 = iprot.readI64();
-          t_variety.Event elem77 = new t_variety.Event();
-          elem77.read(iprot);
-          elem75[elem79] = elem77;
+      for(int elem93 = 0; elem93 < elem87.length; ++elem93) {
+        thrift.TMap elem89 = iprot.readMapBegin();
+        Map<int, t_variety.Event> elem88 = new Map<int, t_variety.Event>();
+        for(int elem91 = 0; elem91 < elem89.length; ++elem91) {
+          int elem92 = iprot.readI64();
+          t_variety.Event elem90 = new t_variety.Event();
+          elem90.read(iprot);
+          elem88[elem92] = elem90;
         }
         iprot.readMapEnd();
-        req.add(elem75);
+        req.add(elem88);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -1335,12 +1335,12 @@ class oneWay_args implements thrift.TBase {
           break;
         case REQ:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem55 = iprot.readMapBegin();
+            thrift.TMap elem68 = iprot.readMapBegin();
             req = new Map<int, String>();
-            for(int elem57 = 0; elem57 < elem55.length; ++elem57) {
-              int elem58 = iprot.readI32();
-              String elem56 = iprot.readString();
-              req[elem58] = elem56;
+            for(int elem70 = 0; elem70 < elem68.length; ++elem70) {
+              int elem71 = iprot.readI32();
+              String elem69 = iprot.readString();
+              req[elem71] = elem69;
             }
             iprot.readMapEnd();
           } else {
@@ -1370,9 +1370,9 @@ class oneWay_args implements thrift.TBase {
     if (this.req != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
       oprot.writeMapBegin(new thrift.TMap(thrift.TType.I32, thrift.TType.STRING, req.length));
-      for(var elem59 in req.keys) {
-        oprot.writeI32(elem59);
-        oprot.writeString(req[elem59]);
+      for(var elem72 in req.keys) {
+        oprot.writeI32(elem72);
+        oprot.writeString(req[elem72]);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -2309,11 +2309,11 @@ class underlying_types_test_args implements thrift.TBase {
       switch (field.id) {
         case LIST_TYPE:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem60 = iprot.readListBegin();
+            thrift.TList elem73 = iprot.readListBegin();
             list_type = new List<int>();
-            for(int elem62 = 0; elem62 < elem60.length; ++elem62) {
-              int elem61 = iprot.readI64();
-              list_type.add(elem61);
+            for(int elem75 = 0; elem75 < elem73.length; ++elem75) {
+              int elem74 = iprot.readI64();
+              list_type.add(elem74);
             }
             iprot.readListEnd();
           } else {
@@ -2322,11 +2322,11 @@ class underlying_types_test_args implements thrift.TBase {
           break;
         case SET_TYPE:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem63 = iprot.readSetBegin();
+            thrift.TSet elem76 = iprot.readSetBegin();
             set_type = new Set<int>();
-            for(int elem65 = 0; elem65 < elem63.length; ++elem65) {
-              int elem64 = iprot.readI64();
-              set_type.add(elem64);
+            for(int elem78 = 0; elem78 < elem76.length; ++elem78) {
+              int elem77 = iprot.readI64();
+              set_type.add(elem77);
             }
             iprot.readSetEnd();
           } else {
@@ -2353,8 +2353,8 @@ class underlying_types_test_args implements thrift.TBase {
     if (this.list_type != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
       oprot.writeListBegin(new thrift.TList(thrift.TType.I64, list_type.length));
-      for(var elem66 in list_type) {
-        oprot.writeI64(elem66);
+      for(var elem79 in list_type) {
+        oprot.writeI64(elem79);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
@@ -2362,8 +2362,8 @@ class underlying_types_test_args implements thrift.TBase {
     if (this.set_type != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
       oprot.writeSetBegin(new thrift.TSet(thrift.TType.I64, set_type.length));
-      for(var elem67 in set_type) {
-        oprot.writeI64(elem67);
+      for(var elem80 in set_type) {
+        oprot.writeI64(elem80);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -2497,11 +2497,11 @@ class underlying_types_test_result implements thrift.TBase {
       switch (field.id) {
         case SUCCESS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem68 = iprot.readListBegin();
+            thrift.TList elem81 = iprot.readListBegin();
             success = new List<int>();
-            for(int elem70 = 0; elem70 < elem68.length; ++elem70) {
-              int elem69 = iprot.readI64();
-              success.add(elem69);
+            for(int elem83 = 0; elem83 < elem81.length; ++elem83) {
+              int elem82 = iprot.readI64();
+              success.add(elem82);
             }
             iprot.readListEnd();
           } else {
@@ -2528,8 +2528,8 @@ class underlying_types_test_result implements thrift.TBase {
     if (isSetSuccess() && this.success != null) {
       oprot.writeFieldBegin(_SUCCESS_FIELD_DESC);
       oprot.writeListBegin(new thrift.TList(thrift.TType.I64, success.length));
-      for(var elem71 in success) {
-        oprot.writeI64(elem71);
+      for(var elem84 in success) {
+        oprot.writeI64(elem84);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/test/expected/dart/variety/f_testing_defaults.dart
+++ b/test/expected/dart/variety/f_testing_defaults.dart
@@ -85,7 +85,7 @@ class TestingDefaults implements thrift.TBase {
     this._iD = -2;
     this._thing = "a constant";
     this._thing2 = "another constant";
-    this._listfield = const [
+    this._listfield = [
       1,
       2,
       3,
@@ -94,20 +94,20 @@ class TestingDefaults implements thrift.TBase {
     ];
     this._iD3 = t_variety.VarietyConstants.other_default;
     this._bin_field4 = t_variety.VarietyConstants.bin_const;
-    this._list2 = const [
+    this._list2 = [
       1,
       3,
       4,
       5,
       8,
     ];
-    this._list4 = const [
+    this._list4 = [
       1,
       2,
       3,
       6,
     ];
-    this._a_map = const {
+    this._a_map = {
       "k1": "v1",
       "k2": "v2",
     };

--- a/test/expected/dart/variety/f_testing_unions.dart
+++ b/test/expected/dart/variety/f_testing_unions.dart
@@ -289,12 +289,12 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem50 = iprot.readMapBegin();
+            thrift.TMap elem63 = iprot.readMapBegin();
             requests = new Map<int, String>();
-            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
-              int elem53 = iprot.readI32();
-              String elem51 = iprot.readString();
-              requests[elem53] = elem51;
+            for(int elem65 = 0; elem65 < elem63.length; ++elem65) {
+              int elem66 = iprot.readI32();
+              String elem64 = iprot.readString();
+              requests[elem66] = elem64;
             }
             iprot.readMapEnd();
           } else {
@@ -357,9 +357,9 @@ class TestingUnions implements thrift.TBase {
     if (isSetRequests() && this.requests != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
       oprot.writeMapBegin(new thrift.TMap(thrift.TType.I32, thrift.TType.STRING, requests.length));
-      for(var elem54 in requests.keys) {
-        oprot.writeI32(elem54);
-        oprot.writeString(requests[elem54]);
+      for(var elem67 in requests.keys) {
+        oprot.writeI32(elem67);
+        oprot.writeString(requests[elem67]);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();

--- a/test/expected/go/actual_base/f_types.txt
+++ b/test/expected/go/actual_base/f_types.txt
@@ -266,11 +266,11 @@ func (p *NestedThing) ReadField1(iprot thrift.TProtocol) error {
 	}
 	p.Things = make([]*Thing, 0, size)
 	for i := 0; i < size; i++ {
-		elem24 := NewThing()
-		if err := elem24.Read(iprot); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem24), err)
+		elem28 := NewThing()
+		if err := elem28.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem28), err)
 		}
-		p.Things = append(p.Things, elem24)
+		p.Things = append(p.Things, elem28)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/go/deprecated_logging/f_foo_service.go
+++ b/test/expected/go/deprecated_logging/f_foo_service.go
@@ -2587,20 +2587,20 @@ func (p *FooOneWayArgs) ReadField2(iprot thrift.TProtocol) error {
 	}
 	p.Req = make(Request, size)
 	for i := 0; i < size; i++ {
-		var elem16 Int
+		var elem20 Int
 		if v, err := iprot.ReadI32(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := Int(v)
-			elem16 = temp
+			elem20 = temp
 		}
-		var elem17 string
+		var elem21 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			elem17 = v
+			elem21 = v
 		}
-		(p.Req)[elem16] = elem17
+		(p.Req)[elem20] = elem21
 	}
 	if err := iprot.ReadMapEnd(); err != nil {
 		return thrift.PrependError("error reading map end: ", err)
@@ -3263,14 +3263,14 @@ func (p *FooUnderlyingTypesTestArgs) ReadField1(iprot thrift.TProtocol) error {
 	}
 	p.ListType = make([]ID, 0, size)
 	for i := 0; i < size; i++ {
-		var elem18 ID
+		var elem22 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem18 = temp
+			elem22 = temp
 		}
-		p.ListType = append(p.ListType, elem18)
+		p.ListType = append(p.ListType, elem22)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -3285,14 +3285,14 @@ func (p *FooUnderlyingTypesTestArgs) ReadField2(iprot thrift.TProtocol) error {
 	}
 	p.SetType = make(map[ID]bool, size)
 	for i := 0; i < size; i++ {
-		var elem19 ID
+		var elem23 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem19 = temp
+			elem23 = temp
 		}
-		(p.SetType)[elem19] = true
+		(p.SetType)[elem23] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -3426,14 +3426,14 @@ func (p *FooUnderlyingTypesTestResult) ReadField0(iprot thrift.TProtocol) error 
 	}
 	p.Success = make([]ID, 0, size)
 	for i := 0; i < size; i++ {
-		var elem20 ID
+		var elem24 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem20 = temp
+			elem24 = temp
 		}
-		p.Success = append(p.Success, elem20)
+		p.Success = append(p.Success, elem24)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/go/slim/f_events_scope.go
+++ b/test/expected/go/slim/f_events_scope.go
@@ -447,25 +447,25 @@ func (l *eventsSubscriber) recvSomeList(op string, pf *frugal.FProtocolFactory, 
 			if err != nil {
 				return thrift.PrependError("error reading map begin: ", err)
 			}
-			elem21 := make(map[ID]*Event, size)
+			elem25 := make(map[ID]*Event, size)
 			for i := 0; i < size; i++ {
-				var elem22 ID
+				var elem26 ID
 				if v, err := iprot.ReadI64(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := ID(v)
-					elem22 = temp
+					elem26 = temp
 				}
-				elem23 := NewEvent()
-				if err := elem23.Read(iprot); err != nil {
-					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem23), err)
+				elem27 := NewEvent()
+				if err := elem27.Read(iprot); err != nil {
+					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem27), err)
 				}
-				(elem21)[elem22] = elem23
+				(elem25)[elem26] = elem27
 			}
 			if err := iprot.ReadMapEnd(); err != nil {
 				return thrift.PrependError("error reading map end: ", err)
 			}
-			req = append(req, elem21)
+			req = append(req, elem25)
 		}
 		if err := iprot.ReadListEnd(); err != nil {
 			return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/go/slim/f_foo_service.go
+++ b/test/expected/go/slim/f_foo_service.go
@@ -2433,20 +2433,20 @@ func (p *FooOneWayArgs) Read(iprot thrift.TProtocol) error {
 			}
 			p.Req = make(Request, size)
 			for i := 0; i < size; i++ {
-				var elem16 Int
+				var elem20 Int
 				if v, err := iprot.ReadI32(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := Int(v)
-					elem16 = temp
+					elem20 = temp
 				}
-				var elem17 string
+				var elem21 string
 				if v, err := iprot.ReadString(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
-					elem17 = v
+					elem21 = v
 				}
-				(p.Req)[elem16] = elem17
+				(p.Req)[elem20] = elem21
 			}
 			if err := iprot.ReadMapEnd(); err != nil {
 				return thrift.PrependError("error reading map end: ", err)
@@ -2925,14 +2925,14 @@ func (p *FooUnderlyingTypesTestArgs) Read(iprot thrift.TProtocol) error {
 			}
 			p.ListType = make([]ID, 0, size)
 			for i := 0; i < size; i++ {
-				var elem18 ID
+				var elem22 ID
 				if v, err := iprot.ReadI64(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := ID(v)
-					elem18 = temp
+					elem22 = temp
 				}
-				p.ListType = append(p.ListType, elem18)
+				p.ListType = append(p.ListType, elem22)
 			}
 			if err := iprot.ReadListEnd(); err != nil {
 				return thrift.PrependError("error reading list end: ", err)
@@ -2944,14 +2944,14 @@ func (p *FooUnderlyingTypesTestArgs) Read(iprot thrift.TProtocol) error {
 			}
 			p.SetType = make(map[ID]bool, size)
 			for i := 0; i < size; i++ {
-				var elem19 ID
+				var elem23 ID
 				if v, err := iprot.ReadI64(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := ID(v)
-					elem19 = temp
+					elem23 = temp
 				}
-				(p.SetType)[elem19] = true
+				(p.SetType)[elem23] = true
 			}
 			if err := iprot.ReadSetEnd(); err != nil {
 				return thrift.PrependError("error reading set end: ", err)
@@ -3078,14 +3078,14 @@ func (p *FooUnderlyingTypesTestResult) Read(iprot thrift.TProtocol) error {
 			}
 			p.Success = make([]ID, 0, size)
 			for i := 0; i < size; i++ {
-				var elem20 ID
+				var elem24 ID
 				if v, err := iprot.ReadI64(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := ID(v)
-					elem20 = temp
+					elem24 = temp
 				}
-				p.Success = append(p.Success, elem20)
+				p.Success = append(p.Success, elem24)
 			}
 			if err := iprot.ReadListEnd(); err != nil {
 				return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/go/slim/f_types.go
+++ b/test/expected/go/slim/f_types.go
@@ -1070,7 +1070,10 @@ type EventWrapper struct {
 	// Deprecated: use something else
 	DeprBinary []byte
 	// Deprecated: use something else
-	DeprList []bool
+	DeprList        []bool
+	EventsDefault   *[]*Event
+	EventMapDefault *map[ID]*Event
+	EventSetDefault *map[*Event]bool
 }
 
 func NewEventWrapper() *EventWrapper {
@@ -1154,6 +1157,45 @@ func (p *EventWrapper) GetDeprBinary() []byte {
 
 func (p *EventWrapper) GetDeprList() []bool {
 	return p.DeprList
+}
+
+var EventWrapper_EventsDefault_DEFAULT []*Event = []*Event{}
+
+func (p *EventWrapper) IsSetEventsDefault() bool {
+	return p.EventsDefault != nil
+}
+
+func (p *EventWrapper) GetEventsDefault() []*Event {
+	if !p.IsSetEventsDefault() {
+		return EventWrapper_EventsDefault_DEFAULT
+	}
+	return *p.EventsDefault
+}
+
+var EventWrapper_EventMapDefault_DEFAULT map[ID]*Event = map[ID]*Event{}
+
+func (p *EventWrapper) IsSetEventMapDefault() bool {
+	return p.EventMapDefault != nil
+}
+
+func (p *EventWrapper) GetEventMapDefault() map[ID]*Event {
+	if !p.IsSetEventMapDefault() {
+		return EventWrapper_EventMapDefault_DEFAULT
+	}
+	return *p.EventMapDefault
+}
+
+var EventWrapper_EventSetDefault_DEFAULT map[*Event]bool = map[*Event]bool{}
+
+func (p *EventWrapper) IsSetEventSetDefault() bool {
+	return p.EventSetDefault != nil
+}
+
+func (p *EventWrapper) GetEventSetDefault() map[*Event]bool {
+	if !p.IsSetEventSetDefault() {
+		return EventWrapper_EventSetDefault_DEFAULT
+	}
+	return *p.EventSetDefault
 }
 
 func (p *EventWrapper) Read(iprot thrift.TProtocol) error {
@@ -1337,6 +1379,64 @@ func (p *EventWrapper) Read(iprot thrift.TProtocol) error {
 			if err := iprot.ReadListEnd(); err != nil {
 				return thrift.PrependError("error reading list end: ", err)
 			}
+		case 14:
+			_, size, err := iprot.ReadListBegin()
+			if err != nil {
+				return thrift.PrependError("error reading list begin: ", err)
+			}
+			temp := make([]*Event, 0, size)
+			p.EventsDefault = &temp
+			for i := 0; i < size; i++ {
+				elem14 := NewEvent()
+				if err := elem14.Read(iprot); err != nil {
+					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem14), err)
+				}
+				*p.EventsDefault = append(*p.EventsDefault, elem14)
+			}
+			if err := iprot.ReadListEnd(); err != nil {
+				return thrift.PrependError("error reading list end: ", err)
+			}
+		case 15:
+			_, _, size, err := iprot.ReadMapBegin()
+			if err != nil {
+				return thrift.PrependError("error reading map begin: ", err)
+			}
+			temp := make(map[ID]*Event, size)
+			p.EventMapDefault = &temp
+			for i := 0; i < size; i++ {
+				var elem15 ID
+				if v, err := iprot.ReadI64(); err != nil {
+					return thrift.PrependError("error reading field 0: ", err)
+				} else {
+					temp := ID(v)
+					elem15 = temp
+				}
+				elem16 := NewEvent()
+				if err := elem16.Read(iprot); err != nil {
+					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem16), err)
+				}
+				(*p.EventMapDefault)[elem15] = elem16
+			}
+			if err := iprot.ReadMapEnd(); err != nil {
+				return thrift.PrependError("error reading map end: ", err)
+			}
+		case 16:
+			_, size, err := iprot.ReadSetBegin()
+			if err != nil {
+				return thrift.PrependError("error reading set begin: ", err)
+			}
+			temp := make(map[*Event]bool, size)
+			p.EventSetDefault = &temp
+			for i := 0; i < size; i++ {
+				elem17 := NewEvent()
+				if err := elem17.Read(iprot); err != nil {
+					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem17), err)
+				}
+				(*p.EventSetDefault)[elem17] = true
+			}
+			if err := iprot.ReadSetEnd(); err != nil {
+				return thrift.PrependError("error reading set end: ", err)
+			}
 		default:
 			if err := iprot.Skip(fieldTypeId); err != nil {
 				return err
@@ -1398,6 +1498,15 @@ func (p *EventWrapper) Write(oprot thrift.TProtocol) error {
 		return thrift.PrependError(fmt.Sprintf("%T::deprBinary:12 ", p), err)
 	}
 	if err := p.writeField13(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField14(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField15(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField16(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -1542,6 +1651,78 @@ func (p *EventWrapper) writeField13(oprot thrift.TProtocol) error {
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write field end error 13:deprList: ", p), err)
+	}
+	return nil
+}
+
+func (p *EventWrapper) writeField14(oprot thrift.TProtocol) error {
+	if p.IsSetEventsDefault() {
+		if err := oprot.WriteFieldBegin("EventsDefault", thrift.LIST, 14); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 14:EventsDefault: ", p), err)
+		}
+		if err := oprot.WriteListBegin(thrift.STRUCT, len(*p.EventsDefault)); err != nil {
+			return thrift.PrependError("error writing list begin: ", err)
+		}
+		for _, v := range *p.EventsDefault {
+			if err := v.Write(oprot); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+			}
+		}
+		if err := oprot.WriteListEnd(); err != nil {
+			return thrift.PrependError("error writing list end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 14:EventsDefault: ", p), err)
+		}
+	}
+	return nil
+}
+
+func (p *EventWrapper) writeField15(oprot thrift.TProtocol) error {
+	if p.IsSetEventMapDefault() {
+		if err := oprot.WriteFieldBegin("EventMapDefault", thrift.MAP, 15); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 15:EventMapDefault: ", p), err)
+		}
+		if err := oprot.WriteMapBegin(thrift.I64, thrift.STRUCT, len(*p.EventMapDefault)); err != nil {
+			return thrift.PrependError("error writing map begin: ", err)
+		}
+		for k, v := range *p.EventMapDefault {
+			if err := oprot.WriteI64(int64(k)); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+			}
+			if err := v.Write(oprot); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+			}
+		}
+		if err := oprot.WriteMapEnd(); err != nil {
+			return thrift.PrependError("error writing map end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 15:EventMapDefault: ", p), err)
+		}
+	}
+	return nil
+}
+
+func (p *EventWrapper) writeField16(oprot thrift.TProtocol) error {
+	if p.IsSetEventSetDefault() {
+		if err := oprot.WriteFieldBegin("EventSetDefault", thrift.SET, 16); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 16:EventSetDefault: ", p), err)
+		}
+		if err := oprot.WriteSetBegin(thrift.STRUCT, len(*p.EventSetDefault)); err != nil {
+			return thrift.PrependError("error writing set begin: ", err)
+		}
+		for v, _ := range *p.EventSetDefault {
+			if err := v.Write(oprot); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+			}
+		}
+		if err := oprot.WriteSetEnd(); err != nil {
+			return thrift.PrependError("error writing set end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 16:EventSetDefault: ", p), err)
+		}
 	}
 	return nil
 }
@@ -1824,20 +2005,20 @@ func (p *TestingUnions) Read(iprot thrift.TProtocol) error {
 			}
 			p.Requests = make(Request, size)
 			for i := 0; i < size; i++ {
-				var elem14 Int
+				var elem18 Int
 				if v, err := iprot.ReadI32(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := Int(v)
-					elem14 = temp
+					elem18 = temp
 				}
-				var elem15 string
+				var elem19 string
 				if v, err := iprot.ReadString(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
-					elem15 = v
+					elem19 = v
 				}
-				(p.Requests)[elem14] = elem15
+				(p.Requests)[elem18] = elem19
 			}
 			if err := iprot.ReadMapEnd(); err != nil {
 				return thrift.PrependError("error reading map end: ", err)

--- a/test/expected/go/variety/f_events_scope.txt
+++ b/test/expected/go/variety/f_events_scope.txt
@@ -447,25 +447,25 @@ func (l *eventsSubscriber) recvSomeList(op string, pf *frugal.FProtocolFactory, 
 			if err != nil {
 				return thrift.PrependError("error reading map begin: ", err)
 			}
-			elem21 := make(map[ID]*Event, size)
+			elem25 := make(map[ID]*Event, size)
 			for i := 0; i < size; i++ {
-				var elem22 ID
+				var elem26 ID
 				if v, err := iprot.ReadI64(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := ID(v)
-					elem22 = temp
+					elem26 = temp
 				}
-				elem23 := NewEvent()
-				if err := elem23.Read(iprot); err != nil {
-					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem23), err)
+				elem27 := NewEvent()
+				if err := elem27.Read(iprot); err != nil {
+					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem27), err)
 				}
-				(elem21)[elem22] = elem23
+				(elem25)[elem26] = elem27
 			}
 			if err := iprot.ReadMapEnd(); err != nil {
 				return thrift.PrependError("error reading map end: ", err)
 			}
-			req = append(req, elem21)
+			req = append(req, elem25)
 		}
 		if err := iprot.ReadListEnd(); err != nil {
 			return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/go/variety/f_foo_service.txt
+++ b/test/expected/go/variety/f_foo_service.txt
@@ -2589,20 +2589,20 @@ func (p *FooOneWayArgs) ReadField2(iprot thrift.TProtocol) error {
 	}
 	p.Req = make(Request, size)
 	for i := 0; i < size; i++ {
-		var elem16 Int
+		var elem20 Int
 		if v, err := iprot.ReadI32(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := Int(v)
-			elem16 = temp
+			elem20 = temp
 		}
-		var elem17 string
+		var elem21 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			elem17 = v
+			elem21 = v
 		}
-		(p.Req)[elem16] = elem17
+		(p.Req)[elem20] = elem21
 	}
 	if err := iprot.ReadMapEnd(); err != nil {
 		return thrift.PrependError("error reading map end: ", err)
@@ -3265,14 +3265,14 @@ func (p *FooUnderlyingTypesTestArgs) ReadField1(iprot thrift.TProtocol) error {
 	}
 	p.ListType = make([]ID, 0, size)
 	for i := 0; i < size; i++ {
-		var elem18 ID
+		var elem22 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem18 = temp
+			elem22 = temp
 		}
-		p.ListType = append(p.ListType, elem18)
+		p.ListType = append(p.ListType, elem22)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -3287,14 +3287,14 @@ func (p *FooUnderlyingTypesTestArgs) ReadField2(iprot thrift.TProtocol) error {
 	}
 	p.SetType = make(map[ID]bool, size)
 	for i := 0; i < size; i++ {
-		var elem19 ID
+		var elem23 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem19 = temp
+			elem23 = temp
 		}
-		(p.SetType)[elem19] = true
+		(p.SetType)[elem23] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -3428,14 +3428,14 @@ func (p *FooUnderlyingTypesTestResult) ReadField0(iprot thrift.TProtocol) error 
 	}
 	p.Success = make([]ID, 0, size)
 	for i := 0; i < size; i++ {
-		var elem20 ID
+		var elem24 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem20 = temp
+			elem24 = temp
 		}
-		p.Success = append(p.Success, elem20)
+		p.Success = append(p.Success, elem24)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/go/variety/f_types.txt
+++ b/test/expected/go/variety/f_types.txt
@@ -1520,7 +1520,10 @@ type EventWrapper struct {
 	// Deprecated: use something else
 	DeprBinary []byte `thrift:"deprBinary,12" db:"deprBinary" json:"deprBinary"`
 	// Deprecated: use something else
-	DeprList []bool `thrift:"deprList,13" db:"deprList" json:"deprList"`
+	DeprList        []bool           `thrift:"deprList,13" db:"deprList" json:"deprList"`
+	EventsDefault   *[]*Event        `thrift:"EventsDefault,14" db:"EventsDefault" json:"EventsDefault,omitempty"`
+	EventMapDefault *map[ID]*Event   `thrift:"EventMapDefault,15" db:"EventMapDefault" json:"EventMapDefault,omitempty"`
+	EventSetDefault *map[*Event]bool `thrift:"EventSetDefault,16" db:"EventSetDefault" json:"EventSetDefault,omitempty"`
 }
 
 func NewEventWrapper() *EventWrapper {
@@ -1606,6 +1609,45 @@ func (p *EventWrapper) GetDeprList() []bool {
 	return p.DeprList
 }
 
+var EventWrapper_EventsDefault_DEFAULT []*Event = []*Event{}
+
+func (p *EventWrapper) IsSetEventsDefault() bool {
+	return p.EventsDefault != nil
+}
+
+func (p *EventWrapper) GetEventsDefault() []*Event {
+	if !p.IsSetEventsDefault() {
+		return EventWrapper_EventsDefault_DEFAULT
+	}
+	return *p.EventsDefault
+}
+
+var EventWrapper_EventMapDefault_DEFAULT map[ID]*Event = map[ID]*Event{}
+
+func (p *EventWrapper) IsSetEventMapDefault() bool {
+	return p.EventMapDefault != nil
+}
+
+func (p *EventWrapper) GetEventMapDefault() map[ID]*Event {
+	if !p.IsSetEventMapDefault() {
+		return EventWrapper_EventMapDefault_DEFAULT
+	}
+	return *p.EventMapDefault
+}
+
+var EventWrapper_EventSetDefault_DEFAULT map[*Event]bool = map[*Event]bool{}
+
+func (p *EventWrapper) IsSetEventSetDefault() bool {
+	return p.EventSetDefault != nil
+}
+
+func (p *EventWrapper) GetEventSetDefault() map[*Event]bool {
+	if !p.IsSetEventSetDefault() {
+		return EventWrapper_EventSetDefault_DEFAULT
+	}
+	return *p.EventSetDefault
+}
+
 func (p *EventWrapper) Read(iprot thrift.TProtocol) error {
 	if _, err := iprot.ReadStructBegin(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
@@ -1673,6 +1715,18 @@ func (p *EventWrapper) Read(iprot thrift.TProtocol) error {
 			}
 		case 13:
 			if err := p.ReadField13(iprot); err != nil {
+				return err
+			}
+		case 14:
+			if err := p.ReadField14(iprot); err != nil {
+				return err
+			}
+		case 15:
+			if err := p.ReadField15(iprot); err != nil {
+				return err
+			}
+		case 16:
+			if err := p.ReadField16(iprot); err != nil {
 				return err
 			}
 		default:
@@ -1896,6 +1950,73 @@ func (p *EventWrapper) ReadField13(iprot thrift.TProtocol) error {
 	return nil
 }
 
+func (p *EventWrapper) ReadField14(iprot thrift.TProtocol) error {
+	_, size, err := iprot.ReadListBegin()
+	if err != nil {
+		return thrift.PrependError("error reading list begin: ", err)
+	}
+	temp := make([]*Event, 0, size)
+	p.EventsDefault = &temp
+	for i := 0; i < size; i++ {
+		elem14 := NewEvent()
+		if err := elem14.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem14), err)
+		}
+		*p.EventsDefault = append(*p.EventsDefault, elem14)
+	}
+	if err := iprot.ReadListEnd(); err != nil {
+		return thrift.PrependError("error reading list end: ", err)
+	}
+	return nil
+}
+
+func (p *EventWrapper) ReadField15(iprot thrift.TProtocol) error {
+	_, _, size, err := iprot.ReadMapBegin()
+	if err != nil {
+		return thrift.PrependError("error reading map begin: ", err)
+	}
+	temp := make(map[ID]*Event, size)
+	p.EventMapDefault = &temp
+	for i := 0; i < size; i++ {
+		var elem15 ID
+		if v, err := iprot.ReadI64(); err != nil {
+			return thrift.PrependError("error reading field 0: ", err)
+		} else {
+			temp := ID(v)
+			elem15 = temp
+		}
+		elem16 := NewEvent()
+		if err := elem16.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem16), err)
+		}
+		(*p.EventMapDefault)[elem15] = elem16
+	}
+	if err := iprot.ReadMapEnd(); err != nil {
+		return thrift.PrependError("error reading map end: ", err)
+	}
+	return nil
+}
+
+func (p *EventWrapper) ReadField16(iprot thrift.TProtocol) error {
+	_, size, err := iprot.ReadSetBegin()
+	if err != nil {
+		return thrift.PrependError("error reading set begin: ", err)
+	}
+	temp := make(map[*Event]bool, size)
+	p.EventSetDefault = &temp
+	for i := 0; i < size; i++ {
+		elem17 := NewEvent()
+		if err := elem17.Read(iprot); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem17), err)
+		}
+		(*p.EventSetDefault)[elem17] = true
+	}
+	if err := iprot.ReadSetEnd(); err != nil {
+		return thrift.PrependError("error reading set end: ", err)
+	}
+	return nil
+}
+
 func (p *EventWrapper) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("EventWrapper"); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
@@ -1937,6 +2058,15 @@ func (p *EventWrapper) Write(oprot thrift.TProtocol) error {
 		return err
 	}
 	if err := p.writeField13(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField14(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField15(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField16(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -2174,6 +2304,78 @@ func (p *EventWrapper) writeField13(oprot thrift.TProtocol) error {
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write field end error 13:deprList: ", p), err)
+	}
+	return nil
+}
+
+func (p *EventWrapper) writeField14(oprot thrift.TProtocol) error {
+	if p.IsSetEventsDefault() {
+		if err := oprot.WriteFieldBegin("EventsDefault", thrift.LIST, 14); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 14:EventsDefault: ", p), err)
+		}
+		if err := oprot.WriteListBegin(thrift.STRUCT, len(*p.EventsDefault)); err != nil {
+			return thrift.PrependError("error writing list begin: ", err)
+		}
+		for _, v := range *p.EventsDefault {
+			if err := v.Write(oprot); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+			}
+		}
+		if err := oprot.WriteListEnd(); err != nil {
+			return thrift.PrependError("error writing list end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 14:EventsDefault: ", p), err)
+		}
+	}
+	return nil
+}
+
+func (p *EventWrapper) writeField15(oprot thrift.TProtocol) error {
+	if p.IsSetEventMapDefault() {
+		if err := oprot.WriteFieldBegin("EventMapDefault", thrift.MAP, 15); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 15:EventMapDefault: ", p), err)
+		}
+		if err := oprot.WriteMapBegin(thrift.I64, thrift.STRUCT, len(*p.EventMapDefault)); err != nil {
+			return thrift.PrependError("error writing map begin: ", err)
+		}
+		for k, v := range *p.EventMapDefault {
+			if err := oprot.WriteI64(int64(k)); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+			}
+			if err := v.Write(oprot); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+			}
+		}
+		if err := oprot.WriteMapEnd(); err != nil {
+			return thrift.PrependError("error writing map end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 15:EventMapDefault: ", p), err)
+		}
+	}
+	return nil
+}
+
+func (p *EventWrapper) writeField16(oprot thrift.TProtocol) error {
+	if p.IsSetEventSetDefault() {
+		if err := oprot.WriteFieldBegin("EventSetDefault", thrift.SET, 16); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 16:EventSetDefault: ", p), err)
+		}
+		if err := oprot.WriteSetBegin(thrift.STRUCT, len(*p.EventSetDefault)); err != nil {
+			return thrift.PrependError("error writing set begin: ", err)
+		}
+		for v, _ := range *p.EventSetDefault {
+			if err := v.Write(oprot); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+			}
+		}
+		if err := oprot.WriteSetEnd(); err != nil {
+			return thrift.PrependError("error writing set end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 16:EventSetDefault: ", p), err)
+		}
 	}
 	return nil
 }
@@ -2574,20 +2776,20 @@ func (p *TestingUnions) ReadField5(iprot thrift.TProtocol) error {
 	}
 	p.Requests = make(Request, size)
 	for i := 0; i < size; i++ {
-		var elem14 Int
+		var elem18 Int
 		if v, err := iprot.ReadI32(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := Int(v)
-			elem14 = temp
+			elem18 = temp
 		}
-		var elem15 string
+		var elem19 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			elem15 = v
+			elem19 = v
 		}
-		(p.Requests)[elem14] = elem15
+		(p.Requests)[elem18] = elem19
 	}
 	if err := iprot.ReadMapEnd(); err != nil {
 		return thrift.PrependError("error reading map end: ", err)

--- a/test/expected/go/variety_async/f_foo_service.txt
+++ b/test/expected/go/variety_async/f_foo_service.txt
@@ -2748,20 +2748,20 @@ func (p *FooOneWayArgs) ReadField2(iprot thrift.TProtocol) error {
 	}
 	p.Req = make(Request, size)
 	for i := 0; i < size; i++ {
-		var elem16 Int
+		var elem20 Int
 		if v, err := iprot.ReadI32(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := Int(v)
-			elem16 = temp
+			elem20 = temp
 		}
-		var elem17 string
+		var elem21 string
 		if v, err := iprot.ReadString(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
-			elem17 = v
+			elem21 = v
 		}
-		(p.Req)[elem16] = elem17
+		(p.Req)[elem20] = elem21
 	}
 	if err := iprot.ReadMapEnd(); err != nil {
 		return thrift.PrependError("error reading map end: ", err)
@@ -3424,14 +3424,14 @@ func (p *FooUnderlyingTypesTestArgs) ReadField1(iprot thrift.TProtocol) error {
 	}
 	p.ListType = make([]ID, 0, size)
 	for i := 0; i < size; i++ {
-		var elem18 ID
+		var elem22 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem18 = temp
+			elem22 = temp
 		}
-		p.ListType = append(p.ListType, elem18)
+		p.ListType = append(p.ListType, elem22)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)
@@ -3446,14 +3446,14 @@ func (p *FooUnderlyingTypesTestArgs) ReadField2(iprot thrift.TProtocol) error {
 	}
 	p.SetType = make(map[ID]bool, size)
 	for i := 0; i < size; i++ {
-		var elem19 ID
+		var elem23 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem19 = temp
+			elem23 = temp
 		}
-		(p.SetType)[elem19] = true
+		(p.SetType)[elem23] = true
 	}
 	if err := iprot.ReadSetEnd(); err != nil {
 		return thrift.PrependError("error reading set end: ", err)
@@ -3587,14 +3587,14 @@ func (p *FooUnderlyingTypesTestResult) ReadField0(iprot thrift.TProtocol) error 
 	}
 	p.Success = make([]ID, 0, size)
 	for i := 0; i < size; i++ {
-		var elem20 ID
+		var elem24 ID
 		if v, err := iprot.ReadI64(); err != nil {
 			return thrift.PrependError("error reading field 0: ", err)
 		} else {
 			temp := ID(v)
-			elem20 = temp
+			elem24 = temp
 		}
-		p.Success = append(p.Success, elem20)
+		p.Success = append(p.Success, elem24)
 	}
 	if err := iprot.ReadListEnd(); err != nil {
 		return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/gopherjs/actual_base/golang/f_types.go
+++ b/test/expected/gopherjs/actual_base/golang/f_types.go
@@ -169,11 +169,11 @@ func (p *NestedThing) Read(iprot thrift.TProtocol) error {
 			}
 			p.Things = make([]*Thing, 0, size)
 			for i := 0; i < size; i++ {
-				elem24 := NewThing()
-				if err := elem24.Read(iprot); err != nil {
-					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem24), err)
+				elem28 := NewThing()
+				if err := elem28.Read(iprot); err != nil {
+					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem28), err)
 				}
-				p.Things = append(p.Things, elem24)
+				p.Things = append(p.Things, elem28)
 			}
 			if err := iprot.ReadListEnd(); err != nil {
 				return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/gopherjs/variety/f_events_scope.go
+++ b/test/expected/gopherjs/variety/f_events_scope.go
@@ -447,25 +447,25 @@ func (l *eventsSubscriber) recvSomeList(op string, pf *frugal.FProtocolFactory, 
 			if err != nil {
 				return thrift.PrependError("error reading map begin: ", err)
 			}
-			elem21 := make(map[ID]*Event, size)
+			elem25 := make(map[ID]*Event, size)
 			for i := 0; i < size; i++ {
-				var elem22 ID
+				var elem26 ID
 				if v, err := iprot.ReadI64(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := ID(v)
-					elem22 = temp
+					elem26 = temp
 				}
-				elem23 := NewEvent()
-				if err := elem23.Read(iprot); err != nil {
-					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem23), err)
+				elem27 := NewEvent()
+				if err := elem27.Read(iprot); err != nil {
+					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem27), err)
 				}
-				(elem21)[elem22] = elem23
+				(elem25)[elem26] = elem27
 			}
 			if err := iprot.ReadMapEnd(); err != nil {
 				return thrift.PrependError("error reading map end: ", err)
 			}
-			req = append(req, elem21)
+			req = append(req, elem25)
 		}
 		if err := iprot.ReadListEnd(); err != nil {
 			return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/gopherjs/variety/f_foo_service.go
+++ b/test/expected/gopherjs/variety/f_foo_service.go
@@ -2433,20 +2433,20 @@ func (p *FooOneWayArgs) Read(iprot thrift.TProtocol) error {
 			}
 			p.Req = make(Request, size)
 			for i := 0; i < size; i++ {
-				var elem16 Int
+				var elem20 Int
 				if v, err := iprot.ReadI32(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := Int(v)
-					elem16 = temp
+					elem20 = temp
 				}
-				var elem17 string
+				var elem21 string
 				if v, err := iprot.ReadString(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
-					elem17 = v
+					elem21 = v
 				}
-				(p.Req)[elem16] = elem17
+				(p.Req)[elem20] = elem21
 			}
 			if err := iprot.ReadMapEnd(); err != nil {
 				return thrift.PrependError("error reading map end: ", err)
@@ -2925,14 +2925,14 @@ func (p *FooUnderlyingTypesTestArgs) Read(iprot thrift.TProtocol) error {
 			}
 			p.ListType = make([]ID, 0, size)
 			for i := 0; i < size; i++ {
-				var elem18 ID
+				var elem22 ID
 				if v, err := iprot.ReadI64(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := ID(v)
-					elem18 = temp
+					elem22 = temp
 				}
-				p.ListType = append(p.ListType, elem18)
+				p.ListType = append(p.ListType, elem22)
 			}
 			if err := iprot.ReadListEnd(); err != nil {
 				return thrift.PrependError("error reading list end: ", err)
@@ -2944,14 +2944,14 @@ func (p *FooUnderlyingTypesTestArgs) Read(iprot thrift.TProtocol) error {
 			}
 			p.SetType = make(map[ID]bool, size)
 			for i := 0; i < size; i++ {
-				var elem19 ID
+				var elem23 ID
 				if v, err := iprot.ReadI64(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := ID(v)
-					elem19 = temp
+					elem23 = temp
 				}
-				(p.SetType)[elem19] = true
+				(p.SetType)[elem23] = true
 			}
 			if err := iprot.ReadSetEnd(); err != nil {
 				return thrift.PrependError("error reading set end: ", err)
@@ -3078,14 +3078,14 @@ func (p *FooUnderlyingTypesTestResult) Read(iprot thrift.TProtocol) error {
 			}
 			p.Success = make([]ID, 0, size)
 			for i := 0; i < size; i++ {
-				var elem20 ID
+				var elem24 ID
 				if v, err := iprot.ReadI64(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := ID(v)
-					elem20 = temp
+					elem24 = temp
 				}
-				p.Success = append(p.Success, elem20)
+				p.Success = append(p.Success, elem24)
 			}
 			if err := iprot.ReadListEnd(); err != nil {
 				return thrift.PrependError("error reading list end: ", err)

--- a/test/expected/gopherjs/variety/f_types.go
+++ b/test/expected/gopherjs/variety/f_types.go
@@ -1070,7 +1070,10 @@ type EventWrapper struct {
 	// Deprecated: use something else
 	DeprBinary []byte
 	// Deprecated: use something else
-	DeprList []bool
+	DeprList        []bool
+	EventsDefault   *[]*Event
+	EventMapDefault *map[ID]*Event
+	EventSetDefault *map[*Event]bool
 }
 
 func NewEventWrapper() *EventWrapper {
@@ -1154,6 +1157,45 @@ func (p *EventWrapper) GetDeprBinary() []byte {
 
 func (p *EventWrapper) GetDeprList() []bool {
 	return p.DeprList
+}
+
+var EventWrapper_EventsDefault_DEFAULT []*Event = []*Event{}
+
+func (p *EventWrapper) IsSetEventsDefault() bool {
+	return p.EventsDefault != nil
+}
+
+func (p *EventWrapper) GetEventsDefault() []*Event {
+	if !p.IsSetEventsDefault() {
+		return EventWrapper_EventsDefault_DEFAULT
+	}
+	return *p.EventsDefault
+}
+
+var EventWrapper_EventMapDefault_DEFAULT map[ID]*Event = map[ID]*Event{}
+
+func (p *EventWrapper) IsSetEventMapDefault() bool {
+	return p.EventMapDefault != nil
+}
+
+func (p *EventWrapper) GetEventMapDefault() map[ID]*Event {
+	if !p.IsSetEventMapDefault() {
+		return EventWrapper_EventMapDefault_DEFAULT
+	}
+	return *p.EventMapDefault
+}
+
+var EventWrapper_EventSetDefault_DEFAULT map[*Event]bool = map[*Event]bool{}
+
+func (p *EventWrapper) IsSetEventSetDefault() bool {
+	return p.EventSetDefault != nil
+}
+
+func (p *EventWrapper) GetEventSetDefault() map[*Event]bool {
+	if !p.IsSetEventSetDefault() {
+		return EventWrapper_EventSetDefault_DEFAULT
+	}
+	return *p.EventSetDefault
 }
 
 func (p *EventWrapper) Read(iprot thrift.TProtocol) error {
@@ -1337,6 +1379,64 @@ func (p *EventWrapper) Read(iprot thrift.TProtocol) error {
 			if err := iprot.ReadListEnd(); err != nil {
 				return thrift.PrependError("error reading list end: ", err)
 			}
+		case 14:
+			_, size, err := iprot.ReadListBegin()
+			if err != nil {
+				return thrift.PrependError("error reading list begin: ", err)
+			}
+			temp := make([]*Event, 0, size)
+			p.EventsDefault = &temp
+			for i := 0; i < size; i++ {
+				elem14 := NewEvent()
+				if err := elem14.Read(iprot); err != nil {
+					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem14), err)
+				}
+				*p.EventsDefault = append(*p.EventsDefault, elem14)
+			}
+			if err := iprot.ReadListEnd(); err != nil {
+				return thrift.PrependError("error reading list end: ", err)
+			}
+		case 15:
+			_, _, size, err := iprot.ReadMapBegin()
+			if err != nil {
+				return thrift.PrependError("error reading map begin: ", err)
+			}
+			temp := make(map[ID]*Event, size)
+			p.EventMapDefault = &temp
+			for i := 0; i < size; i++ {
+				var elem15 ID
+				if v, err := iprot.ReadI64(); err != nil {
+					return thrift.PrependError("error reading field 0: ", err)
+				} else {
+					temp := ID(v)
+					elem15 = temp
+				}
+				elem16 := NewEvent()
+				if err := elem16.Read(iprot); err != nil {
+					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem16), err)
+				}
+				(*p.EventMapDefault)[elem15] = elem16
+			}
+			if err := iprot.ReadMapEnd(); err != nil {
+				return thrift.PrependError("error reading map end: ", err)
+			}
+		case 16:
+			_, size, err := iprot.ReadSetBegin()
+			if err != nil {
+				return thrift.PrependError("error reading set begin: ", err)
+			}
+			temp := make(map[*Event]bool, size)
+			p.EventSetDefault = &temp
+			for i := 0; i < size; i++ {
+				elem17 := NewEvent()
+				if err := elem17.Read(iprot); err != nil {
+					return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", elem17), err)
+				}
+				(*p.EventSetDefault)[elem17] = true
+			}
+			if err := iprot.ReadSetEnd(); err != nil {
+				return thrift.PrependError("error reading set end: ", err)
+			}
 		default:
 			if err := iprot.Skip(fieldTypeId); err != nil {
 				return err
@@ -1398,6 +1498,15 @@ func (p *EventWrapper) Write(oprot thrift.TProtocol) error {
 		return thrift.PrependError(fmt.Sprintf("%T::deprBinary:12 ", p), err)
 	}
 	if err := p.writeField13(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField14(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField15(oprot); err != nil {
+		return err
+	}
+	if err := p.writeField16(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -1542,6 +1651,78 @@ func (p *EventWrapper) writeField13(oprot thrift.TProtocol) error {
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T write field end error 13:deprList: ", p), err)
+	}
+	return nil
+}
+
+func (p *EventWrapper) writeField14(oprot thrift.TProtocol) error {
+	if p.IsSetEventsDefault() {
+		if err := oprot.WriteFieldBegin("EventsDefault", thrift.LIST, 14); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 14:EventsDefault: ", p), err)
+		}
+		if err := oprot.WriteListBegin(thrift.STRUCT, len(*p.EventsDefault)); err != nil {
+			return thrift.PrependError("error writing list begin: ", err)
+		}
+		for _, v := range *p.EventsDefault {
+			if err := v.Write(oprot); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+			}
+		}
+		if err := oprot.WriteListEnd(); err != nil {
+			return thrift.PrependError("error writing list end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 14:EventsDefault: ", p), err)
+		}
+	}
+	return nil
+}
+
+func (p *EventWrapper) writeField15(oprot thrift.TProtocol) error {
+	if p.IsSetEventMapDefault() {
+		if err := oprot.WriteFieldBegin("EventMapDefault", thrift.MAP, 15); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 15:EventMapDefault: ", p), err)
+		}
+		if err := oprot.WriteMapBegin(thrift.I64, thrift.STRUCT, len(*p.EventMapDefault)); err != nil {
+			return thrift.PrependError("error writing map begin: ", err)
+		}
+		for k, v := range *p.EventMapDefault {
+			if err := oprot.WriteI64(int64(k)); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
+			}
+			if err := v.Write(oprot); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+			}
+		}
+		if err := oprot.WriteMapEnd(); err != nil {
+			return thrift.PrependError("error writing map end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 15:EventMapDefault: ", p), err)
+		}
+	}
+	return nil
+}
+
+func (p *EventWrapper) writeField16(oprot thrift.TProtocol) error {
+	if p.IsSetEventSetDefault() {
+		if err := oprot.WriteFieldBegin("EventSetDefault", thrift.SET, 16); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 16:EventSetDefault: ", p), err)
+		}
+		if err := oprot.WriteSetBegin(thrift.STRUCT, len(*p.EventSetDefault)); err != nil {
+			return thrift.PrependError("error writing set begin: ", err)
+		}
+		for v, _ := range *p.EventSetDefault {
+			if err := v.Write(oprot); err != nil {
+				return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", v), err)
+			}
+		}
+		if err := oprot.WriteSetEnd(); err != nil {
+			return thrift.PrependError("error writing set end: ", err)
+		}
+		if err := oprot.WriteFieldEnd(); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 16:EventSetDefault: ", p), err)
+		}
 	}
 	return nil
 }
@@ -1824,20 +2005,20 @@ func (p *TestingUnions) Read(iprot thrift.TProtocol) error {
 			}
 			p.Requests = make(Request, size)
 			for i := 0; i < size; i++ {
-				var elem14 Int
+				var elem18 Int
 				if v, err := iprot.ReadI32(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
 					temp := Int(v)
-					elem14 = temp
+					elem18 = temp
 				}
-				var elem15 string
+				var elem19 string
 				if v, err := iprot.ReadString(); err != nil {
 					return thrift.PrependError("error reading field 0: ", err)
 				} else {
-					elem15 = v
+					elem19 = v
 				}
-				(p.Requests)[elem14] = elem15
+				(p.Requests)[elem18] = elem19
 			}
 			if err := iprot.ReadMapEnd(); err != nil {
 				return thrift.PrependError("error reading map end: ", err)

--- a/test/expected/html/standalone/variety.html
+++ b/test/expected/html/standalone/variety.html
@@ -1060,6 +1060,33 @@ code { line-height: 20px; }
 						<td></td>
 					</tr>
 					
+					<tr>
+						<td>14</td>
+						<td>EventsDefault</td>
+						<td><code>list&lt;<a href="#struct_Event">Event</a>&gt;</code></td>
+						<td></td>
+						<td>optional</td>
+						<td></td>
+					</tr>
+					
+					<tr>
+						<td>15</td>
+						<td>EventMapDefault</td>
+						<td><code>map&lt;<a href="#typedef_id">id</a>, <a href="#struct_Event">Event</a>&gt;</code></td>
+						<td></td>
+						<td>optional</td>
+						<td></td>
+					</tr>
+					
+					<tr>
+						<td>16</td>
+						<td>EventSetDefault</td>
+						<td><code>set&lt;<a href="#struct_Event">Event</a>&gt;</code></td>
+						<td></td>
+						<td>optional</td>
+						<td></td>
+					</tr>
+					
 				</table>
 				<br />
 				

--- a/test/expected/html/variety.html
+++ b/test/expected/html/variety.html
@@ -875,6 +875,33 @@
 						<td></td>
 					</tr>
 					
+					<tr>
+						<td>14</td>
+						<td>EventsDefault</td>
+						<td><code>list&lt;<a href="#struct_Event">Event</a>&gt;</code></td>
+						<td></td>
+						<td>optional</td>
+						<td></td>
+					</tr>
+					
+					<tr>
+						<td>15</td>
+						<td>EventMapDefault</td>
+						<td><code>map&lt;<a href="#typedef_id">id</a>, <a href="#struct_Event">Event</a>&gt;</code></td>
+						<td></td>
+						<td>optional</td>
+						<td></td>
+					</tr>
+					
+					<tr>
+						<td>16</td>
+						<td>EventSetDefault</td>
+						<td><code>set&lt;<a href="#struct_Event">Event</a>&gt;</code></td>
+						<td></td>
+						<td>optional</td>
+						<td></td>
+					</tr>
+					
 				</table>
 				<br />
 				

--- a/test/expected/java/actual_base/nested_thing.java
+++ b/test/expected/java/actual_base/nested_thing.java
@@ -119,9 +119,9 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 	public nested_thing(nested_thing other) {
 		if (other.isSetThings()) {
 			this.things = new ArrayList<thing>(other.things.size());
-			for (thing elem333 : other.things) {
-				thing elem334 = new thing(elem333);
-				this.things.add(elem334);
+			for (thing elem368 : other.things) {
+				thing elem369 = new thing(elem368);
+				this.things.add(elem369);
 			}
 		}
 	}
@@ -337,12 +337,12 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 				switch (schemeField.id) {
 					case 1: // THINGS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem335 = iprot.readListBegin();
-							struct.things = new ArrayList<thing>(elem335.size);
-							for (int elem336 = 0; elem336 < elem335.size; ++elem336) {
-								thing elem337 = new thing();
-								elem337.read(iprot);
-								struct.things.add(elem337);
+							org.apache.thrift.protocol.TList elem370 = iprot.readListBegin();
+							struct.things = new ArrayList<thing>(elem370.size);
+							for (int elem371 = 0; elem371 < elem370.size; ++elem371) {
+								thing elem372 = new thing();
+								elem372.read(iprot);
+								struct.things.add(elem372);
 							}
 							iprot.readListEnd();
 							struct.setThingsIsSet(true);
@@ -368,8 +368,8 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 			if (struct.things != null) {
 				oprot.writeFieldBegin(THINGS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.things.size()));
-				for (thing elem338 : struct.things) {
-					elem338.write(oprot);
+				for (thing elem373 : struct.things) {
+					elem373.write(oprot);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -398,8 +398,8 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 			oprot.writeBitSet(optionals, 1);
 			if (struct.isSetThings()) {
 				oprot.writeI32(struct.things.size());
-				for (thing elem339 : struct.things) {
-					elem339.write(oprot);
+				for (thing elem374 : struct.things) {
+					elem374.write(oprot);
 				}
 			}
 		}
@@ -409,12 +409,12 @@ public class nested_thing implements org.apache.thrift.TBase<nested_thing, neste
 			TTupleProtocol iprot = (TTupleProtocol) prot;
 			BitSet incoming = iprot.readBitSet(1);
 			if (incoming.get(0)) {
-				org.apache.thrift.protocol.TList elem340 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-				struct.things = new ArrayList<thing>(elem340.size);
-				for (int elem341 = 0; elem341 < elem340.size; ++elem341) {
-					thing elem342 = new thing();
-					elem342.read(iprot);
-					struct.things.add(elem342);
+				org.apache.thrift.protocol.TList elem375 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+				struct.things = new ArrayList<thing>(elem375.size);
+				for (int elem376 = 0; elem376 < elem375.size; ++elem376) {
+					thing elem377 = new thing();
+					elem377.read(iprot);
+					struct.things.add(elem377);
 				}
 				struct.setThingsIsSet(true);
 			}

--- a/test/expected/java/actual_base/thing.java
+++ b/test/expected/java/actual_base/thing.java
@@ -428,13 +428,13 @@ public class thing implements org.apache.thrift.TBase<thing, thing._Fields>, jav
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(AN_ID_FIELD_DESC);
-			int elem329 = struct.an_id;
-			oprot.writeI32(elem329);
+			int elem364 = struct.an_id;
+			oprot.writeI32(elem364);
 			oprot.writeFieldEnd();
 			if (struct.a_string != null) {
 				oprot.writeFieldBegin(A_STRING_FIELD_DESC);
-				String elem330 = struct.a_string;
-				oprot.writeString(elem330);
+				String elem365 = struct.a_string;
+				oprot.writeString(elem365);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -463,12 +463,12 @@ public class thing implements org.apache.thrift.TBase<thing, thing._Fields>, jav
 			}
 			oprot.writeBitSet(optionals, 2);
 			if (struct.isSetAn_id()) {
-				int elem331 = struct.an_id;
-				oprot.writeI32(elem331);
+				int elem366 = struct.an_id;
+				oprot.writeI32(elem366);
 			}
 			if (struct.isSetA_string()) {
-				String elem332 = struct.a_string;
-				oprot.writeString(elem332);
+				String elem367 = struct.a_string;
+				oprot.writeString(elem367);
 			}
 		}
 

--- a/test/expected/java/boxed_primitives/FFoo.java
+++ b/test/expected/java/boxed_primitives/FFoo.java
@@ -2203,16 +2203,16 @@ public class FFoo {
 
 				oprot.writeStructBegin(STRUCT_DESC);
 				oprot.writeFieldBegin(NUM_FIELD_DESC);
-				Integer elem222 = struct.num;
-				if (elem222 == null) {
-					elem222 = 0;
+				Integer elem257 = struct.num;
+				if (elem257 == null) {
+					elem257 = 0;
 				}
-				oprot.writeI32(elem222);
+				oprot.writeI32(elem257);
 				oprot.writeFieldEnd();
 				if (struct.Str != null) {
 					oprot.writeFieldBegin(STR_FIELD_DESC);
-					String elem223 = struct.Str;
-					oprot.writeString(elem223);
+					String elem258 = struct.Str;
+					oprot.writeString(elem258);
 					oprot.writeFieldEnd();
 				}
 				if (struct.event != null) {
@@ -2249,15 +2249,15 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 3);
 				if (struct.isSetNum()) {
-					Integer elem224 = struct.num;
-					if (elem224 == null) {
-						elem224 = 0;
+					Integer elem259 = struct.num;
+					if (elem259 == null) {
+						elem259 = 0;
 					}
-					oprot.writeI32(elem224);
+					oprot.writeI32(elem259);
 				}
 				if (struct.isSetStr()) {
-					String elem225 = struct.Str;
-					oprot.writeString(elem225);
+					String elem260 = struct.Str;
+					oprot.writeString(elem260);
 				}
 				if (struct.isSetEvent()) {
 					struct.event.write(oprot);
@@ -2782,11 +2782,11 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.isSetSuccess()) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					Long elem226 = struct.success;
-					if (elem226 == null) {
-						elem226 = 0L;
+					Long elem261 = struct.success;
+					if (elem261 == null) {
+						elem261 = 0L;
 					}
-					oprot.writeI64(elem226);
+					oprot.writeI64(elem261);
 					oprot.writeFieldEnd();
 				}
 				if (struct.awe != null) {
@@ -2828,11 +2828,11 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 3);
 				if (struct.isSetSuccess()) {
-					Long elem227 = struct.success;
-					if (elem227 == null) {
-						elem227 = 0L;
+					Long elem262 = struct.success;
+					if (elem262 == null) {
+						elem262 = 0L;
 					}
-					oprot.writeI64(elem227);
+					oprot.writeI64(elem262);
 				}
 				if (struct.isSetAwe()) {
 					struct.awe.write(oprot);
@@ -2963,10 +2963,10 @@ public class FFoo {
 			}
 			if (other.isSetReq()) {
 				this.req = new HashMap<Integer,String>(other.req.size());
-				for (Map.Entry<Integer, String> elem228 : other.req.entrySet()) {
-					Integer elem230 = elem228.getKey();
-					String elem229 = elem228.getValue();
-					this.req.put(elem230, elem229);
+				for (Map.Entry<Integer, String> elem263 : other.req.entrySet()) {
+					Integer elem265 = elem263.getKey();
+					String elem264 = elem263.getValue();
+					this.req.put(elem265, elem264);
 				}
 			}
 		}
@@ -3257,12 +3257,12 @@ public class FFoo {
 							break;
 						case 2: // REQ
 							if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
-								org.apache.thrift.protocol.TMap elem231 = iprot.readMapBegin();
-								struct.req = new HashMap<Integer,String>(2*elem231.size);
-								for (int elem232 = 0; elem232 < elem231.size; ++elem232) {
-									Integer elem234 = iprot.readI32();
-									String elem233 = iprot.readString();
-									struct.req.put(elem234, elem233);
+								org.apache.thrift.protocol.TMap elem266 = iprot.readMapBegin();
+								struct.req = new HashMap<Integer,String>(2*elem266.size);
+								for (int elem267 = 0; elem267 < elem266.size; ++elem267) {
+									Integer elem269 = iprot.readI32();
+									String elem268 = iprot.readString();
+									struct.req.put(elem269, elem268);
 								}
 								iprot.readMapEnd();
 								struct.setReqIsSet(true);
@@ -3286,23 +3286,23 @@ public class FFoo {
 
 				oprot.writeStructBegin(STRUCT_DESC);
 				oprot.writeFieldBegin(ID_FIELD_DESC);
-				Long elem235 = struct.id;
-				if (elem235 == null) {
-					elem235 = 0L;
+				Long elem270 = struct.id;
+				if (elem270 == null) {
+					elem270 = 0L;
 				}
-				oprot.writeI64(elem235);
+				oprot.writeI64(elem270);
 				oprot.writeFieldEnd();
 				if (struct.req != null) {
 					oprot.writeFieldBegin(REQ_FIELD_DESC);
 					oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, struct.req.size()));
-					for (Map.Entry<Integer, String> elem236 : struct.req.entrySet()) {
-						Integer elem237 = elem236.getKey();
-						if (elem237 == null) {
-							elem237 = 0;
+					for (Map.Entry<Integer, String> elem271 : struct.req.entrySet()) {
+						Integer elem272 = elem271.getKey();
+						if (elem272 == null) {
+							elem272 = 0;
 						}
-						oprot.writeI32(elem237);
-						String elem238 = elem236.getValue();
-						oprot.writeString(elem238);
+						oprot.writeI32(elem272);
+						String elem273 = elem271.getValue();
+						oprot.writeString(elem273);
 					}
 					oprot.writeMapEnd();
 					oprot.writeFieldEnd();
@@ -3333,22 +3333,22 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetId()) {
-					Long elem239 = struct.id;
-					if (elem239 == null) {
-						elem239 = 0L;
+					Long elem274 = struct.id;
+					if (elem274 == null) {
+						elem274 = 0L;
 					}
-					oprot.writeI64(elem239);
+					oprot.writeI64(elem274);
 				}
 				if (struct.isSetReq()) {
 					oprot.writeI32(struct.req.size());
-					for (Map.Entry<Integer, String> elem240 : struct.req.entrySet()) {
-						Integer elem241 = elem240.getKey();
-						if (elem241 == null) {
-							elem241 = 0;
+					for (Map.Entry<Integer, String> elem275 : struct.req.entrySet()) {
+						Integer elem276 = elem275.getKey();
+						if (elem276 == null) {
+							elem276 = 0;
 						}
-						oprot.writeI32(elem241);
-						String elem242 = elem240.getValue();
-						oprot.writeString(elem242);
+						oprot.writeI32(elem276);
+						String elem277 = elem275.getValue();
+						oprot.writeString(elem277);
 					}
 				}
 			}
@@ -3362,12 +3362,12 @@ public class FFoo {
 					struct.setIdIsSet(true);
 				}
 				if (incoming.get(1)) {
-					org.apache.thrift.protocol.TMap elem243 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-					struct.req = new HashMap<Integer,String>(2*elem243.size);
-					for (int elem244 = 0; elem244 < elem243.size; ++elem244) {
-						Integer elem246 = iprot.readI32();
-						String elem245 = iprot.readString();
-						struct.req.put(elem246, elem245);
+					org.apache.thrift.protocol.TMap elem278 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+					struct.req = new HashMap<Integer,String>(2*elem278.size);
+					for (int elem279 = 0; elem279 < elem278.size; ++elem279) {
+						Integer elem281 = iprot.readI32();
+						String elem280 = iprot.readString();
+						struct.req.put(elem281, elem280);
 					}
 					struct.setReqIsSet(true);
 				}
@@ -3785,14 +3785,14 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.bin != null) {
 					oprot.writeFieldBegin(BIN_FIELD_DESC);
-					java.nio.ByteBuffer elem247 = struct.bin;
-					oprot.writeBinary(elem247);
+					java.nio.ByteBuffer elem282 = struct.bin;
+					oprot.writeBinary(elem282);
 					oprot.writeFieldEnd();
 				}
 				if (struct.Str != null) {
 					oprot.writeFieldBegin(STR_FIELD_DESC);
-					String elem248 = struct.Str;
-					oprot.writeString(elem248);
+					String elem283 = struct.Str;
+					oprot.writeString(elem283);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -3821,12 +3821,12 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetBin()) {
-					java.nio.ByteBuffer elem249 = struct.bin;
-					oprot.writeBinary(elem249);
+					java.nio.ByteBuffer elem284 = struct.bin;
+					oprot.writeBinary(elem284);
 				}
 				if (struct.isSetStr()) {
-					String elem250 = struct.Str;
-					oprot.writeString(elem250);
+					String elem285 = struct.Str;
+					oprot.writeString(elem285);
 				}
 			}
 
@@ -4260,8 +4260,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					java.nio.ByteBuffer elem251 = struct.success;
-					oprot.writeBinary(elem251);
+					java.nio.ByteBuffer elem286 = struct.success;
+					oprot.writeBinary(elem286);
 					oprot.writeFieldEnd();
 				}
 				if (struct.api != null) {
@@ -4295,8 +4295,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetSuccess()) {
-					java.nio.ByteBuffer elem252 = struct.success;
-					oprot.writeBinary(elem252);
+					java.nio.ByteBuffer elem287 = struct.success;
+					oprot.writeBinary(elem287);
 				}
 				if (struct.isSetApi()) {
 					struct.api.write(oprot);
@@ -4811,25 +4811,25 @@ public class FFoo {
 
 				oprot.writeStructBegin(STRUCT_DESC);
 				oprot.writeFieldBegin(OPT_NUM_FIELD_DESC);
-				Integer elem253 = struct.opt_num;
-				if (elem253 == null) {
-					elem253 = 0;
+				Integer elem288 = struct.opt_num;
+				if (elem288 == null) {
+					elem288 = 0;
 				}
-				oprot.writeI32(elem253);
+				oprot.writeI32(elem288);
 				oprot.writeFieldEnd();
 				oprot.writeFieldBegin(DEFAULT_NUM_FIELD_DESC);
-				Integer elem254 = struct.default_num;
-				if (elem254 == null) {
-					elem254 = 0;
+				Integer elem289 = struct.default_num;
+				if (elem289 == null) {
+					elem289 = 0;
 				}
-				oprot.writeI32(elem254);
+				oprot.writeI32(elem289);
 				oprot.writeFieldEnd();
 				oprot.writeFieldBegin(REQ_NUM_FIELD_DESC);
-				Integer elem255 = struct.req_num;
-				if (elem255 == null) {
-					elem255 = 0;
+				Integer elem290 = struct.req_num;
+				if (elem290 == null) {
+					elem290 = 0;
 				}
-				oprot.writeI32(elem255);
+				oprot.writeI32(elem290);
 				oprot.writeFieldEnd();
 				oprot.writeFieldStop();
 				oprot.writeStructEnd();
@@ -4848,11 +4848,11 @@ public class FFoo {
 			@Override
 			public void write(org.apache.thrift.protocol.TProtocol prot, param_modifiers_args struct) throws org.apache.thrift.TException {
 				TTupleProtocol oprot = (TTupleProtocol) prot;
-				Integer elem256 = struct.req_num;
-				if (elem256 == null) {
-					elem256 = 0;
+				Integer elem291 = struct.req_num;
+				if (elem291 == null) {
+					elem291 = 0;
 				}
-				oprot.writeI32(elem256);
+				oprot.writeI32(elem291);
 				BitSet optionals = new BitSet();
 				if (struct.isSetOpt_num()) {
 					optionals.set(0);
@@ -4862,18 +4862,18 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetOpt_num()) {
-					Integer elem257 = struct.opt_num;
-					if (elem257 == null) {
-						elem257 = 0;
+					Integer elem292 = struct.opt_num;
+					if (elem292 == null) {
+						elem292 = 0;
 					}
-					oprot.writeI32(elem257);
+					oprot.writeI32(elem292);
 				}
 				if (struct.isSetDefault_num()) {
-					Integer elem258 = struct.default_num;
-					if (elem258 == null) {
-						elem258 = 0;
+					Integer elem293 = struct.default_num;
+					if (elem293 == null) {
+						elem293 = 0;
 					}
-					oprot.writeI32(elem258);
+					oprot.writeI32(elem293);
 				}
 			}
 
@@ -5206,11 +5206,11 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.isSetSuccess()) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					Long elem259 = struct.success;
-					if (elem259 == null) {
-						elem259 = 0L;
+					Long elem294 = struct.success;
+					if (elem294 == null) {
+						elem294 = 0L;
 					}
-					oprot.writeI64(elem259);
+					oprot.writeI64(elem294);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -5236,11 +5236,11 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					Long elem260 = struct.success;
-					if (elem260 == null) {
-						elem260 = 0L;
+					Long elem295 = struct.success;
+					if (elem295 == null) {
+						elem295 = 0L;
 					}
-					oprot.writeI64(elem260);
+					oprot.writeI64(elem295);
 				}
 			}
 
@@ -5352,16 +5352,16 @@ public class FFoo {
 		public underlying_types_test_args(underlying_types_test_args other) {
 			if (other.isSetList_type()) {
 				this.list_type = new ArrayList<Long>(other.list_type.size());
-				for (Long elem261 : other.list_type) {
-					Long elem262 = elem261;
-					this.list_type.add(elem262);
+				for (Long elem296 : other.list_type) {
+					Long elem297 = elem296;
+					this.list_type.add(elem297);
 				}
 			}
 			if (other.isSetSet_type()) {
 				this.set_type = new HashSet<Long>(other.set_type.size());
-				for (Long elem263 : other.set_type) {
-					Long elem264 = elem263;
-					this.set_type.add(elem264);
+				for (Long elem298 : other.set_type) {
+					Long elem299 = elem298;
+					this.set_type.add(elem299);
 				}
 			}
 		}
@@ -5663,11 +5663,11 @@ public class FFoo {
 					switch (schemeField.id) {
 						case 1: // LIST_TYPE
 							if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-								org.apache.thrift.protocol.TList elem265 = iprot.readListBegin();
-								struct.list_type = new ArrayList<Long>(elem265.size);
-								for (int elem266 = 0; elem266 < elem265.size; ++elem266) {
-									Long elem267 = iprot.readI64();
-									struct.list_type.add(elem267);
+								org.apache.thrift.protocol.TList elem300 = iprot.readListBegin();
+								struct.list_type = new ArrayList<Long>(elem300.size);
+								for (int elem301 = 0; elem301 < elem300.size; ++elem301) {
+									Long elem302 = iprot.readI64();
+									struct.list_type.add(elem302);
 								}
 								iprot.readListEnd();
 								struct.setList_typeIsSet(true);
@@ -5677,11 +5677,11 @@ public class FFoo {
 							break;
 						case 2: // SET_TYPE
 							if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
-								org.apache.thrift.protocol.TSet elem268 = iprot.readSetBegin();
-								struct.set_type = new HashSet<Long>(2*elem268.size);
-								for (int elem269 = 0; elem269 < elem268.size; ++elem269) {
-									Long elem270 = iprot.readI64();
-									struct.set_type.add(elem270);
+								org.apache.thrift.protocol.TSet elem303 = iprot.readSetBegin();
+								struct.set_type = new HashSet<Long>(2*elem303.size);
+								for (int elem304 = 0; elem304 < elem303.size; ++elem304) {
+									Long elem305 = iprot.readI64();
+									struct.set_type.add(elem305);
 								}
 								iprot.readSetEnd();
 								struct.setSet_typeIsSet(true);
@@ -5707,12 +5707,12 @@ public class FFoo {
 				if (struct.list_type != null) {
 					oprot.writeFieldBegin(LIST_TYPE_FIELD_DESC);
 					oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.list_type.size()));
-					for (Long elem271 : struct.list_type) {
-						Long elem272 = elem271;
-						if (elem272 == null) {
-							elem272 = 0L;
+					for (Long elem306 : struct.list_type) {
+						Long elem307 = elem306;
+						if (elem307 == null) {
+							elem307 = 0L;
 						}
-						oprot.writeI64(elem272);
+						oprot.writeI64(elem307);
 					}
 					oprot.writeListEnd();
 					oprot.writeFieldEnd();
@@ -5720,12 +5720,12 @@ public class FFoo {
 				if (struct.set_type != null) {
 					oprot.writeFieldBegin(SET_TYPE_FIELD_DESC);
 					oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, struct.set_type.size()));
-					for (Long elem273 : struct.set_type) {
-						Long elem274 = elem273;
-						if (elem274 == null) {
-							elem274 = 0L;
+					for (Long elem308 : struct.set_type) {
+						Long elem309 = elem308;
+						if (elem309 == null) {
+							elem309 = 0L;
 						}
-						oprot.writeI64(elem274);
+						oprot.writeI64(elem309);
 					}
 					oprot.writeSetEnd();
 					oprot.writeFieldEnd();
@@ -5757,22 +5757,22 @@ public class FFoo {
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetList_type()) {
 					oprot.writeI32(struct.list_type.size());
-					for (Long elem275 : struct.list_type) {
-						Long elem276 = elem275;
-						if (elem276 == null) {
-							elem276 = 0L;
+					for (Long elem310 : struct.list_type) {
+						Long elem311 = elem310;
+						if (elem311 == null) {
+							elem311 = 0L;
 						}
-						oprot.writeI64(elem276);
+						oprot.writeI64(elem311);
 					}
 				}
 				if (struct.isSetSet_type()) {
 					oprot.writeI32(struct.set_type.size());
-					for (Long elem277 : struct.set_type) {
-						Long elem278 = elem277;
-						if (elem278 == null) {
-							elem278 = 0L;
+					for (Long elem312 : struct.set_type) {
+						Long elem313 = elem312;
+						if (elem313 == null) {
+							elem313 = 0L;
 						}
-						oprot.writeI64(elem278);
+						oprot.writeI64(elem313);
 					}
 				}
 			}
@@ -5782,20 +5782,20 @@ public class FFoo {
 				TTupleProtocol iprot = (TTupleProtocol) prot;
 				BitSet incoming = iprot.readBitSet(2);
 				if (incoming.get(0)) {
-					org.apache.thrift.protocol.TList elem279 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-					struct.list_type = new ArrayList<Long>(elem279.size);
-					for (int elem280 = 0; elem280 < elem279.size; ++elem280) {
-						Long elem281 = iprot.readI64();
-						struct.list_type.add(elem281);
+					org.apache.thrift.protocol.TList elem314 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+					struct.list_type = new ArrayList<Long>(elem314.size);
+					for (int elem315 = 0; elem315 < elem314.size; ++elem315) {
+						Long elem316 = iprot.readI64();
+						struct.list_type.add(elem316);
 					}
 					struct.setList_typeIsSet(true);
 				}
 				if (incoming.get(1)) {
-					org.apache.thrift.protocol.TSet elem282 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-					struct.set_type = new HashSet<Long>(2*elem282.size);
-					for (int elem283 = 0; elem283 < elem282.size; ++elem283) {
-						Long elem284 = iprot.readI64();
-						struct.set_type.add(elem284);
+					org.apache.thrift.protocol.TSet elem317 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+					struct.set_type = new HashSet<Long>(2*elem317.size);
+					for (int elem318 = 0; elem318 < elem317.size; ++elem318) {
+						Long elem319 = iprot.readI64();
+						struct.set_type.add(elem319);
 					}
 					struct.setSet_typeIsSet(true);
 				}
@@ -5892,9 +5892,9 @@ public class FFoo {
 		public underlying_types_test_result(underlying_types_test_result other) {
 			if (other.isSetSuccess()) {
 				this.success = new ArrayList<Long>(other.success.size());
-				for (Long elem285 : other.success) {
-					Long elem286 = elem285;
-					this.success.add(elem286);
+				for (Long elem320 : other.success) {
+					Long elem321 = elem320;
+					this.success.add(elem321);
 				}
 			}
 		}
@@ -6110,11 +6110,11 @@ public class FFoo {
 					switch (schemeField.id) {
 						case 0: // SUCCESS
 							if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-								org.apache.thrift.protocol.TList elem287 = iprot.readListBegin();
-								struct.success = new ArrayList<Long>(elem287.size);
-								for (int elem288 = 0; elem288 < elem287.size; ++elem288) {
-									Long elem289 = iprot.readI64();
-									struct.success.add(elem289);
+								org.apache.thrift.protocol.TList elem322 = iprot.readListBegin();
+								struct.success = new ArrayList<Long>(elem322.size);
+								for (int elem323 = 0; elem323 < elem322.size; ++elem323) {
+									Long elem324 = iprot.readI64();
+									struct.success.add(elem324);
 								}
 								iprot.readListEnd();
 								struct.setSuccessIsSet(true);
@@ -6140,12 +6140,12 @@ public class FFoo {
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
 					oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.success.size()));
-					for (Long elem290 : struct.success) {
-						Long elem291 = elem290;
-						if (elem291 == null) {
-							elem291 = 0L;
+					for (Long elem325 : struct.success) {
+						Long elem326 = elem325;
+						if (elem326 == null) {
+							elem326 = 0L;
 						}
-						oprot.writeI64(elem291);
+						oprot.writeI64(elem326);
 					}
 					oprot.writeListEnd();
 					oprot.writeFieldEnd();
@@ -6174,12 +6174,12 @@ public class FFoo {
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
 					oprot.writeI32(struct.success.size());
-					for (Long elem292 : struct.success) {
-						Long elem293 = elem292;
-						if (elem293 == null) {
-							elem293 = 0L;
+					for (Long elem327 : struct.success) {
+						Long elem328 = elem327;
+						if (elem328 == null) {
+							elem328 = 0L;
 						}
-						oprot.writeI64(elem293);
+						oprot.writeI64(elem328);
 					}
 				}
 			}
@@ -6189,11 +6189,11 @@ public class FFoo {
 				TTupleProtocol iprot = (TTupleProtocol) prot;
 				BitSet incoming = iprot.readBitSet(1);
 				if (incoming.get(0)) {
-					org.apache.thrift.protocol.TList elem294 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-					struct.success = new ArrayList<Long>(elem294.size);
-					for (int elem295 = 0; elem295 < elem294.size; ++elem295) {
-						Long elem296 = iprot.readI64();
-						struct.success.add(elem296);
+					org.apache.thrift.protocol.TList elem329 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+					struct.success = new ArrayList<Long>(elem329.size);
+					for (int elem330 = 0; elem330 < elem329.size; ++elem330) {
+						Long elem331 = iprot.readI64();
+						struct.success.add(elem331);
 					}
 					struct.setSuccessIsSet(true);
 				}
@@ -7356,11 +7356,11 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.isSetSuccess()) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					Integer elem297 = struct.success;
-					if (elem297 == null) {
-						elem297 = 0;
+					Integer elem332 = struct.success;
+					if (elem332 == null) {
+						elem332 = 0;
 					}
-					oprot.writeI32(elem297);
+					oprot.writeI32(elem332);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -7386,11 +7386,11 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					Integer elem298 = struct.success;
-					if (elem298 == null) {
-						elem298 = 0;
+					Integer elem333 = struct.success;
+					if (elem333 == null) {
+						elem333 = 0;
 					}
-					oprot.writeI32(elem298);
+					oprot.writeI32(elem333);
 				}
 			}
 
@@ -8433,8 +8433,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.newMessage != null) {
 					oprot.writeFieldBegin(NEW_MESSAGE_FIELD_DESC);
-					String elem299 = struct.newMessage;
-					oprot.writeString(elem299);
+					String elem334 = struct.newMessage;
+					oprot.writeString(elem334);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -8460,8 +8460,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetNewMessage()) {
-					String elem300 = struct.newMessage;
-					oprot.writeString(elem300);
+					String elem335 = struct.newMessage;
+					oprot.writeString(elem335);
 				}
 			}
 
@@ -8788,8 +8788,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					String elem301 = struct.success;
-					oprot.writeString(elem301);
+					String elem336 = struct.success;
+					oprot.writeString(elem336);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -8815,8 +8815,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					String elem302 = struct.success;
-					oprot.writeString(elem302);
+					String elem337 = struct.success;
+					oprot.writeString(elem337);
 				}
 			}
 
@@ -9143,8 +9143,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.messageArgs != null) {
 					oprot.writeFieldBegin(MESSAGE_ARGS_FIELD_DESC);
-					String elem303 = struct.messageArgs;
-					oprot.writeString(elem303);
+					String elem338 = struct.messageArgs;
+					oprot.writeString(elem338);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -9170,8 +9170,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetMessageArgs()) {
-					String elem304 = struct.messageArgs;
-					oprot.writeString(elem304);
+					String elem339 = struct.messageArgs;
+					oprot.writeString(elem339);
 				}
 			}
 
@@ -9498,8 +9498,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					String elem305 = struct.success;
-					oprot.writeString(elem305);
+					String elem340 = struct.success;
+					oprot.writeString(elem340);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -9525,8 +9525,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					String elem306 = struct.success;
-					oprot.writeString(elem306);
+					String elem341 = struct.success;
+					oprot.writeString(elem341);
 				}
 			}
 
@@ -9853,8 +9853,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.messageResult != null) {
 					oprot.writeFieldBegin(MESSAGE_RESULT_FIELD_DESC);
-					String elem307 = struct.messageResult;
-					oprot.writeString(elem307);
+					String elem342 = struct.messageResult;
+					oprot.writeString(elem342);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -9880,8 +9880,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetMessageResult()) {
-					String elem308 = struct.messageResult;
-					oprot.writeString(elem308);
+					String elem343 = struct.messageResult;
+					oprot.writeString(elem343);
 				}
 			}
 
@@ -10208,8 +10208,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					String elem309 = struct.success;
-					oprot.writeString(elem309);
+					String elem344 = struct.success;
+					oprot.writeString(elem344);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -10235,8 +10235,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					String elem310 = struct.success;
-					oprot.writeString(elem310);
+					String elem345 = struct.success;
+					oprot.writeString(elem345);
 				}
 			}
 

--- a/test/expected/java/deprecated_logging/FFoo.java
+++ b/test/expected/java/deprecated_logging/FFoo.java
@@ -2200,13 +2200,13 @@ public class FFoo {
 
 				oprot.writeStructBegin(STRUCT_DESC);
 				oprot.writeFieldBegin(NUM_FIELD_DESC);
-				int elem222 = struct.num;
-				oprot.writeI32(elem222);
+				int elem257 = struct.num;
+				oprot.writeI32(elem257);
 				oprot.writeFieldEnd();
 				if (struct.Str != null) {
 					oprot.writeFieldBegin(STR_FIELD_DESC);
-					String elem223 = struct.Str;
-					oprot.writeString(elem223);
+					String elem258 = struct.Str;
+					oprot.writeString(elem258);
 					oprot.writeFieldEnd();
 				}
 				if (struct.event != null) {
@@ -2243,12 +2243,12 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 3);
 				if (struct.isSetNum()) {
-					int elem224 = struct.num;
-					oprot.writeI32(elem224);
+					int elem259 = struct.num;
+					oprot.writeI32(elem259);
 				}
 				if (struct.isSetStr()) {
-					String elem225 = struct.Str;
-					oprot.writeString(elem225);
+					String elem260 = struct.Str;
+					oprot.writeString(elem260);
 				}
 				if (struct.isSetEvent()) {
 					struct.event.write(oprot);
@@ -2772,8 +2772,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.isSetSuccess()) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					long elem226 = struct.success;
-					oprot.writeI64(elem226);
+					long elem261 = struct.success;
+					oprot.writeI64(elem261);
 					oprot.writeFieldEnd();
 				}
 				if (struct.awe != null) {
@@ -2815,8 +2815,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 3);
 				if (struct.isSetSuccess()) {
-					long elem227 = struct.success;
-					oprot.writeI64(elem227);
+					long elem262 = struct.success;
+					oprot.writeI64(elem262);
 				}
 				if (struct.isSetAwe()) {
 					struct.awe.write(oprot);
@@ -3235,12 +3235,12 @@ public class FFoo {
 							break;
 						case 2: // REQ
 							if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
-								org.apache.thrift.protocol.TMap elem230 = iprot.readMapBegin();
-								struct.req = new HashMap<Integer,String>(2*elem230.size);
-								for (int elem231 = 0; elem231 < elem230.size; ++elem231) {
-									int elem233 = iprot.readI32();
-									String elem232 = iprot.readString();
-									struct.req.put(elem233, elem232);
+								org.apache.thrift.protocol.TMap elem265 = iprot.readMapBegin();
+								struct.req = new HashMap<Integer,String>(2*elem265.size);
+								for (int elem266 = 0; elem266 < elem265.size; ++elem266) {
+									int elem268 = iprot.readI32();
+									String elem267 = iprot.readString();
+									struct.req.put(elem268, elem267);
 								}
 								iprot.readMapEnd();
 								struct.setReqIsSet(true);
@@ -3264,17 +3264,17 @@ public class FFoo {
 
 				oprot.writeStructBegin(STRUCT_DESC);
 				oprot.writeFieldBegin(ID_FIELD_DESC);
-				long elem234 = struct.id;
-				oprot.writeI64(elem234);
+				long elem269 = struct.id;
+				oprot.writeI64(elem269);
 				oprot.writeFieldEnd();
 				if (struct.req != null) {
 					oprot.writeFieldBegin(REQ_FIELD_DESC);
 					oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, struct.req.size()));
-					for (Map.Entry<Integer, String> elem235 : struct.req.entrySet()) {
-						int elem236 = elem235.getKey();
-						oprot.writeI32(elem236);
-						String elem237 = elem235.getValue();
-						oprot.writeString(elem237);
+					for (Map.Entry<Integer, String> elem270 : struct.req.entrySet()) {
+						int elem271 = elem270.getKey();
+						oprot.writeI32(elem271);
+						String elem272 = elem270.getValue();
+						oprot.writeString(elem272);
 					}
 					oprot.writeMapEnd();
 					oprot.writeFieldEnd();
@@ -3305,16 +3305,16 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetId()) {
-					long elem238 = struct.id;
-					oprot.writeI64(elem238);
+					long elem273 = struct.id;
+					oprot.writeI64(elem273);
 				}
 				if (struct.isSetReq()) {
 					oprot.writeI32(struct.req.size());
-					for (Map.Entry<Integer, String> elem239 : struct.req.entrySet()) {
-						int elem240 = elem239.getKey();
-						oprot.writeI32(elem240);
-						String elem241 = elem239.getValue();
-						oprot.writeString(elem241);
+					for (Map.Entry<Integer, String> elem274 : struct.req.entrySet()) {
+						int elem275 = elem274.getKey();
+						oprot.writeI32(elem275);
+						String elem276 = elem274.getValue();
+						oprot.writeString(elem276);
 					}
 				}
 			}
@@ -3328,12 +3328,12 @@ public class FFoo {
 					struct.setIdIsSet(true);
 				}
 				if (incoming.get(1)) {
-					org.apache.thrift.protocol.TMap elem242 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-					struct.req = new HashMap<Integer,String>(2*elem242.size);
-					for (int elem243 = 0; elem243 < elem242.size; ++elem243) {
-						int elem245 = iprot.readI32();
-						String elem244 = iprot.readString();
-						struct.req.put(elem245, elem244);
+					org.apache.thrift.protocol.TMap elem277 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+					struct.req = new HashMap<Integer,String>(2*elem277.size);
+					for (int elem278 = 0; elem278 < elem277.size; ++elem278) {
+						int elem280 = iprot.readI32();
+						String elem279 = iprot.readString();
+						struct.req.put(elem280, elem279);
 					}
 					struct.setReqIsSet(true);
 				}
@@ -3751,14 +3751,14 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.bin != null) {
 					oprot.writeFieldBegin(BIN_FIELD_DESC);
-					java.nio.ByteBuffer elem246 = struct.bin;
-					oprot.writeBinary(elem246);
+					java.nio.ByteBuffer elem281 = struct.bin;
+					oprot.writeBinary(elem281);
 					oprot.writeFieldEnd();
 				}
 				if (struct.Str != null) {
 					oprot.writeFieldBegin(STR_FIELD_DESC);
-					String elem247 = struct.Str;
-					oprot.writeString(elem247);
+					String elem282 = struct.Str;
+					oprot.writeString(elem282);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -3787,12 +3787,12 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetBin()) {
-					java.nio.ByteBuffer elem248 = struct.bin;
-					oprot.writeBinary(elem248);
+					java.nio.ByteBuffer elem283 = struct.bin;
+					oprot.writeBinary(elem283);
 				}
 				if (struct.isSetStr()) {
-					String elem249 = struct.Str;
-					oprot.writeString(elem249);
+					String elem284 = struct.Str;
+					oprot.writeString(elem284);
 				}
 			}
 
@@ -4226,8 +4226,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					java.nio.ByteBuffer elem250 = struct.success;
-					oprot.writeBinary(elem250);
+					java.nio.ByteBuffer elem285 = struct.success;
+					oprot.writeBinary(elem285);
 					oprot.writeFieldEnd();
 				}
 				if (struct.api != null) {
@@ -4261,8 +4261,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetSuccess()) {
-					java.nio.ByteBuffer elem251 = struct.success;
-					oprot.writeBinary(elem251);
+					java.nio.ByteBuffer elem286 = struct.success;
+					oprot.writeBinary(elem286);
 				}
 				if (struct.isSetApi()) {
 					struct.api.write(oprot);
@@ -4768,16 +4768,16 @@ public class FFoo {
 
 				oprot.writeStructBegin(STRUCT_DESC);
 				oprot.writeFieldBegin(OPT_NUM_FIELD_DESC);
-				int elem252 = struct.opt_num;
-				oprot.writeI32(elem252);
+				int elem287 = struct.opt_num;
+				oprot.writeI32(elem287);
 				oprot.writeFieldEnd();
 				oprot.writeFieldBegin(DEFAULT_NUM_FIELD_DESC);
-				int elem253 = struct.default_num;
-				oprot.writeI32(elem253);
+				int elem288 = struct.default_num;
+				oprot.writeI32(elem288);
 				oprot.writeFieldEnd();
 				oprot.writeFieldBegin(REQ_NUM_FIELD_DESC);
-				int elem254 = struct.req_num;
-				oprot.writeI32(elem254);
+				int elem289 = struct.req_num;
+				oprot.writeI32(elem289);
 				oprot.writeFieldEnd();
 				oprot.writeFieldStop();
 				oprot.writeStructEnd();
@@ -4796,8 +4796,8 @@ public class FFoo {
 			@Override
 			public void write(org.apache.thrift.protocol.TProtocol prot, param_modifiers_args struct) throws org.apache.thrift.TException {
 				TTupleProtocol oprot = (TTupleProtocol) prot;
-				int elem255 = struct.req_num;
-				oprot.writeI32(elem255);
+				int elem290 = struct.req_num;
+				oprot.writeI32(elem290);
 				BitSet optionals = new BitSet();
 				if (struct.isSetOpt_num()) {
 					optionals.set(0);
@@ -4807,12 +4807,12 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetOpt_num()) {
-					int elem256 = struct.opt_num;
-					oprot.writeI32(elem256);
+					int elem291 = struct.opt_num;
+					oprot.writeI32(elem291);
 				}
 				if (struct.isSetDefault_num()) {
-					int elem257 = struct.default_num;
-					oprot.writeI32(elem257);
+					int elem292 = struct.default_num;
+					oprot.writeI32(elem292);
 				}
 			}
 
@@ -5144,8 +5144,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.isSetSuccess()) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					long elem258 = struct.success;
-					oprot.writeI64(elem258);
+					long elem293 = struct.success;
+					oprot.writeI64(elem293);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -5171,8 +5171,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					long elem259 = struct.success;
-					oprot.writeI64(elem259);
+					long elem294 = struct.success;
+					oprot.writeI64(elem294);
 				}
 			}
 
@@ -5284,16 +5284,16 @@ public class FFoo {
 		public underlying_types_test_args(underlying_types_test_args other) {
 			if (other.isSetList_type()) {
 				this.list_type = new ArrayList<Long>(other.list_type.size());
-				for (long elem260 : other.list_type) {
-					long elem261 = elem260;
-					this.list_type.add(elem261);
+				for (long elem295 : other.list_type) {
+					long elem296 = elem295;
+					this.list_type.add(elem296);
 				}
 			}
 			if (other.isSetSet_type()) {
 				this.set_type = new HashSet<Long>(other.set_type.size());
-				for (long elem262 : other.set_type) {
-					long elem263 = elem262;
-					this.set_type.add(elem263);
+				for (long elem297 : other.set_type) {
+					long elem298 = elem297;
+					this.set_type.add(elem298);
 				}
 			}
 		}
@@ -5595,11 +5595,11 @@ public class FFoo {
 					switch (schemeField.id) {
 						case 1: // LIST_TYPE
 							if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-								org.apache.thrift.protocol.TList elem264 = iprot.readListBegin();
-								struct.list_type = new ArrayList<Long>(elem264.size);
-								for (int elem265 = 0; elem265 < elem264.size; ++elem265) {
-									long elem266 = iprot.readI64();
-									struct.list_type.add(elem266);
+								org.apache.thrift.protocol.TList elem299 = iprot.readListBegin();
+								struct.list_type = new ArrayList<Long>(elem299.size);
+								for (int elem300 = 0; elem300 < elem299.size; ++elem300) {
+									long elem301 = iprot.readI64();
+									struct.list_type.add(elem301);
 								}
 								iprot.readListEnd();
 								struct.setList_typeIsSet(true);
@@ -5609,11 +5609,11 @@ public class FFoo {
 							break;
 						case 2: // SET_TYPE
 							if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
-								org.apache.thrift.protocol.TSet elem267 = iprot.readSetBegin();
-								struct.set_type = new HashSet<Long>(2*elem267.size);
-								for (int elem268 = 0; elem268 < elem267.size; ++elem268) {
-									long elem269 = iprot.readI64();
-									struct.set_type.add(elem269);
+								org.apache.thrift.protocol.TSet elem302 = iprot.readSetBegin();
+								struct.set_type = new HashSet<Long>(2*elem302.size);
+								for (int elem303 = 0; elem303 < elem302.size; ++elem303) {
+									long elem304 = iprot.readI64();
+									struct.set_type.add(elem304);
 								}
 								iprot.readSetEnd();
 								struct.setSet_typeIsSet(true);
@@ -5639,9 +5639,9 @@ public class FFoo {
 				if (struct.list_type != null) {
 					oprot.writeFieldBegin(LIST_TYPE_FIELD_DESC);
 					oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.list_type.size()));
-					for (long elem270 : struct.list_type) {
-						long elem271 = elem270;
-						oprot.writeI64(elem271);
+					for (long elem305 : struct.list_type) {
+						long elem306 = elem305;
+						oprot.writeI64(elem306);
 					}
 					oprot.writeListEnd();
 					oprot.writeFieldEnd();
@@ -5649,9 +5649,9 @@ public class FFoo {
 				if (struct.set_type != null) {
 					oprot.writeFieldBegin(SET_TYPE_FIELD_DESC);
 					oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, struct.set_type.size()));
-					for (long elem272 : struct.set_type) {
-						long elem273 = elem272;
-						oprot.writeI64(elem273);
+					for (long elem307 : struct.set_type) {
+						long elem308 = elem307;
+						oprot.writeI64(elem308);
 					}
 					oprot.writeSetEnd();
 					oprot.writeFieldEnd();
@@ -5683,16 +5683,16 @@ public class FFoo {
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetList_type()) {
 					oprot.writeI32(struct.list_type.size());
-					for (long elem274 : struct.list_type) {
-						long elem275 = elem274;
-						oprot.writeI64(elem275);
+					for (long elem309 : struct.list_type) {
+						long elem310 = elem309;
+						oprot.writeI64(elem310);
 					}
 				}
 				if (struct.isSetSet_type()) {
 					oprot.writeI32(struct.set_type.size());
-					for (long elem276 : struct.set_type) {
-						long elem277 = elem276;
-						oprot.writeI64(elem277);
+					for (long elem311 : struct.set_type) {
+						long elem312 = elem311;
+						oprot.writeI64(elem312);
 					}
 				}
 			}
@@ -5702,20 +5702,20 @@ public class FFoo {
 				TTupleProtocol iprot = (TTupleProtocol) prot;
 				BitSet incoming = iprot.readBitSet(2);
 				if (incoming.get(0)) {
-					org.apache.thrift.protocol.TList elem278 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-					struct.list_type = new ArrayList<Long>(elem278.size);
-					for (int elem279 = 0; elem279 < elem278.size; ++elem279) {
-						long elem280 = iprot.readI64();
-						struct.list_type.add(elem280);
+					org.apache.thrift.protocol.TList elem313 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+					struct.list_type = new ArrayList<Long>(elem313.size);
+					for (int elem314 = 0; elem314 < elem313.size; ++elem314) {
+						long elem315 = iprot.readI64();
+						struct.list_type.add(elem315);
 					}
 					struct.setList_typeIsSet(true);
 				}
 				if (incoming.get(1)) {
-					org.apache.thrift.protocol.TSet elem281 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-					struct.set_type = new HashSet<Long>(2*elem281.size);
-					for (int elem282 = 0; elem282 < elem281.size; ++elem282) {
-						long elem283 = iprot.readI64();
-						struct.set_type.add(elem283);
+					org.apache.thrift.protocol.TSet elem316 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+					struct.set_type = new HashSet<Long>(2*elem316.size);
+					for (int elem317 = 0; elem317 < elem316.size; ++elem317) {
+						long elem318 = iprot.readI64();
+						struct.set_type.add(elem318);
 					}
 					struct.setSet_typeIsSet(true);
 				}
@@ -5812,9 +5812,9 @@ public class FFoo {
 		public underlying_types_test_result(underlying_types_test_result other) {
 			if (other.isSetSuccess()) {
 				this.success = new ArrayList<Long>(other.success.size());
-				for (long elem284 : other.success) {
-					long elem285 = elem284;
-					this.success.add(elem285);
+				for (long elem319 : other.success) {
+					long elem320 = elem319;
+					this.success.add(elem320);
 				}
 			}
 		}
@@ -6030,11 +6030,11 @@ public class FFoo {
 					switch (schemeField.id) {
 						case 0: // SUCCESS
 							if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-								org.apache.thrift.protocol.TList elem286 = iprot.readListBegin();
-								struct.success = new ArrayList<Long>(elem286.size);
-								for (int elem287 = 0; elem287 < elem286.size; ++elem287) {
-									long elem288 = iprot.readI64();
-									struct.success.add(elem288);
+								org.apache.thrift.protocol.TList elem321 = iprot.readListBegin();
+								struct.success = new ArrayList<Long>(elem321.size);
+								for (int elem322 = 0; elem322 < elem321.size; ++elem322) {
+									long elem323 = iprot.readI64();
+									struct.success.add(elem323);
 								}
 								iprot.readListEnd();
 								struct.setSuccessIsSet(true);
@@ -6060,9 +6060,9 @@ public class FFoo {
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
 					oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.success.size()));
-					for (long elem289 : struct.success) {
-						long elem290 = elem289;
-						oprot.writeI64(elem290);
+					for (long elem324 : struct.success) {
+						long elem325 = elem324;
+						oprot.writeI64(elem325);
 					}
 					oprot.writeListEnd();
 					oprot.writeFieldEnd();
@@ -6091,9 +6091,9 @@ public class FFoo {
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
 					oprot.writeI32(struct.success.size());
-					for (long elem291 : struct.success) {
-						long elem292 = elem291;
-						oprot.writeI64(elem292);
+					for (long elem326 : struct.success) {
+						long elem327 = elem326;
+						oprot.writeI64(elem327);
 					}
 				}
 			}
@@ -6103,11 +6103,11 @@ public class FFoo {
 				TTupleProtocol iprot = (TTupleProtocol) prot;
 				BitSet incoming = iprot.readBitSet(1);
 				if (incoming.get(0)) {
-					org.apache.thrift.protocol.TList elem293 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-					struct.success = new ArrayList<Long>(elem293.size);
-					for (int elem294 = 0; elem294 < elem293.size; ++elem294) {
-						long elem295 = iprot.readI64();
-						struct.success.add(elem295);
+					org.apache.thrift.protocol.TList elem328 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+					struct.success = new ArrayList<Long>(elem328.size);
+					for (int elem329 = 0; elem329 < elem328.size; ++elem329) {
+						long elem330 = iprot.readI64();
+						struct.success.add(elem330);
 					}
 					struct.setSuccessIsSet(true);
 				}
@@ -7269,8 +7269,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.isSetSuccess()) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					int elem296 = struct.success;
-					oprot.writeI32(elem296);
+					int elem331 = struct.success;
+					oprot.writeI32(elem331);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -7296,8 +7296,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					int elem297 = struct.success;
-					oprot.writeI32(elem297);
+					int elem332 = struct.success;
+					oprot.writeI32(elem332);
 				}
 			}
 
@@ -8340,8 +8340,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.newMessage != null) {
 					oprot.writeFieldBegin(NEW_MESSAGE_FIELD_DESC);
-					String elem298 = struct.newMessage;
-					oprot.writeString(elem298);
+					String elem333 = struct.newMessage;
+					oprot.writeString(elem333);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -8367,8 +8367,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetNewMessage()) {
-					String elem299 = struct.newMessage;
-					oprot.writeString(elem299);
+					String elem334 = struct.newMessage;
+					oprot.writeString(elem334);
 				}
 			}
 
@@ -8695,8 +8695,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					String elem300 = struct.success;
-					oprot.writeString(elem300);
+					String elem335 = struct.success;
+					oprot.writeString(elem335);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -8722,8 +8722,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					String elem301 = struct.success;
-					oprot.writeString(elem301);
+					String elem336 = struct.success;
+					oprot.writeString(elem336);
 				}
 			}
 
@@ -9050,8 +9050,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.messageArgs != null) {
 					oprot.writeFieldBegin(MESSAGE_ARGS_FIELD_DESC);
-					String elem302 = struct.messageArgs;
-					oprot.writeString(elem302);
+					String elem337 = struct.messageArgs;
+					oprot.writeString(elem337);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -9077,8 +9077,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetMessageArgs()) {
-					String elem303 = struct.messageArgs;
-					oprot.writeString(elem303);
+					String elem338 = struct.messageArgs;
+					oprot.writeString(elem338);
 				}
 			}
 
@@ -9405,8 +9405,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					String elem304 = struct.success;
-					oprot.writeString(elem304);
+					String elem339 = struct.success;
+					oprot.writeString(elem339);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -9432,8 +9432,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					String elem305 = struct.success;
-					oprot.writeString(elem305);
+					String elem340 = struct.success;
+					oprot.writeString(elem340);
 				}
 			}
 
@@ -9760,8 +9760,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.messageResult != null) {
 					oprot.writeFieldBegin(MESSAGE_RESULT_FIELD_DESC);
-					String elem306 = struct.messageResult;
-					oprot.writeString(elem306);
+					String elem341 = struct.messageResult;
+					oprot.writeString(elem341);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -9787,8 +9787,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetMessageResult()) {
-					String elem307 = struct.messageResult;
-					oprot.writeString(elem307);
+					String elem342 = struct.messageResult;
+					oprot.writeString(elem342);
 				}
 			}
 
@@ -10115,8 +10115,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					String elem308 = struct.success;
-					oprot.writeString(elem308);
+					String elem343 = struct.success;
+					oprot.writeString(elem343);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -10142,8 +10142,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					String elem309 = struct.success;
-					oprot.writeString(elem309);
+					String elem344 = struct.success;
+					oprot.writeString(elem344);
 				}
 			}
 

--- a/test/expected/java/variety/AwesomeException.java
+++ b/test/expected/java/variety/AwesomeException.java
@@ -546,18 +546,18 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 
 			oprot.writeStructBegin(STRUCT_DESC);
 			oprot.writeFieldBegin(ID_FIELD_DESC);
-			long elem216 = struct.ID;
-			oprot.writeI64(elem216);
+			long elem251 = struct.ID;
+			oprot.writeI64(elem251);
 			oprot.writeFieldEnd();
 			if (struct.Reason != null) {
 				oprot.writeFieldBegin(REASON_FIELD_DESC);
-				String elem217 = struct.Reason;
-				oprot.writeString(elem217);
+				String elem252 = struct.Reason;
+				oprot.writeString(elem252);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldBegin(DEPR_FIELD_DESC);
-			boolean elem218 = struct.depr;
-			oprot.writeBool(elem218);
+			boolean elem253 = struct.depr;
+			oprot.writeBool(elem253);
 			oprot.writeFieldEnd();
 			oprot.writeFieldStop();
 			oprot.writeStructEnd();
@@ -588,16 +588,16 @@ public class AwesomeException extends TException implements org.apache.thrift.TB
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetID()) {
-				long elem219 = struct.ID;
-				oprot.writeI64(elem219);
+				long elem254 = struct.ID;
+				oprot.writeI64(elem254);
 			}
 			if (struct.isSetReason()) {
-				String elem220 = struct.Reason;
-				oprot.writeString(elem220);
+				String elem255 = struct.Reason;
+				oprot.writeString(elem255);
 			}
 			if (struct.isSetDepr()) {
-				boolean elem221 = struct.depr;
-				oprot.writeBool(elem221);
+				boolean elem256 = struct.depr;
+				oprot.writeBool(elem256);
 			}
 		}
 

--- a/test/expected/java/variety/EventWrapper.java
+++ b/test/expected/java/variety/EventWrapper.java
@@ -48,6 +48,9 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 	private static final org.apache.thrift.protocol.TField DEPR_FIELD_DESC = new org.apache.thrift.protocol.TField("depr", org.apache.thrift.protocol.TType.BOOL, (short)11);
 	private static final org.apache.thrift.protocol.TField DEPR_BINARY_FIELD_DESC = new org.apache.thrift.protocol.TField("deprBinary", org.apache.thrift.protocol.TType.STRING, (short)12);
 	private static final org.apache.thrift.protocol.TField DEPR_LIST_FIELD_DESC = new org.apache.thrift.protocol.TField("deprList", org.apache.thrift.protocol.TType.LIST, (short)13);
+	private static final org.apache.thrift.protocol.TField EVENTS_DEFAULT_FIELD_DESC = new org.apache.thrift.protocol.TField("EventsDefault", org.apache.thrift.protocol.TType.LIST, (short)14);
+	private static final org.apache.thrift.protocol.TField EVENT_MAP_DEFAULT_FIELD_DESC = new org.apache.thrift.protocol.TField("EventMapDefault", org.apache.thrift.protocol.TType.MAP, (short)15);
+	private static final org.apache.thrift.protocol.TField EVENT_SET_DEFAULT_FIELD_DESC = new org.apache.thrift.protocol.TField("EventSetDefault", org.apache.thrift.protocol.TType.SET, (short)16);
 
 	private static final Map<Class<? extends IScheme>, SchemeFactory> schemes = new HashMap<Class<? extends IScheme>, SchemeFactory>();
 	static {
@@ -82,6 +85,9 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 	 */
 	@Deprecated
 	public java.util.List<Boolean> deprList;
+	public java.util.List<Event> EventsDefault; // optional
+	public java.util.Map<Long, Event> EventMapDefault; // optional
+	public java.util.Set<Event> EventSetDefault; // optional
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
 	public enum _Fields implements org.apache.thrift.TFieldIdEnum {
 		ID((short)1, "ID"),
@@ -100,7 +106,10 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		 */
 		DEPR((short)11, "depr"),
 		DEPR_BINARY((short)12, "deprBinary"),
-		DEPR_LIST((short)13, "deprList")
+		DEPR_LIST((short)13, "deprList"),
+		EVENTS_DEFAULT((short)14, "EventsDefault"),
+		EVENT_MAP_DEFAULT((short)15, "EventMapDefault"),
+		EVENT_SET_DEFAULT((short)16, "EventSetDefault")
 		;
 
 		private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
@@ -142,6 +151,12 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 					return DEPR_BINARY;
 				case 13: // DEPR_LIST
 					return DEPR_LIST;
+				case 14: // EVENTS_DEFAULT
+					return EVENTS_DEFAULT;
+				case 15: // EVENT_MAP_DEFAULT
+					return EVENT_MAP_DEFAULT;
+				case 16: // EVENT_SET_DEFAULT
+					return EVENT_SET_DEFAULT;
 				default:
 					return null;
 			}
@@ -187,6 +202,12 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 	private static final int __DEPR_ISSET_ID = 2;
 	private byte __isset_bitfield = 0;
 	public EventWrapper() {
+		this.EventsDefault = new ArrayList<Event>();
+
+		this.EventMapDefault = new HashMap<Long,Event>();
+
+		this.EventSetDefault = new HashSet<Event>();
+
 	}
 
 	public EventWrapper(
@@ -286,6 +307,28 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 				this.deprList.add(elem107);
 			}
 		}
+		if (other.isSetEventsDefault()) {
+			this.EventsDefault = new ArrayList<Event>(other.EventsDefault.size());
+			for (Event elem108 : other.EventsDefault) {
+				Event elem109 = new Event(elem108);
+				this.EventsDefault.add(elem109);
+			}
+		}
+		if (other.isSetEventMapDefault()) {
+			this.EventMapDefault = new HashMap<Long,Event>(other.EventMapDefault.size());
+			for (Map.Entry<Long, Event> elem110 : other.EventMapDefault.entrySet()) {
+				long elem112 = elem110.getKey();
+				Event elem111 = new Event(elem110.getValue());
+				this.EventMapDefault.put(elem112, elem111);
+			}
+		}
+		if (other.isSetEventSetDefault()) {
+			this.EventSetDefault = new HashSet<Event>(other.EventSetDefault.size());
+			for (Event elem113 : other.EventSetDefault) {
+				Event elem114 = new Event(elem113);
+				this.EventSetDefault.add(elem114);
+			}
+		}
 	}
 
 	public EventWrapper deepCopy() {
@@ -322,6 +365,12 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		this.deprBinary = null;
 
 		this.deprList = null;
+
+		this.EventsDefault = new ArrayList<Event>();
+
+		this.EventMapDefault = new HashMap<Long,Event>();
+
+		this.EventSetDefault = new HashSet<Event>();
 
 	}
 
@@ -757,6 +806,119 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		}
 	}
 
+	public int getEventsDefaultSize() {
+		return (this.EventsDefault == null) ? 0 : this.EventsDefault.size();
+	}
+
+	public java.util.Iterator<Event> getEventsDefaultIterator() {
+		return (this.EventsDefault == null) ? null : this.EventsDefault.iterator();
+	}
+
+	public void addToEventsDefault(Event elem) {
+		if (this.EventsDefault == null) {
+			this.EventsDefault = new ArrayList<Event>();
+		}
+		this.EventsDefault.add(elem);
+	}
+
+	public java.util.List<Event> getEventsDefault() {
+		return this.EventsDefault;
+	}
+
+	public EventWrapper setEventsDefault(java.util.List<Event> EventsDefault) {
+		this.EventsDefault = EventsDefault;
+		return this;
+	}
+
+	public void unsetEventsDefault() {
+		this.EventsDefault = null;
+	}
+
+	/** Returns true if field EventsDefault is set (has been assigned a value) and false otherwise */
+	public boolean isSetEventsDefault() {
+		return this.EventsDefault != null;
+	}
+
+	public void setEventsDefaultIsSet(boolean value) {
+		if (!value) {
+			this.EventsDefault = null;
+		}
+	}
+
+	public int getEventMapDefaultSize() {
+		return (this.EventMapDefault == null) ? 0 : this.EventMapDefault.size();
+	}
+
+	public void putToEventMapDefault(long key, Event val) {
+		if (this.EventMapDefault == null) {
+			this.EventMapDefault = new HashMap<Long,Event>();
+		}
+		this.EventMapDefault.put(key, val);
+	}
+
+	public java.util.Map<Long, Event> getEventMapDefault() {
+		return this.EventMapDefault;
+	}
+
+	public EventWrapper setEventMapDefault(java.util.Map<Long, Event> EventMapDefault) {
+		this.EventMapDefault = EventMapDefault;
+		return this;
+	}
+
+	public void unsetEventMapDefault() {
+		this.EventMapDefault = null;
+	}
+
+	/** Returns true if field EventMapDefault is set (has been assigned a value) and false otherwise */
+	public boolean isSetEventMapDefault() {
+		return this.EventMapDefault != null;
+	}
+
+	public void setEventMapDefaultIsSet(boolean value) {
+		if (!value) {
+			this.EventMapDefault = null;
+		}
+	}
+
+	public int getEventSetDefaultSize() {
+		return (this.EventSetDefault == null) ? 0 : this.EventSetDefault.size();
+	}
+
+	public java.util.Iterator<Event> getEventSetDefaultIterator() {
+		return (this.EventSetDefault == null) ? null : this.EventSetDefault.iterator();
+	}
+
+	public void addToEventSetDefault(Event elem) {
+		if (this.EventSetDefault == null) {
+			this.EventSetDefault = new HashSet<Event>();
+		}
+		this.EventSetDefault.add(elem);
+	}
+
+	public java.util.Set<Event> getEventSetDefault() {
+		return this.EventSetDefault;
+	}
+
+	public EventWrapper setEventSetDefault(java.util.Set<Event> EventSetDefault) {
+		this.EventSetDefault = EventSetDefault;
+		return this;
+	}
+
+	public void unsetEventSetDefault() {
+		this.EventSetDefault = null;
+	}
+
+	/** Returns true if field EventSetDefault is set (has been assigned a value) and false otherwise */
+	public boolean isSetEventSetDefault() {
+		return this.EventSetDefault != null;
+	}
+
+	public void setEventSetDefaultIsSet(boolean value) {
+		if (!value) {
+			this.EventSetDefault = null;
+		}
+	}
+
 	public void setFieldValue(_Fields field, Object value) {
 		switch (field) {
 		case ID:
@@ -863,6 +1025,30 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			}
 			break;
 
+		case EVENTS_DEFAULT:
+			if (value == null) {
+				unsetEventsDefault();
+			} else {
+				setEventsDefault((java.util.List<Event>)value);
+			}
+			break;
+
+		case EVENT_MAP_DEFAULT:
+			if (value == null) {
+				unsetEventMapDefault();
+			} else {
+				setEventMapDefault((java.util.Map<Long, Event>)value);
+			}
+			break;
+
+		case EVENT_SET_DEFAULT:
+			if (value == null) {
+				unsetEventSetDefault();
+			} else {
+				setEventSetDefault((java.util.Set<Event>)value);
+			}
+			break;
+
 		}
 	}
 
@@ -907,6 +1093,15 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		case DEPR_LIST:
 			return getDeprList();
 
+		case EVENTS_DEFAULT:
+			return getEventsDefault();
+
+		case EVENT_MAP_DEFAULT:
+			return getEventMapDefault();
+
+		case EVENT_SET_DEFAULT:
+			return getEventSetDefault();
+
 		}
 		throw new IllegalStateException();
 	}
@@ -944,6 +1139,12 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			return isSetDeprBinary();
 		case DEPR_LIST:
 			return isSetDeprList();
+		case EVENTS_DEFAULT:
+			return isSetEventsDefault();
+		case EVENT_MAP_DEFAULT:
+			return isSetEventMapDefault();
+		case EVENT_SET_DEFAULT:
+			return isSetEventSetDefault();
 		}
 		throw new IllegalStateException();
 	}
@@ -1078,6 +1279,33 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 				return false;
 		}
 
+		boolean this_present_EventsDefault = true && this.isSetEventsDefault();
+		boolean that_present_EventsDefault = true && that.isSetEventsDefault();
+		if (this_present_EventsDefault || that_present_EventsDefault) {
+			if (!(this_present_EventsDefault && that_present_EventsDefault))
+				return false;
+			if (!this.EventsDefault.equals(that.EventsDefault))
+				return false;
+		}
+
+		boolean this_present_EventMapDefault = true && this.isSetEventMapDefault();
+		boolean that_present_EventMapDefault = true && that.isSetEventMapDefault();
+		if (this_present_EventMapDefault || that_present_EventMapDefault) {
+			if (!(this_present_EventMapDefault && that_present_EventMapDefault))
+				return false;
+			if (!this.EventMapDefault.equals(that.EventMapDefault))
+				return false;
+		}
+
+		boolean this_present_EventSetDefault = true && this.isSetEventSetDefault();
+		boolean that_present_EventSetDefault = true && that.isSetEventSetDefault();
+		if (this_present_EventSetDefault || that_present_EventSetDefault) {
+			if (!(this_present_EventSetDefault && that_present_EventSetDefault))
+				return false;
+			if (!this.EventSetDefault.equals(that.EventSetDefault))
+				return false;
+		}
+
 		return true;
 	}
 
@@ -1149,6 +1377,21 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 		list.add(present_deprList);
 		if (present_deprList)
 			list.add(deprList);
+
+		boolean present_EventsDefault = true && (isSetEventsDefault());
+		list.add(present_EventsDefault);
+		if (present_EventsDefault)
+			list.add(EventsDefault);
+
+		boolean present_EventMapDefault = true && (isSetEventMapDefault());
+		list.add(present_EventMapDefault);
+		if (present_EventMapDefault)
+			list.add(EventMapDefault);
+
+		boolean present_EventSetDefault = true && (isSetEventSetDefault());
+		list.add(present_EventSetDefault);
+		if (present_EventSetDefault)
+			list.add(EventSetDefault);
 
 		return list.hashCode();
 	}
@@ -1291,6 +1534,36 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 				return lastComparison;
 			}
 		}
+		lastComparison = Boolean.valueOf(isSetEventsDefault()).compareTo(other.isSetEventsDefault());
+		if (lastComparison != 0) {
+			return lastComparison;
+		}
+		if (isSetEventsDefault()) {
+			lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.EventsDefault, other.EventsDefault);
+			if (lastComparison != 0) {
+				return lastComparison;
+			}
+		}
+		lastComparison = Boolean.valueOf(isSetEventMapDefault()).compareTo(other.isSetEventMapDefault());
+		if (lastComparison != 0) {
+			return lastComparison;
+		}
+		if (isSetEventMapDefault()) {
+			lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.EventMapDefault, other.EventMapDefault);
+			if (lastComparison != 0) {
+				return lastComparison;
+			}
+		}
+		lastComparison = Boolean.valueOf(isSetEventSetDefault()).compareTo(other.isSetEventSetDefault());
+		if (lastComparison != 0) {
+			return lastComparison;
+		}
+		if (isSetEventSetDefault()) {
+			lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.EventSetDefault, other.EventSetDefault);
+			if (lastComparison != 0) {
+				return lastComparison;
+			}
+		}
 		return 0;
 	}
 
@@ -1404,6 +1677,36 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			sb.append(this.deprList);
 		}
 		first = false;
+		if (isSetEventsDefault()) {
+			if (!first) sb.append(", ");
+			sb.append("EventsDefault:");
+			if (this.EventsDefault == null) {
+				sb.append("null");
+			} else {
+				sb.append(this.EventsDefault);
+			}
+			first = false;
+		}
+		if (isSetEventMapDefault()) {
+			if (!first) sb.append(", ");
+			sb.append("EventMapDefault:");
+			if (this.EventMapDefault == null) {
+				sb.append("null");
+			} else {
+				sb.append(this.EventMapDefault);
+			}
+			first = false;
+		}
+		if (isSetEventSetDefault()) {
+			if (!first) sb.append(", ");
+			sb.append("EventSetDefault:");
+			if (this.EventSetDefault == null) {
+				sb.append("null");
+			} else {
+				sb.append(this.EventSetDefault);
+			}
+			first = false;
+		}
 		sb.append(")");
 		return sb.toString();
 	}
@@ -1473,12 +1776,12 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 						break;
 					case 3: // EVENTS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem108 = iprot.readListBegin();
-							struct.Events = new ArrayList<Event>(elem108.size);
-							for (int elem109 = 0; elem109 < elem108.size; ++elem109) {
-								Event elem110 = new Event();
-								elem110.read(iprot);
-								struct.Events.add(elem110);
+							org.apache.thrift.protocol.TList elem115 = iprot.readListBegin();
+							struct.Events = new ArrayList<Event>(elem115.size);
+							for (int elem116 = 0; elem116 < elem115.size; ++elem116) {
+								Event elem117 = new Event();
+								elem117.read(iprot);
+								struct.Events.add(elem117);
 							}
 							iprot.readListEnd();
 							struct.setEventsIsSet(true);
@@ -1488,12 +1791,12 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 						break;
 					case 4: // EVENTS2
 						if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
-							org.apache.thrift.protocol.TSet elem111 = iprot.readSetBegin();
-							struct.Events2 = new HashSet<Event>(2*elem111.size);
-							for (int elem112 = 0; elem112 < elem111.size; ++elem112) {
-								Event elem113 = new Event();
-								elem113.read(iprot);
-								struct.Events2.add(elem113);
+							org.apache.thrift.protocol.TSet elem118 = iprot.readSetBegin();
+							struct.Events2 = new HashSet<Event>(2*elem118.size);
+							for (int elem119 = 0; elem119 < elem118.size; ++elem119) {
+								Event elem120 = new Event();
+								elem120.read(iprot);
+								struct.Events2.add(elem120);
 							}
 							iprot.readSetEnd();
 							struct.setEvents2IsSet(true);
@@ -1503,13 +1806,13 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 						break;
 					case 5: // EVENT_MAP
 						if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
-							org.apache.thrift.protocol.TMap elem114 = iprot.readMapBegin();
-							struct.EventMap = new HashMap<Long,Event>(2*elem114.size);
-							for (int elem115 = 0; elem115 < elem114.size; ++elem115) {
-								long elem117 = iprot.readI64();
-								Event elem116 = new Event();
-								elem116.read(iprot);
-								struct.EventMap.put(elem117, elem116);
+							org.apache.thrift.protocol.TMap elem121 = iprot.readMapBegin();
+							struct.EventMap = new HashMap<Long,Event>(2*elem121.size);
+							for (int elem122 = 0; elem122 < elem121.size; ++elem122) {
+								long elem124 = iprot.readI64();
+								Event elem123 = new Event();
+								elem123.read(iprot);
+								struct.EventMap.put(elem124, elem123);
 							}
 							iprot.readMapEnd();
 							struct.setEventMapIsSet(true);
@@ -1519,17 +1822,17 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 						break;
 					case 6: // NUMS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem118 = iprot.readListBegin();
-							struct.Nums = new ArrayList<java.util.List<Integer>>(elem118.size);
-							for (int elem119 = 0; elem119 < elem118.size; ++elem119) {
-								org.apache.thrift.protocol.TList elem121 = iprot.readListBegin();
-								java.util.List<Integer> elem120 = new ArrayList<Integer>(elem121.size);
-								for (int elem122 = 0; elem122 < elem121.size; ++elem122) {
-									int elem123 = iprot.readI32();
-									elem120.add(elem123);
+							org.apache.thrift.protocol.TList elem125 = iprot.readListBegin();
+							struct.Nums = new ArrayList<java.util.List<Integer>>(elem125.size);
+							for (int elem126 = 0; elem126 < elem125.size; ++elem126) {
+								org.apache.thrift.protocol.TList elem128 = iprot.readListBegin();
+								java.util.List<Integer> elem127 = new ArrayList<Integer>(elem128.size);
+								for (int elem129 = 0; elem129 < elem128.size; ++elem129) {
+									int elem130 = iprot.readI32();
+									elem127.add(elem130);
 								}
 								iprot.readListEnd();
-								struct.Nums.add(elem120);
+								struct.Nums.add(elem127);
 							}
 							iprot.readListEnd();
 							struct.setNumsIsSet(true);
@@ -1539,11 +1842,11 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 						break;
 					case 7: // ENUMS
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem124 = iprot.readListBegin();
-							struct.Enums = new ArrayList<ItsAnEnum>(elem124.size);
-							for (int elem125 = 0; elem125 < elem124.size; ++elem125) {
-								ItsAnEnum elem126 = ItsAnEnum.findByValue(iprot.readI32());
-								struct.Enums.add(elem126);
+							org.apache.thrift.protocol.TList elem131 = iprot.readListBegin();
+							struct.Enums = new ArrayList<ItsAnEnum>(elem131.size);
+							for (int elem132 = 0; elem132 < elem131.size; ++elem132) {
+								ItsAnEnum elem133 = ItsAnEnum.findByValue(iprot.readI32());
+								struct.Enums.add(elem133);
 							}
 							iprot.readListEnd();
 							struct.setEnumsIsSet(true);
@@ -1594,14 +1897,60 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 						break;
 					case 13: // DEPR_LIST
 						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-							org.apache.thrift.protocol.TList elem127 = iprot.readListBegin();
-							struct.deprList = new ArrayList<Boolean>(elem127.size);
-							for (int elem128 = 0; elem128 < elem127.size; ++elem128) {
-								boolean elem129 = iprot.readBool();
-								struct.deprList.add(elem129);
+							org.apache.thrift.protocol.TList elem134 = iprot.readListBegin();
+							struct.deprList = new ArrayList<Boolean>(elem134.size);
+							for (int elem135 = 0; elem135 < elem134.size; ++elem135) {
+								boolean elem136 = iprot.readBool();
+								struct.deprList.add(elem136);
 							}
 							iprot.readListEnd();
 							struct.setDeprListIsSet(true);
+						} else {
+							org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+						}
+						break;
+					case 14: // EVENTS_DEFAULT
+						if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
+							org.apache.thrift.protocol.TList elem137 = iprot.readListBegin();
+							struct.EventsDefault = new ArrayList<Event>(elem137.size);
+							for (int elem138 = 0; elem138 < elem137.size; ++elem138) {
+								Event elem139 = new Event();
+								elem139.read(iprot);
+								struct.EventsDefault.add(elem139);
+							}
+							iprot.readListEnd();
+							struct.setEventsDefaultIsSet(true);
+						} else {
+							org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+						}
+						break;
+					case 15: // EVENT_MAP_DEFAULT
+						if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
+							org.apache.thrift.protocol.TMap elem140 = iprot.readMapBegin();
+							struct.EventMapDefault = new HashMap<Long,Event>(2*elem140.size);
+							for (int elem141 = 0; elem141 < elem140.size; ++elem141) {
+								long elem143 = iprot.readI64();
+								Event elem142 = new Event();
+								elem142.read(iprot);
+								struct.EventMapDefault.put(elem143, elem142);
+							}
+							iprot.readMapEnd();
+							struct.setEventMapDefaultIsSet(true);
+						} else {
+							org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+						}
+						break;
+					case 16: // EVENT_SET_DEFAULT
+						if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
+							org.apache.thrift.protocol.TSet elem144 = iprot.readSetBegin();
+							struct.EventSetDefault = new HashSet<Event>(2*elem144.size);
+							for (int elem145 = 0; elem145 < elem144.size; ++elem145) {
+								Event elem146 = new Event();
+								elem146.read(iprot);
+								struct.EventSetDefault.add(elem146);
+							}
+							iprot.readSetEnd();
+							struct.setEventSetDefaultIsSet(true);
 						} else {
 							org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
 						}
@@ -1623,8 +1972,8 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.isSetID()) {
 				oprot.writeFieldBegin(ID_FIELD_DESC);
-				long elem130 = struct.ID;
-				oprot.writeI64(elem130);
+				long elem147 = struct.ID;
+				oprot.writeI64(elem147);
 				oprot.writeFieldEnd();
 			}
 			if (struct.Ev != null) {
@@ -1635,8 +1984,8 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			if (struct.Events != null) {
 				oprot.writeFieldBegin(EVENTS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.Events.size()));
-				for (Event elem131 : struct.Events) {
-					elem131.write(oprot);
+				for (Event elem148 : struct.Events) {
+					elem148.write(oprot);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
@@ -1644,8 +1993,8 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			if (struct.Events2 != null) {
 				oprot.writeFieldBegin(EVENTS2_FIELD_DESC);
 				oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.STRUCT, struct.Events2.size()));
-				for (Event elem132 : struct.Events2) {
-					elem132.write(oprot);
+				for (Event elem149 : struct.Events2) {
+					elem149.write(oprot);
 				}
 				oprot.writeSetEnd();
 				oprot.writeFieldEnd();
@@ -1653,10 +2002,10 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			if (struct.EventMap != null) {
 				oprot.writeFieldBegin(EVENT_MAP_FIELD_DESC);
 				oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, struct.EventMap.size()));
-				for (Map.Entry<Long, Event> elem133 : struct.EventMap.entrySet()) {
-					long elem134 = elem133.getKey();
-					oprot.writeI64(elem134);
-					elem133.getValue().write(oprot);
+				for (Map.Entry<Long, Event> elem150 : struct.EventMap.entrySet()) {
+					long elem151 = elem150.getKey();
+					oprot.writeI64(elem151);
+					elem150.getValue().write(oprot);
 				}
 				oprot.writeMapEnd();
 				oprot.writeFieldEnd();
@@ -1664,11 +2013,11 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			if (struct.Nums != null) {
 				oprot.writeFieldBegin(NUMS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.LIST, struct.Nums.size()));
-				for (java.util.List<Integer> elem135 : struct.Nums) {
-					oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, elem135.size()));
-					for (int elem136 : elem135) {
-						int elem137 = elem136;
-						oprot.writeI32(elem137);
+				for (java.util.List<Integer> elem152 : struct.Nums) {
+					oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, elem152.size()));
+					for (int elem153 : elem152) {
+						int elem154 = elem153;
+						oprot.writeI32(elem154);
 					}
 					oprot.writeListEnd();
 				}
@@ -1678,16 +2027,16 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			if (struct.Enums != null) {
 				oprot.writeFieldBegin(ENUMS_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, struct.Enums.size()));
-				for (ItsAnEnum elem138 : struct.Enums) {
-					ItsAnEnum elem139 = elem138;
-					oprot.writeI32(elem139.getValue());
+				for (ItsAnEnum elem155 : struct.Enums) {
+					ItsAnEnum elem156 = elem155;
+					oprot.writeI32(elem156.getValue());
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldBegin(A_BOOL_FIELD_FIELD_DESC);
-			boolean elem140 = struct.aBoolField;
-			oprot.writeBool(elem140);
+			boolean elem157 = struct.aBoolField;
+			oprot.writeBool(elem157);
 			oprot.writeFieldEnd();
 			if (struct.a_union != null) {
 				oprot.writeFieldBegin(A_UNION_FIELD_DESC);
@@ -1696,29 +2045,64 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			}
 			if (struct.typedefOfTypedef != null) {
 				oprot.writeFieldBegin(TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-				String elem141 = struct.typedefOfTypedef;
-				oprot.writeString(elem141);
+				String elem158 = struct.typedefOfTypedef;
+				oprot.writeString(elem158);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldBegin(DEPR_FIELD_DESC);
-			boolean elem142 = struct.depr;
-			oprot.writeBool(elem142);
+			boolean elem159 = struct.depr;
+			oprot.writeBool(elem159);
 			oprot.writeFieldEnd();
 			if (struct.deprBinary != null) {
 				oprot.writeFieldBegin(DEPR_BINARY_FIELD_DESC);
-				java.nio.ByteBuffer elem143 = struct.deprBinary;
-				oprot.writeBinary(elem143);
+				java.nio.ByteBuffer elem160 = struct.deprBinary;
+				oprot.writeBinary(elem160);
 				oprot.writeFieldEnd();
 			}
 			if (struct.deprList != null) {
 				oprot.writeFieldBegin(DEPR_LIST_FIELD_DESC);
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.BOOL, struct.deprList.size()));
-				for (boolean elem144 : struct.deprList) {
-					boolean elem145 = elem144;
-					oprot.writeBool(elem145);
+				for (boolean elem161 : struct.deprList) {
+					boolean elem162 = elem161;
+					oprot.writeBool(elem162);
 				}
 				oprot.writeListEnd();
 				oprot.writeFieldEnd();
+			}
+			if (struct.EventsDefault != null) {
+				if (struct.isSetEventsDefault()) {
+					oprot.writeFieldBegin(EVENTS_DEFAULT_FIELD_DESC);
+					oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, struct.EventsDefault.size()));
+					for (Event elem163 : struct.EventsDefault) {
+						elem163.write(oprot);
+					}
+					oprot.writeListEnd();
+					oprot.writeFieldEnd();
+				}
+			}
+			if (struct.EventMapDefault != null) {
+				if (struct.isSetEventMapDefault()) {
+					oprot.writeFieldBegin(EVENT_MAP_DEFAULT_FIELD_DESC);
+					oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, struct.EventMapDefault.size()));
+					for (Map.Entry<Long, Event> elem164 : struct.EventMapDefault.entrySet()) {
+						long elem165 = elem164.getKey();
+						oprot.writeI64(elem165);
+						elem164.getValue().write(oprot);
+					}
+					oprot.writeMapEnd();
+					oprot.writeFieldEnd();
+				}
+			}
+			if (struct.EventSetDefault != null) {
+				if (struct.isSetEventSetDefault()) {
+					oprot.writeFieldBegin(EVENT_SET_DEFAULT_FIELD_DESC);
+					oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.STRUCT, struct.EventSetDefault.size()));
+					for (Event elem166 : struct.EventSetDefault) {
+						elem166.write(oprot);
+					}
+					oprot.writeSetEnd();
+					oprot.writeFieldEnd();
+				}
 			}
 			oprot.writeFieldStop();
 			oprot.writeStructEnd();
@@ -1775,72 +2159,101 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			if (struct.isSetDeprList()) {
 				optionals.set(11);
 			}
-			oprot.writeBitSet(optionals, 12);
+			if (struct.isSetEventsDefault()) {
+				optionals.set(12);
+			}
+			if (struct.isSetEventMapDefault()) {
+				optionals.set(13);
+			}
+			if (struct.isSetEventSetDefault()) {
+				optionals.set(14);
+			}
+			oprot.writeBitSet(optionals, 15);
 			if (struct.isSetID()) {
-				long elem146 = struct.ID;
-				oprot.writeI64(elem146);
+				long elem167 = struct.ID;
+				oprot.writeI64(elem167);
 			}
 			if (struct.isSetEvents()) {
 				oprot.writeI32(struct.Events.size());
-				for (Event elem147 : struct.Events) {
-					elem147.write(oprot);
+				for (Event elem168 : struct.Events) {
+					elem168.write(oprot);
 				}
 			}
 			if (struct.isSetEvents2()) {
 				oprot.writeI32(struct.Events2.size());
-				for (Event elem148 : struct.Events2) {
-					elem148.write(oprot);
+				for (Event elem169 : struct.Events2) {
+					elem169.write(oprot);
 				}
 			}
 			if (struct.isSetEventMap()) {
 				oprot.writeI32(struct.EventMap.size());
-				for (Map.Entry<Long, Event> elem149 : struct.EventMap.entrySet()) {
-					long elem150 = elem149.getKey();
-					oprot.writeI64(elem150);
-					elem149.getValue().write(oprot);
+				for (Map.Entry<Long, Event> elem170 : struct.EventMap.entrySet()) {
+					long elem171 = elem170.getKey();
+					oprot.writeI64(elem171);
+					elem170.getValue().write(oprot);
 				}
 			}
 			if (struct.isSetNums()) {
 				oprot.writeI32(struct.Nums.size());
-				for (java.util.List<Integer> elem151 : struct.Nums) {
-					oprot.writeI32(elem151.size());
-					for (int elem152 : elem151) {
-						int elem153 = elem152;
-						oprot.writeI32(elem153);
+				for (java.util.List<Integer> elem172 : struct.Nums) {
+					oprot.writeI32(elem172.size());
+					for (int elem173 : elem172) {
+						int elem174 = elem173;
+						oprot.writeI32(elem174);
 					}
 				}
 			}
 			if (struct.isSetEnums()) {
 				oprot.writeI32(struct.Enums.size());
-				for (ItsAnEnum elem154 : struct.Enums) {
-					ItsAnEnum elem155 = elem154;
-					oprot.writeI32(elem155.getValue());
+				for (ItsAnEnum elem175 : struct.Enums) {
+					ItsAnEnum elem176 = elem175;
+					oprot.writeI32(elem176.getValue());
 				}
 			}
 			if (struct.isSetABoolField()) {
-				boolean elem156 = struct.aBoolField;
-				oprot.writeBool(elem156);
+				boolean elem177 = struct.aBoolField;
+				oprot.writeBool(elem177);
 			}
 			if (struct.isSetA_union()) {
 				struct.a_union.write(oprot);
 			}
 			if (struct.isSetTypedefOfTypedef()) {
-				String elem157 = struct.typedefOfTypedef;
-				oprot.writeString(elem157);
+				String elem178 = struct.typedefOfTypedef;
+				oprot.writeString(elem178);
 			}
 			if (struct.isSetDepr()) {
-				boolean elem158 = struct.depr;
-				oprot.writeBool(elem158);
+				boolean elem179 = struct.depr;
+				oprot.writeBool(elem179);
 			}
 			if (struct.isSetDeprBinary()) {
-				java.nio.ByteBuffer elem159 = struct.deprBinary;
-				oprot.writeBinary(elem159);
+				java.nio.ByteBuffer elem180 = struct.deprBinary;
+				oprot.writeBinary(elem180);
 			}
 			if (struct.isSetDeprList()) {
 				oprot.writeI32(struct.deprList.size());
-				for (boolean elem160 : struct.deprList) {
-					boolean elem161 = elem160;
-					oprot.writeBool(elem161);
+				for (boolean elem181 : struct.deprList) {
+					boolean elem182 = elem181;
+					oprot.writeBool(elem182);
+				}
+			}
+			if (struct.isSetEventsDefault()) {
+				oprot.writeI32(struct.EventsDefault.size());
+				for (Event elem183 : struct.EventsDefault) {
+					elem183.write(oprot);
+				}
+			}
+			if (struct.isSetEventMapDefault()) {
+				oprot.writeI32(struct.EventMapDefault.size());
+				for (Map.Entry<Long, Event> elem184 : struct.EventMapDefault.entrySet()) {
+					long elem185 = elem184.getKey();
+					oprot.writeI64(elem185);
+					elem184.getValue().write(oprot);
+				}
+			}
+			if (struct.isSetEventSetDefault()) {
+				oprot.writeI32(struct.EventSetDefault.size());
+				for (Event elem186 : struct.EventSetDefault) {
+					elem186.write(oprot);
 				}
 			}
 		}
@@ -1851,62 +2264,62 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 			struct.Ev = new Event();
 			struct.Ev.read(iprot);
 			struct.setEvIsSet(true);
-			BitSet incoming = iprot.readBitSet(12);
+			BitSet incoming = iprot.readBitSet(15);
 			if (incoming.get(0)) {
 				struct.ID = iprot.readI64();
 				struct.setIDIsSet(true);
 			}
 			if (incoming.get(1)) {
-				org.apache.thrift.protocol.TList elem162 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-				struct.Events = new ArrayList<Event>(elem162.size);
-				for (int elem163 = 0; elem163 < elem162.size; ++elem163) {
-					Event elem164 = new Event();
-					elem164.read(iprot);
-					struct.Events.add(elem164);
+				org.apache.thrift.protocol.TList elem187 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+				struct.Events = new ArrayList<Event>(elem187.size);
+				for (int elem188 = 0; elem188 < elem187.size; ++elem188) {
+					Event elem189 = new Event();
+					elem189.read(iprot);
+					struct.Events.add(elem189);
 				}
 				struct.setEventsIsSet(true);
 			}
 			if (incoming.get(2)) {
-				org.apache.thrift.protocol.TSet elem165 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-				struct.Events2 = new HashSet<Event>(2*elem165.size);
-				for (int elem166 = 0; elem166 < elem165.size; ++elem166) {
-					Event elem167 = new Event();
-					elem167.read(iprot);
-					struct.Events2.add(elem167);
+				org.apache.thrift.protocol.TSet elem190 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+				struct.Events2 = new HashSet<Event>(2*elem190.size);
+				for (int elem191 = 0; elem191 < elem190.size; ++elem191) {
+					Event elem192 = new Event();
+					elem192.read(iprot);
+					struct.Events2.add(elem192);
 				}
 				struct.setEvents2IsSet(true);
 			}
 			if (incoming.get(3)) {
-				org.apache.thrift.protocol.TMap elem168 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
-				struct.EventMap = new HashMap<Long,Event>(2*elem168.size);
-				for (int elem169 = 0; elem169 < elem168.size; ++elem169) {
-					long elem171 = iprot.readI64();
-					Event elem170 = new Event();
-					elem170.read(iprot);
-					struct.EventMap.put(elem171, elem170);
+				org.apache.thrift.protocol.TMap elem193 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+				struct.EventMap = new HashMap<Long,Event>(2*elem193.size);
+				for (int elem194 = 0; elem194 < elem193.size; ++elem194) {
+					long elem196 = iprot.readI64();
+					Event elem195 = new Event();
+					elem195.read(iprot);
+					struct.EventMap.put(elem196, elem195);
 				}
 				struct.setEventMapIsSet(true);
 			}
 			if (incoming.get(4)) {
-				org.apache.thrift.protocol.TList elem172 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.LIST, iprot.readI32());
-				struct.Nums = new ArrayList<java.util.List<Integer>>(elem172.size);
-				for (int elem173 = 0; elem173 < elem172.size; ++elem173) {
-					org.apache.thrift.protocol.TList elem175 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, iprot.readI32());
-					java.util.List<Integer> elem174 = new ArrayList<Integer>(elem175.size);
-					for (int elem176 = 0; elem176 < elem175.size; ++elem176) {
-						int elem177 = iprot.readI32();
-						elem174.add(elem177);
+				org.apache.thrift.protocol.TList elem197 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.LIST, iprot.readI32());
+				struct.Nums = new ArrayList<java.util.List<Integer>>(elem197.size);
+				for (int elem198 = 0; elem198 < elem197.size; ++elem198) {
+					org.apache.thrift.protocol.TList elem200 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, iprot.readI32());
+					java.util.List<Integer> elem199 = new ArrayList<Integer>(elem200.size);
+					for (int elem201 = 0; elem201 < elem200.size; ++elem201) {
+						int elem202 = iprot.readI32();
+						elem199.add(elem202);
 					}
-					struct.Nums.add(elem174);
+					struct.Nums.add(elem199);
 				}
 				struct.setNumsIsSet(true);
 			}
 			if (incoming.get(5)) {
-				org.apache.thrift.protocol.TList elem178 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, iprot.readI32());
-				struct.Enums = new ArrayList<ItsAnEnum>(elem178.size);
-				for (int elem179 = 0; elem179 < elem178.size; ++elem179) {
-					ItsAnEnum elem180 = ItsAnEnum.findByValue(iprot.readI32());
-					struct.Enums.add(elem180);
+				org.apache.thrift.protocol.TList elem203 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I32, iprot.readI32());
+				struct.Enums = new ArrayList<ItsAnEnum>(elem203.size);
+				for (int elem204 = 0; elem204 < elem203.size; ++elem204) {
+					ItsAnEnum elem205 = ItsAnEnum.findByValue(iprot.readI32());
+					struct.Enums.add(elem205);
 				}
 				struct.setEnumsIsSet(true);
 			}
@@ -1932,13 +2345,44 @@ public class EventWrapper implements org.apache.thrift.TBase<EventWrapper, Event
 				struct.setDeprBinaryIsSet(true);
 			}
 			if (incoming.get(11)) {
-				org.apache.thrift.protocol.TList elem181 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.BOOL, iprot.readI32());
-				struct.deprList = new ArrayList<Boolean>(elem181.size);
-				for (int elem182 = 0; elem182 < elem181.size; ++elem182) {
-					boolean elem183 = iprot.readBool();
-					struct.deprList.add(elem183);
+				org.apache.thrift.protocol.TList elem206 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.BOOL, iprot.readI32());
+				struct.deprList = new ArrayList<Boolean>(elem206.size);
+				for (int elem207 = 0; elem207 < elem206.size; ++elem207) {
+					boolean elem208 = iprot.readBool();
+					struct.deprList.add(elem208);
 				}
 				struct.setDeprListIsSet(true);
+			}
+			if (incoming.get(12)) {
+				org.apache.thrift.protocol.TList elem209 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+				struct.EventsDefault = new ArrayList<Event>(elem209.size);
+				for (int elem210 = 0; elem210 < elem209.size; ++elem210) {
+					Event elem211 = new Event();
+					elem211.read(iprot);
+					struct.EventsDefault.add(elem211);
+				}
+				struct.setEventsDefaultIsSet(true);
+			}
+			if (incoming.get(13)) {
+				org.apache.thrift.protocol.TMap elem212 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+				struct.EventMapDefault = new HashMap<Long,Event>(2*elem212.size);
+				for (int elem213 = 0; elem213 < elem212.size; ++elem213) {
+					long elem215 = iprot.readI64();
+					Event elem214 = new Event();
+					elem214.read(iprot);
+					struct.EventMapDefault.put(elem215, elem214);
+				}
+				struct.setEventMapDefaultIsSet(true);
+			}
+			if (incoming.get(14)) {
+				org.apache.thrift.protocol.TSet elem216 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.STRUCT, iprot.readI32());
+				struct.EventSetDefault = new HashSet<Event>(2*elem216.size);
+				for (int elem217 = 0; elem217 < elem216.size; ++elem217) {
+					Event elem218 = new Event();
+					elem218.read(iprot);
+					struct.EventSetDefault.add(elem218);
+				}
+				struct.setEventSetDefaultIsSet(true);
 			}
 		}
 

--- a/test/expected/java/variety/EventsPublisher.java
+++ b/test/expected/java/variety/EventsPublisher.java
@@ -163,8 +163,8 @@ public class EventsPublisher {
 				FProtocol oprot = protocolFactory.getProtocol(memoryBuffer);
 				oprot.writeRequestHeader(ctx);
 				oprot.writeMessageBegin(new TMessage(op, TMessageType.CALL, 0));
-				long elem310 = req;
-				oprot.writeI64(elem310);
+				long elem345 = req;
+				oprot.writeI64(elem345);
 				oprot.writeMessageEnd();
 				transport.publish(topic, memoryBuffer.getWriteBytes());
 			}
@@ -179,8 +179,8 @@ public class EventsPublisher {
 				FProtocol oprot = protocolFactory.getProtocol(memoryBuffer);
 				oprot.writeRequestHeader(ctx);
 				oprot.writeMessageBegin(new TMessage(op, TMessageType.CALL, 0));
-				String elem311 = req;
-				oprot.writeString(elem311);
+				String elem346 = req;
+				oprot.writeString(elem346);
 				oprot.writeMessageEnd();
 				transport.publish(topic, memoryBuffer.getWriteBytes());
 			}
@@ -196,12 +196,12 @@ public class EventsPublisher {
 				oprot.writeRequestHeader(ctx);
 				oprot.writeMessageBegin(new TMessage(op, TMessageType.CALL, 0));
 				oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.MAP, req.size()));
-				for (java.util.Map<Long, Event> elem312 : req) {
-					oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, elem312.size()));
-					for (Map.Entry<Long, Event> elem313 : elem312.entrySet()) {
-						long elem314 = elem313.getKey();
-						oprot.writeI64(elem314);
-						elem313.getValue().write(oprot);
+				for (java.util.Map<Long, Event> elem347 : req) {
+					oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I64, org.apache.thrift.protocol.TType.STRUCT, elem347.size()));
+					for (Map.Entry<Long, Event> elem348 : elem347.entrySet()) {
+						long elem349 = elem348.getKey();
+						oprot.writeI64(elem349);
+						elem348.getValue().write(oprot);
 					}
 					oprot.writeMapEnd();
 				}

--- a/test/expected/java/variety/EventsSubscriber.java
+++ b/test/expected/java/variety/EventsSubscriber.java
@@ -240,19 +240,19 @@ public class EventsSubscriber {
 						iprot.readMessageEnd();
 						throw new TApplicationException(TApplicationExceptionType.UNKNOWN_METHOD);
 					}
-					org.apache.thrift.protocol.TList elem315 = iprot.readListBegin();
-					java.util.List<java.util.Map<Long, Event>> received = new ArrayList<java.util.Map<Long, Event>>(elem315.size);
-					for (int elem316 = 0; elem316 < elem315.size; ++elem316) {
-						org.apache.thrift.protocol.TMap elem318 = iprot.readMapBegin();
-						java.util.Map<Long, Event> elem317 = new HashMap<Long,Event>(2*elem318.size);
-						for (int elem319 = 0; elem319 < elem318.size; ++elem319) {
-							long elem321 = iprot.readI64();
-							Event elem320 = new Event();
-							elem320.read(iprot);
-							elem317.put(elem321, elem320);
+					org.apache.thrift.protocol.TList elem350 = iprot.readListBegin();
+					java.util.List<java.util.Map<Long, Event>> received = new ArrayList<java.util.Map<Long, Event>>(elem350.size);
+					for (int elem351 = 0; elem351 < elem350.size; ++elem351) {
+						org.apache.thrift.protocol.TMap elem353 = iprot.readMapBegin();
+						java.util.Map<Long, Event> elem352 = new HashMap<Long,Event>(2*elem353.size);
+						for (int elem354 = 0; elem354 < elem353.size; ++elem354) {
+							long elem356 = iprot.readI64();
+							Event elem355 = new Event();
+							elem355.read(iprot);
+							elem352.put(elem356, elem355);
 						}
 						iprot.readMapEnd();
-						received.add(elem317);
+						received.add(elem352);
 					}
 					iprot.readListEnd();
 					iprot.readMessageEnd();
@@ -374,19 +374,19 @@ public class EventsSubscriber {
 						iprot.readMessageEnd();
 						throw new TApplicationException(TApplicationExceptionType.UNKNOWN_METHOD);
 					}
-					org.apache.thrift.protocol.TList elem322 = iprot.readListBegin();
-					java.util.List<java.util.Map<Long, Event>> received = new ArrayList<java.util.Map<Long, Event>>(elem322.size);
-					for (int elem323 = 0; elem323 < elem322.size; ++elem323) {
-						org.apache.thrift.protocol.TMap elem325 = iprot.readMapBegin();
-						java.util.Map<Long, Event> elem324 = new HashMap<Long,Event>(2*elem325.size);
-						for (int elem326 = 0; elem326 < elem325.size; ++elem326) {
-							long elem328 = iprot.readI64();
-							Event elem327 = new Event();
-							elem327.read(iprot);
-							elem324.put(elem328, elem327);
+					org.apache.thrift.protocol.TList elem357 = iprot.readListBegin();
+					java.util.List<java.util.Map<Long, Event>> received = new ArrayList<java.util.Map<Long, Event>>(elem357.size);
+					for (int elem358 = 0; elem358 < elem357.size; ++elem358) {
+						org.apache.thrift.protocol.TMap elem360 = iprot.readMapBegin();
+						java.util.Map<Long, Event> elem359 = new HashMap<Long,Event>(2*elem360.size);
+						for (int elem361 = 0; elem361 < elem360.size; ++elem361) {
+							long elem363 = iprot.readI64();
+							Event elem362 = new Event();
+							elem362.read(iprot);
+							elem359.put(elem363, elem362);
 						}
 						iprot.readMapEnd();
-						received.add(elem324);
+						received.add(elem359);
 					}
 					iprot.readListEnd();
 					iprot.readMessageEnd();

--- a/test/expected/java/variety/FFoo.java
+++ b/test/expected/java/variety/FFoo.java
@@ -2202,13 +2202,13 @@ public class FFoo {
 
 				oprot.writeStructBegin(STRUCT_DESC);
 				oprot.writeFieldBegin(NUM_FIELD_DESC);
-				int elem222 = struct.num;
-				oprot.writeI32(elem222);
+				int elem257 = struct.num;
+				oprot.writeI32(elem257);
 				oprot.writeFieldEnd();
 				if (struct.Str != null) {
 					oprot.writeFieldBegin(STR_FIELD_DESC);
-					String elem223 = struct.Str;
-					oprot.writeString(elem223);
+					String elem258 = struct.Str;
+					oprot.writeString(elem258);
 					oprot.writeFieldEnd();
 				}
 				if (struct.event != null) {
@@ -2245,12 +2245,12 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 3);
 				if (struct.isSetNum()) {
-					int elem224 = struct.num;
-					oprot.writeI32(elem224);
+					int elem259 = struct.num;
+					oprot.writeI32(elem259);
 				}
 				if (struct.isSetStr()) {
-					String elem225 = struct.Str;
-					oprot.writeString(elem225);
+					String elem260 = struct.Str;
+					oprot.writeString(elem260);
 				}
 				if (struct.isSetEvent()) {
 					struct.event.write(oprot);
@@ -2774,8 +2774,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.isSetSuccess()) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					long elem226 = struct.success;
-					oprot.writeI64(elem226);
+					long elem261 = struct.success;
+					oprot.writeI64(elem261);
 					oprot.writeFieldEnd();
 				}
 				if (struct.awe != null) {
@@ -2817,8 +2817,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 3);
 				if (struct.isSetSuccess()) {
-					long elem227 = struct.success;
-					oprot.writeI64(elem227);
+					long elem262 = struct.success;
+					oprot.writeI64(elem262);
 				}
 				if (struct.isSetAwe()) {
 					struct.awe.write(oprot);
@@ -3237,12 +3237,12 @@ public class FFoo {
 							break;
 						case 2: // REQ
 							if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
-								org.apache.thrift.protocol.TMap elem230 = iprot.readMapBegin();
-								struct.req = new HashMap<Integer,String>(2*elem230.size);
-								for (int elem231 = 0; elem231 < elem230.size; ++elem231) {
-									int elem233 = iprot.readI32();
-									String elem232 = iprot.readString();
-									struct.req.put(elem233, elem232);
+								org.apache.thrift.protocol.TMap elem265 = iprot.readMapBegin();
+								struct.req = new HashMap<Integer,String>(2*elem265.size);
+								for (int elem266 = 0; elem266 < elem265.size; ++elem266) {
+									int elem268 = iprot.readI32();
+									String elem267 = iprot.readString();
+									struct.req.put(elem268, elem267);
 								}
 								iprot.readMapEnd();
 								struct.setReqIsSet(true);
@@ -3266,17 +3266,17 @@ public class FFoo {
 
 				oprot.writeStructBegin(STRUCT_DESC);
 				oprot.writeFieldBegin(ID_FIELD_DESC);
-				long elem234 = struct.id;
-				oprot.writeI64(elem234);
+				long elem269 = struct.id;
+				oprot.writeI64(elem269);
 				oprot.writeFieldEnd();
 				if (struct.req != null) {
 					oprot.writeFieldBegin(REQ_FIELD_DESC);
 					oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, struct.req.size()));
-					for (Map.Entry<Integer, String> elem235 : struct.req.entrySet()) {
-						int elem236 = elem235.getKey();
-						oprot.writeI32(elem236);
-						String elem237 = elem235.getValue();
-						oprot.writeString(elem237);
+					for (Map.Entry<Integer, String> elem270 : struct.req.entrySet()) {
+						int elem271 = elem270.getKey();
+						oprot.writeI32(elem271);
+						String elem272 = elem270.getValue();
+						oprot.writeString(elem272);
 					}
 					oprot.writeMapEnd();
 					oprot.writeFieldEnd();
@@ -3307,16 +3307,16 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetId()) {
-					long elem238 = struct.id;
-					oprot.writeI64(elem238);
+					long elem273 = struct.id;
+					oprot.writeI64(elem273);
 				}
 				if (struct.isSetReq()) {
 					oprot.writeI32(struct.req.size());
-					for (Map.Entry<Integer, String> elem239 : struct.req.entrySet()) {
-						int elem240 = elem239.getKey();
-						oprot.writeI32(elem240);
-						String elem241 = elem239.getValue();
-						oprot.writeString(elem241);
+					for (Map.Entry<Integer, String> elem274 : struct.req.entrySet()) {
+						int elem275 = elem274.getKey();
+						oprot.writeI32(elem275);
+						String elem276 = elem274.getValue();
+						oprot.writeString(elem276);
 					}
 				}
 			}
@@ -3330,12 +3330,12 @@ public class FFoo {
 					struct.setIdIsSet(true);
 				}
 				if (incoming.get(1)) {
-					org.apache.thrift.protocol.TMap elem242 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-					struct.req = new HashMap<Integer,String>(2*elem242.size);
-					for (int elem243 = 0; elem243 < elem242.size; ++elem243) {
-						int elem245 = iprot.readI32();
-						String elem244 = iprot.readString();
-						struct.req.put(elem245, elem244);
+					org.apache.thrift.protocol.TMap elem277 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+					struct.req = new HashMap<Integer,String>(2*elem277.size);
+					for (int elem278 = 0; elem278 < elem277.size; ++elem278) {
+						int elem280 = iprot.readI32();
+						String elem279 = iprot.readString();
+						struct.req.put(elem280, elem279);
 					}
 					struct.setReqIsSet(true);
 				}
@@ -3753,14 +3753,14 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.bin != null) {
 					oprot.writeFieldBegin(BIN_FIELD_DESC);
-					java.nio.ByteBuffer elem246 = struct.bin;
-					oprot.writeBinary(elem246);
+					java.nio.ByteBuffer elem281 = struct.bin;
+					oprot.writeBinary(elem281);
 					oprot.writeFieldEnd();
 				}
 				if (struct.Str != null) {
 					oprot.writeFieldBegin(STR_FIELD_DESC);
-					String elem247 = struct.Str;
-					oprot.writeString(elem247);
+					String elem282 = struct.Str;
+					oprot.writeString(elem282);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -3789,12 +3789,12 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetBin()) {
-					java.nio.ByteBuffer elem248 = struct.bin;
-					oprot.writeBinary(elem248);
+					java.nio.ByteBuffer elem283 = struct.bin;
+					oprot.writeBinary(elem283);
 				}
 				if (struct.isSetStr()) {
-					String elem249 = struct.Str;
-					oprot.writeString(elem249);
+					String elem284 = struct.Str;
+					oprot.writeString(elem284);
 				}
 			}
 
@@ -4228,8 +4228,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					java.nio.ByteBuffer elem250 = struct.success;
-					oprot.writeBinary(elem250);
+					java.nio.ByteBuffer elem285 = struct.success;
+					oprot.writeBinary(elem285);
 					oprot.writeFieldEnd();
 				}
 				if (struct.api != null) {
@@ -4263,8 +4263,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetSuccess()) {
-					java.nio.ByteBuffer elem251 = struct.success;
-					oprot.writeBinary(elem251);
+					java.nio.ByteBuffer elem286 = struct.success;
+					oprot.writeBinary(elem286);
 				}
 				if (struct.isSetApi()) {
 					struct.api.write(oprot);
@@ -4770,16 +4770,16 @@ public class FFoo {
 
 				oprot.writeStructBegin(STRUCT_DESC);
 				oprot.writeFieldBegin(OPT_NUM_FIELD_DESC);
-				int elem252 = struct.opt_num;
-				oprot.writeI32(elem252);
+				int elem287 = struct.opt_num;
+				oprot.writeI32(elem287);
 				oprot.writeFieldEnd();
 				oprot.writeFieldBegin(DEFAULT_NUM_FIELD_DESC);
-				int elem253 = struct.default_num;
-				oprot.writeI32(elem253);
+				int elem288 = struct.default_num;
+				oprot.writeI32(elem288);
 				oprot.writeFieldEnd();
 				oprot.writeFieldBegin(REQ_NUM_FIELD_DESC);
-				int elem254 = struct.req_num;
-				oprot.writeI32(elem254);
+				int elem289 = struct.req_num;
+				oprot.writeI32(elem289);
 				oprot.writeFieldEnd();
 				oprot.writeFieldStop();
 				oprot.writeStructEnd();
@@ -4798,8 +4798,8 @@ public class FFoo {
 			@Override
 			public void write(org.apache.thrift.protocol.TProtocol prot, param_modifiers_args struct) throws org.apache.thrift.TException {
 				TTupleProtocol oprot = (TTupleProtocol) prot;
-				int elem255 = struct.req_num;
-				oprot.writeI32(elem255);
+				int elem290 = struct.req_num;
+				oprot.writeI32(elem290);
 				BitSet optionals = new BitSet();
 				if (struct.isSetOpt_num()) {
 					optionals.set(0);
@@ -4809,12 +4809,12 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetOpt_num()) {
-					int elem256 = struct.opt_num;
-					oprot.writeI32(elem256);
+					int elem291 = struct.opt_num;
+					oprot.writeI32(elem291);
 				}
 				if (struct.isSetDefault_num()) {
-					int elem257 = struct.default_num;
-					oprot.writeI32(elem257);
+					int elem292 = struct.default_num;
+					oprot.writeI32(elem292);
 				}
 			}
 
@@ -5146,8 +5146,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.isSetSuccess()) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					long elem258 = struct.success;
-					oprot.writeI64(elem258);
+					long elem293 = struct.success;
+					oprot.writeI64(elem293);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -5173,8 +5173,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					long elem259 = struct.success;
-					oprot.writeI64(elem259);
+					long elem294 = struct.success;
+					oprot.writeI64(elem294);
 				}
 			}
 
@@ -5286,16 +5286,16 @@ public class FFoo {
 		public underlying_types_test_args(underlying_types_test_args other) {
 			if (other.isSetList_type()) {
 				this.list_type = new ArrayList<Long>(other.list_type.size());
-				for (long elem260 : other.list_type) {
-					long elem261 = elem260;
-					this.list_type.add(elem261);
+				for (long elem295 : other.list_type) {
+					long elem296 = elem295;
+					this.list_type.add(elem296);
 				}
 			}
 			if (other.isSetSet_type()) {
 				this.set_type = new HashSet<Long>(other.set_type.size());
-				for (long elem262 : other.set_type) {
-					long elem263 = elem262;
-					this.set_type.add(elem263);
+				for (long elem297 : other.set_type) {
+					long elem298 = elem297;
+					this.set_type.add(elem298);
 				}
 			}
 		}
@@ -5597,11 +5597,11 @@ public class FFoo {
 					switch (schemeField.id) {
 						case 1: // LIST_TYPE
 							if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-								org.apache.thrift.protocol.TList elem264 = iprot.readListBegin();
-								struct.list_type = new ArrayList<Long>(elem264.size);
-								for (int elem265 = 0; elem265 < elem264.size; ++elem265) {
-									long elem266 = iprot.readI64();
-									struct.list_type.add(elem266);
+								org.apache.thrift.protocol.TList elem299 = iprot.readListBegin();
+								struct.list_type = new ArrayList<Long>(elem299.size);
+								for (int elem300 = 0; elem300 < elem299.size; ++elem300) {
+									long elem301 = iprot.readI64();
+									struct.list_type.add(elem301);
 								}
 								iprot.readListEnd();
 								struct.setList_typeIsSet(true);
@@ -5611,11 +5611,11 @@ public class FFoo {
 							break;
 						case 2: // SET_TYPE
 							if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
-								org.apache.thrift.protocol.TSet elem267 = iprot.readSetBegin();
-								struct.set_type = new HashSet<Long>(2*elem267.size);
-								for (int elem268 = 0; elem268 < elem267.size; ++elem268) {
-									long elem269 = iprot.readI64();
-									struct.set_type.add(elem269);
+								org.apache.thrift.protocol.TSet elem302 = iprot.readSetBegin();
+								struct.set_type = new HashSet<Long>(2*elem302.size);
+								for (int elem303 = 0; elem303 < elem302.size; ++elem303) {
+									long elem304 = iprot.readI64();
+									struct.set_type.add(elem304);
 								}
 								iprot.readSetEnd();
 								struct.setSet_typeIsSet(true);
@@ -5641,9 +5641,9 @@ public class FFoo {
 				if (struct.list_type != null) {
 					oprot.writeFieldBegin(LIST_TYPE_FIELD_DESC);
 					oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.list_type.size()));
-					for (long elem270 : struct.list_type) {
-						long elem271 = elem270;
-						oprot.writeI64(elem271);
+					for (long elem305 : struct.list_type) {
+						long elem306 = elem305;
+						oprot.writeI64(elem306);
 					}
 					oprot.writeListEnd();
 					oprot.writeFieldEnd();
@@ -5651,9 +5651,9 @@ public class FFoo {
 				if (struct.set_type != null) {
 					oprot.writeFieldBegin(SET_TYPE_FIELD_DESC);
 					oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, struct.set_type.size()));
-					for (long elem272 : struct.set_type) {
-						long elem273 = elem272;
-						oprot.writeI64(elem273);
+					for (long elem307 : struct.set_type) {
+						long elem308 = elem307;
+						oprot.writeI64(elem308);
 					}
 					oprot.writeSetEnd();
 					oprot.writeFieldEnd();
@@ -5685,16 +5685,16 @@ public class FFoo {
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetList_type()) {
 					oprot.writeI32(struct.list_type.size());
-					for (long elem274 : struct.list_type) {
-						long elem275 = elem274;
-						oprot.writeI64(elem275);
+					for (long elem309 : struct.list_type) {
+						long elem310 = elem309;
+						oprot.writeI64(elem310);
 					}
 				}
 				if (struct.isSetSet_type()) {
 					oprot.writeI32(struct.set_type.size());
-					for (long elem276 : struct.set_type) {
-						long elem277 = elem276;
-						oprot.writeI64(elem277);
+					for (long elem311 : struct.set_type) {
+						long elem312 = elem311;
+						oprot.writeI64(elem312);
 					}
 				}
 			}
@@ -5704,20 +5704,20 @@ public class FFoo {
 				TTupleProtocol iprot = (TTupleProtocol) prot;
 				BitSet incoming = iprot.readBitSet(2);
 				if (incoming.get(0)) {
-					org.apache.thrift.protocol.TList elem278 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-					struct.list_type = new ArrayList<Long>(elem278.size);
-					for (int elem279 = 0; elem279 < elem278.size; ++elem279) {
-						long elem280 = iprot.readI64();
-						struct.list_type.add(elem280);
+					org.apache.thrift.protocol.TList elem313 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+					struct.list_type = new ArrayList<Long>(elem313.size);
+					for (int elem314 = 0; elem314 < elem313.size; ++elem314) {
+						long elem315 = iprot.readI64();
+						struct.list_type.add(elem315);
 					}
 					struct.setList_typeIsSet(true);
 				}
 				if (incoming.get(1)) {
-					org.apache.thrift.protocol.TSet elem281 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-					struct.set_type = new HashSet<Long>(2*elem281.size);
-					for (int elem282 = 0; elem282 < elem281.size; ++elem282) {
-						long elem283 = iprot.readI64();
-						struct.set_type.add(elem283);
+					org.apache.thrift.protocol.TSet elem316 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+					struct.set_type = new HashSet<Long>(2*elem316.size);
+					for (int elem317 = 0; elem317 < elem316.size; ++elem317) {
+						long elem318 = iprot.readI64();
+						struct.set_type.add(elem318);
 					}
 					struct.setSet_typeIsSet(true);
 				}
@@ -5814,9 +5814,9 @@ public class FFoo {
 		public underlying_types_test_result(underlying_types_test_result other) {
 			if (other.isSetSuccess()) {
 				this.success = new ArrayList<Long>(other.success.size());
-				for (long elem284 : other.success) {
-					long elem285 = elem284;
-					this.success.add(elem285);
+				for (long elem319 : other.success) {
+					long elem320 = elem319;
+					this.success.add(elem320);
 				}
 			}
 		}
@@ -6032,11 +6032,11 @@ public class FFoo {
 					switch (schemeField.id) {
 						case 0: // SUCCESS
 							if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-								org.apache.thrift.protocol.TList elem286 = iprot.readListBegin();
-								struct.success = new ArrayList<Long>(elem286.size);
-								for (int elem287 = 0; elem287 < elem286.size; ++elem287) {
-									long elem288 = iprot.readI64();
-									struct.success.add(elem288);
+								org.apache.thrift.protocol.TList elem321 = iprot.readListBegin();
+								struct.success = new ArrayList<Long>(elem321.size);
+								for (int elem322 = 0; elem322 < elem321.size; ++elem322) {
+									long elem323 = iprot.readI64();
+									struct.success.add(elem323);
 								}
 								iprot.readListEnd();
 								struct.setSuccessIsSet(true);
@@ -6062,9 +6062,9 @@ public class FFoo {
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
 					oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.success.size()));
-					for (long elem289 : struct.success) {
-						long elem290 = elem289;
-						oprot.writeI64(elem290);
+					for (long elem324 : struct.success) {
+						long elem325 = elem324;
+						oprot.writeI64(elem325);
 					}
 					oprot.writeListEnd();
 					oprot.writeFieldEnd();
@@ -6093,9 +6093,9 @@ public class FFoo {
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
 					oprot.writeI32(struct.success.size());
-					for (long elem291 : struct.success) {
-						long elem292 = elem291;
-						oprot.writeI64(elem292);
+					for (long elem326 : struct.success) {
+						long elem327 = elem326;
+						oprot.writeI64(elem327);
 					}
 				}
 			}
@@ -6105,11 +6105,11 @@ public class FFoo {
 				TTupleProtocol iprot = (TTupleProtocol) prot;
 				BitSet incoming = iprot.readBitSet(1);
 				if (incoming.get(0)) {
-					org.apache.thrift.protocol.TList elem293 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-					struct.success = new ArrayList<Long>(elem293.size);
-					for (int elem294 = 0; elem294 < elem293.size; ++elem294) {
-						long elem295 = iprot.readI64();
-						struct.success.add(elem295);
+					org.apache.thrift.protocol.TList elem328 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+					struct.success = new ArrayList<Long>(elem328.size);
+					for (int elem329 = 0; elem329 < elem328.size; ++elem329) {
+						long elem330 = iprot.readI64();
+						struct.success.add(elem330);
 					}
 					struct.setSuccessIsSet(true);
 				}
@@ -7271,8 +7271,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.isSetSuccess()) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					int elem296 = struct.success;
-					oprot.writeI32(elem296);
+					int elem331 = struct.success;
+					oprot.writeI32(elem331);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -7298,8 +7298,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					int elem297 = struct.success;
-					oprot.writeI32(elem297);
+					int elem332 = struct.success;
+					oprot.writeI32(elem332);
 				}
 			}
 
@@ -8342,8 +8342,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.newMessage != null) {
 					oprot.writeFieldBegin(NEW_MESSAGE_FIELD_DESC);
-					String elem298 = struct.newMessage;
-					oprot.writeString(elem298);
+					String elem333 = struct.newMessage;
+					oprot.writeString(elem333);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -8369,8 +8369,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetNewMessage()) {
-					String elem299 = struct.newMessage;
-					oprot.writeString(elem299);
+					String elem334 = struct.newMessage;
+					oprot.writeString(elem334);
 				}
 			}
 
@@ -8697,8 +8697,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					String elem300 = struct.success;
-					oprot.writeString(elem300);
+					String elem335 = struct.success;
+					oprot.writeString(elem335);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -8724,8 +8724,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					String elem301 = struct.success;
-					oprot.writeString(elem301);
+					String elem336 = struct.success;
+					oprot.writeString(elem336);
 				}
 			}
 
@@ -9052,8 +9052,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.messageArgs != null) {
 					oprot.writeFieldBegin(MESSAGE_ARGS_FIELD_DESC);
-					String elem302 = struct.messageArgs;
-					oprot.writeString(elem302);
+					String elem337 = struct.messageArgs;
+					oprot.writeString(elem337);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -9079,8 +9079,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetMessageArgs()) {
-					String elem303 = struct.messageArgs;
-					oprot.writeString(elem303);
+					String elem338 = struct.messageArgs;
+					oprot.writeString(elem338);
 				}
 			}
 
@@ -9407,8 +9407,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					String elem304 = struct.success;
-					oprot.writeString(elem304);
+					String elem339 = struct.success;
+					oprot.writeString(elem339);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -9434,8 +9434,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					String elem305 = struct.success;
-					oprot.writeString(elem305);
+					String elem340 = struct.success;
+					oprot.writeString(elem340);
 				}
 			}
 
@@ -9762,8 +9762,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.messageResult != null) {
 					oprot.writeFieldBegin(MESSAGE_RESULT_FIELD_DESC);
-					String elem306 = struct.messageResult;
-					oprot.writeString(elem306);
+					String elem341 = struct.messageResult;
+					oprot.writeString(elem341);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -9789,8 +9789,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetMessageResult()) {
-					String elem307 = struct.messageResult;
-					oprot.writeString(elem307);
+					String elem342 = struct.messageResult;
+					oprot.writeString(elem342);
 				}
 			}
 
@@ -10117,8 +10117,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					String elem308 = struct.success;
-					oprot.writeString(elem308);
+					String elem343 = struct.success;
+					oprot.writeString(elem343);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -10144,8 +10144,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					String elem309 = struct.success;
-					oprot.writeString(elem309);
+					String elem344 = struct.success;
+					oprot.writeString(elem344);
 				}
 			}
 

--- a/test/expected/java/variety/FooArgs.java
+++ b/test/expected/java/variety/FooArgs.java
@@ -519,20 +519,20 @@ public class FooArgs implements org.apache.thrift.TBase<FooArgs, FooArgs._Fields
 			oprot.writeStructBegin(STRUCT_DESC);
 			if (struct.newMessage != null) {
 				oprot.writeFieldBegin(NEW_MESSAGE_FIELD_DESC);
-				String elem184 = struct.newMessage;
-				oprot.writeString(elem184);
+				String elem219 = struct.newMessage;
+				oprot.writeString(elem219);
 				oprot.writeFieldEnd();
 			}
 			if (struct.messageArgs != null) {
 				oprot.writeFieldBegin(MESSAGE_ARGS_FIELD_DESC);
-				String elem185 = struct.messageArgs;
-				oprot.writeString(elem185);
+				String elem220 = struct.messageArgs;
+				oprot.writeString(elem220);
 				oprot.writeFieldEnd();
 			}
 			if (struct.messageResult != null) {
 				oprot.writeFieldBegin(MESSAGE_RESULT_FIELD_DESC);
-				String elem186 = struct.messageResult;
-				oprot.writeString(elem186);
+				String elem221 = struct.messageResult;
+				oprot.writeString(elem221);
 				oprot.writeFieldEnd();
 			}
 			oprot.writeFieldStop();
@@ -564,16 +564,16 @@ public class FooArgs implements org.apache.thrift.TBase<FooArgs, FooArgs._Fields
 			}
 			oprot.writeBitSet(optionals, 3);
 			if (struct.isSetNewMessage()) {
-				String elem187 = struct.newMessage;
-				oprot.writeString(elem187);
+				String elem222 = struct.newMessage;
+				oprot.writeString(elem222);
 			}
 			if (struct.isSetMessageArgs()) {
-				String elem188 = struct.messageArgs;
-				oprot.writeString(elem188);
+				String elem223 = struct.messageArgs;
+				oprot.writeString(elem223);
 			}
 			if (struct.isSetMessageResult()) {
-				String elem189 = struct.messageResult;
-				oprot.writeString(elem189);
+				String elem224 = struct.messageResult;
+				oprot.writeString(elem224);
 			}
 		}
 

--- a/test/expected/java/variety/TestingUnions.java
+++ b/test/expected/java/variety/TestingUnions.java
@@ -263,12 +263,12 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 					}
 				case REQUESTS:
 					if (field.type == REQUESTS_FIELD_DESC.type) {
-						org.apache.thrift.protocol.TMap elem190 = iprot.readMapBegin();
-						java.util.Map<Integer, String> Requests = new HashMap<Integer,String>(2*elem190.size);
-						for (int elem191 = 0; elem191 < elem190.size; ++elem191) {
-							Integer elem193 = iprot.readI32();
-							String elem192 = iprot.readString();
-							Requests.put(elem193, elem192);
+						org.apache.thrift.protocol.TMap elem225 = iprot.readMapBegin();
+						java.util.Map<Integer, String> Requests = new HashMap<Integer,String>(2*elem225.size);
+						for (int elem226 = 0; elem226 < elem225.size; ++elem226) {
+							Integer elem228 = iprot.readI32();
+							String elem227 = iprot.readString();
+							Requests.put(elem228, elem227);
 						}
 						iprot.readMapEnd();
 						return Requests;
@@ -306,44 +306,44 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 		switch (setField_) {
 			case AN_ID:
 				Long AnID = (Long)value_;
-				long elem194 = AnID;
-				oprot.writeI64(elem194);
+				long elem229 = AnID;
+				oprot.writeI64(elem229);
 				return;
 			case A_STRING:
 				String aString = (String)value_;
-				String elem195 = aString;
-				oprot.writeString(elem195);
+				String elem230 = aString;
+				oprot.writeString(elem230);
 				return;
 			case SOMEOTHERTHING:
 				Integer someotherthing = (Integer)value_;
-				int elem196 = someotherthing;
-				oprot.writeI32(elem196);
+				int elem231 = someotherthing;
+				oprot.writeI32(elem231);
 				return;
 			case AN_INT16:
 				Short AnInt16 = (Short)value_;
-				short elem197 = AnInt16;
-				oprot.writeI16(elem197);
+				short elem232 = AnInt16;
+				oprot.writeI16(elem232);
 				return;
 			case REQUESTS:
 				java.util.Map<Integer, String> Requests = (java.util.Map<Integer, String>)value_;
 				oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, Requests.size()));
-				for (Map.Entry<Integer, String> elem198 : Requests.entrySet()) {
-					int elem199 = elem198.getKey();
-					oprot.writeI32(elem199);
-					String elem200 = elem198.getValue();
-					oprot.writeString(elem200);
+				for (Map.Entry<Integer, String> elem233 : Requests.entrySet()) {
+					int elem234 = elem233.getKey();
+					oprot.writeI32(elem234);
+					String elem235 = elem233.getValue();
+					oprot.writeString(elem235);
 				}
 				oprot.writeMapEnd();
 				return;
 			case BIN_FIELD_IN_UNION:
 				java.nio.ByteBuffer bin_field_in_union = (java.nio.ByteBuffer)value_;
-				java.nio.ByteBuffer elem201 = bin_field_in_union;
-				oprot.writeBinary(elem201);
+				java.nio.ByteBuffer elem236 = bin_field_in_union;
+				oprot.writeBinary(elem236);
 				return;
 			case DEPR:
 				Boolean depr = (Boolean)value_;
-				boolean elem202 = depr;
-				oprot.writeBool(elem202);
+				boolean elem237 = depr;
+				oprot.writeBool(elem237);
 				return;
 			default:
 				throw new IllegalStateException("Cannot write union with unknown field " + setField_);
@@ -368,12 +368,12 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 					Short AnInt16 = iprot.readI16();
 					return AnInt16;
 				case REQUESTS:
-					org.apache.thrift.protocol.TMap elem203 = iprot.readMapBegin();
-					java.util.Map<Integer, String> Requests = new HashMap<Integer,String>(2*elem203.size);
-					for (int elem204 = 0; elem204 < elem203.size; ++elem204) {
-						Integer elem206 = iprot.readI32();
-						String elem205 = iprot.readString();
-						Requests.put(elem206, elem205);
+					org.apache.thrift.protocol.TMap elem238 = iprot.readMapBegin();
+					java.util.Map<Integer, String> Requests = new HashMap<Integer,String>(2*elem238.size);
+					for (int elem239 = 0; elem239 < elem238.size; ++elem239) {
+						Integer elem241 = iprot.readI32();
+						String elem240 = iprot.readString();
+						Requests.put(elem241, elem240);
 					}
 					iprot.readMapEnd();
 					return Requests;
@@ -396,44 +396,44 @@ public class TestingUnions extends org.apache.thrift.TUnion<TestingUnions, Testi
 		switch (setField_) {
 			case AN_ID:
 				Long AnID = (Long)value_;
-				long elem207 = AnID;
-				oprot.writeI64(elem207);
+				long elem242 = AnID;
+				oprot.writeI64(elem242);
 				return;
 			case A_STRING:
 				String aString = (String)value_;
-				String elem208 = aString;
-				oprot.writeString(elem208);
+				String elem243 = aString;
+				oprot.writeString(elem243);
 				return;
 			case SOMEOTHERTHING:
 				Integer someotherthing = (Integer)value_;
-				int elem209 = someotherthing;
-				oprot.writeI32(elem209);
+				int elem244 = someotherthing;
+				oprot.writeI32(elem244);
 				return;
 			case AN_INT16:
 				Short AnInt16 = (Short)value_;
-				short elem210 = AnInt16;
-				oprot.writeI16(elem210);
+				short elem245 = AnInt16;
+				oprot.writeI16(elem245);
 				return;
 			case REQUESTS:
 				java.util.Map<Integer, String> Requests = (java.util.Map<Integer, String>)value_;
 				oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, Requests.size()));
-				for (Map.Entry<Integer, String> elem211 : Requests.entrySet()) {
-					int elem212 = elem211.getKey();
-					oprot.writeI32(elem212);
-					String elem213 = elem211.getValue();
-					oprot.writeString(elem213);
+				for (Map.Entry<Integer, String> elem246 : Requests.entrySet()) {
+					int elem247 = elem246.getKey();
+					oprot.writeI32(elem247);
+					String elem248 = elem246.getValue();
+					oprot.writeString(elem248);
 				}
 				oprot.writeMapEnd();
 				return;
 			case BIN_FIELD_IN_UNION:
 				java.nio.ByteBuffer bin_field_in_union = (java.nio.ByteBuffer)value_;
-				java.nio.ByteBuffer elem214 = bin_field_in_union;
-				oprot.writeBinary(elem214);
+				java.nio.ByteBuffer elem249 = bin_field_in_union;
+				oprot.writeBinary(elem249);
 				return;
 			case DEPR:
 				Boolean depr = (Boolean)value_;
-				boolean elem215 = depr;
-				oprot.writeBool(elem215);
+				boolean elem250 = depr;
+				oprot.writeBool(elem250);
 				return;
 			default:
 				throw new IllegalStateException("Cannot write union with unknown field " + setField_);

--- a/test/expected/java/variety_async/FFoo.java
+++ b/test/expected/java/variety_async/FFoo.java
@@ -2309,13 +2309,13 @@ public class FFoo {
 
 				oprot.writeStructBegin(STRUCT_DESC);
 				oprot.writeFieldBegin(NUM_FIELD_DESC);
-				int elem222 = struct.num;
-				oprot.writeI32(elem222);
+				int elem257 = struct.num;
+				oprot.writeI32(elem257);
 				oprot.writeFieldEnd();
 				if (struct.Str != null) {
 					oprot.writeFieldBegin(STR_FIELD_DESC);
-					String elem223 = struct.Str;
-					oprot.writeString(elem223);
+					String elem258 = struct.Str;
+					oprot.writeString(elem258);
 					oprot.writeFieldEnd();
 				}
 				if (struct.event != null) {
@@ -2352,12 +2352,12 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 3);
 				if (struct.isSetNum()) {
-					int elem224 = struct.num;
-					oprot.writeI32(elem224);
+					int elem259 = struct.num;
+					oprot.writeI32(elem259);
 				}
 				if (struct.isSetStr()) {
-					String elem225 = struct.Str;
-					oprot.writeString(elem225);
+					String elem260 = struct.Str;
+					oprot.writeString(elem260);
 				}
 				if (struct.isSetEvent()) {
 					struct.event.write(oprot);
@@ -2881,8 +2881,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.isSetSuccess()) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					long elem226 = struct.success;
-					oprot.writeI64(elem226);
+					long elem261 = struct.success;
+					oprot.writeI64(elem261);
 					oprot.writeFieldEnd();
 				}
 				if (struct.awe != null) {
@@ -2924,8 +2924,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 3);
 				if (struct.isSetSuccess()) {
-					long elem227 = struct.success;
-					oprot.writeI64(elem227);
+					long elem262 = struct.success;
+					oprot.writeI64(elem262);
 				}
 				if (struct.isSetAwe()) {
 					struct.awe.write(oprot);
@@ -3344,12 +3344,12 @@ public class FFoo {
 							break;
 						case 2: // REQ
 							if (schemeField.type == org.apache.thrift.protocol.TType.MAP) {
-								org.apache.thrift.protocol.TMap elem230 = iprot.readMapBegin();
-								struct.req = new HashMap<Integer,String>(2*elem230.size);
-								for (int elem231 = 0; elem231 < elem230.size; ++elem231) {
-									int elem233 = iprot.readI32();
-									String elem232 = iprot.readString();
-									struct.req.put(elem233, elem232);
+								org.apache.thrift.protocol.TMap elem265 = iprot.readMapBegin();
+								struct.req = new HashMap<Integer,String>(2*elem265.size);
+								for (int elem266 = 0; elem266 < elem265.size; ++elem266) {
+									int elem268 = iprot.readI32();
+									String elem267 = iprot.readString();
+									struct.req.put(elem268, elem267);
 								}
 								iprot.readMapEnd();
 								struct.setReqIsSet(true);
@@ -3373,17 +3373,17 @@ public class FFoo {
 
 				oprot.writeStructBegin(STRUCT_DESC);
 				oprot.writeFieldBegin(ID_FIELD_DESC);
-				long elem234 = struct.id;
-				oprot.writeI64(elem234);
+				long elem269 = struct.id;
+				oprot.writeI64(elem269);
 				oprot.writeFieldEnd();
 				if (struct.req != null) {
 					oprot.writeFieldBegin(REQ_FIELD_DESC);
 					oprot.writeMapBegin(new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, struct.req.size()));
-					for (Map.Entry<Integer, String> elem235 : struct.req.entrySet()) {
-						int elem236 = elem235.getKey();
-						oprot.writeI32(elem236);
-						String elem237 = elem235.getValue();
-						oprot.writeString(elem237);
+					for (Map.Entry<Integer, String> elem270 : struct.req.entrySet()) {
+						int elem271 = elem270.getKey();
+						oprot.writeI32(elem271);
+						String elem272 = elem270.getValue();
+						oprot.writeString(elem272);
 					}
 					oprot.writeMapEnd();
 					oprot.writeFieldEnd();
@@ -3414,16 +3414,16 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetId()) {
-					long elem238 = struct.id;
-					oprot.writeI64(elem238);
+					long elem273 = struct.id;
+					oprot.writeI64(elem273);
 				}
 				if (struct.isSetReq()) {
 					oprot.writeI32(struct.req.size());
-					for (Map.Entry<Integer, String> elem239 : struct.req.entrySet()) {
-						int elem240 = elem239.getKey();
-						oprot.writeI32(elem240);
-						String elem241 = elem239.getValue();
-						oprot.writeString(elem241);
+					for (Map.Entry<Integer, String> elem274 : struct.req.entrySet()) {
+						int elem275 = elem274.getKey();
+						oprot.writeI32(elem275);
+						String elem276 = elem274.getValue();
+						oprot.writeString(elem276);
 					}
 				}
 			}
@@ -3437,12 +3437,12 @@ public class FFoo {
 					struct.setIdIsSet(true);
 				}
 				if (incoming.get(1)) {
-					org.apache.thrift.protocol.TMap elem242 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
-					struct.req = new HashMap<Integer,String>(2*elem242.size);
-					for (int elem243 = 0; elem243 < elem242.size; ++elem243) {
-						int elem245 = iprot.readI32();
-						String elem244 = iprot.readString();
-						struct.req.put(elem245, elem244);
+					org.apache.thrift.protocol.TMap elem277 = new org.apache.thrift.protocol.TMap(org.apache.thrift.protocol.TType.I32, org.apache.thrift.protocol.TType.STRING, iprot.readI32());
+					struct.req = new HashMap<Integer,String>(2*elem277.size);
+					for (int elem278 = 0; elem278 < elem277.size; ++elem278) {
+						int elem280 = iprot.readI32();
+						String elem279 = iprot.readString();
+						struct.req.put(elem280, elem279);
 					}
 					struct.setReqIsSet(true);
 				}
@@ -3860,14 +3860,14 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.bin != null) {
 					oprot.writeFieldBegin(BIN_FIELD_DESC);
-					java.nio.ByteBuffer elem246 = struct.bin;
-					oprot.writeBinary(elem246);
+					java.nio.ByteBuffer elem281 = struct.bin;
+					oprot.writeBinary(elem281);
 					oprot.writeFieldEnd();
 				}
 				if (struct.Str != null) {
 					oprot.writeFieldBegin(STR_FIELD_DESC);
-					String elem247 = struct.Str;
-					oprot.writeString(elem247);
+					String elem282 = struct.Str;
+					oprot.writeString(elem282);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -3896,12 +3896,12 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetBin()) {
-					java.nio.ByteBuffer elem248 = struct.bin;
-					oprot.writeBinary(elem248);
+					java.nio.ByteBuffer elem283 = struct.bin;
+					oprot.writeBinary(elem283);
 				}
 				if (struct.isSetStr()) {
-					String elem249 = struct.Str;
-					oprot.writeString(elem249);
+					String elem284 = struct.Str;
+					oprot.writeString(elem284);
 				}
 			}
 
@@ -4335,8 +4335,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					java.nio.ByteBuffer elem250 = struct.success;
-					oprot.writeBinary(elem250);
+					java.nio.ByteBuffer elem285 = struct.success;
+					oprot.writeBinary(elem285);
 					oprot.writeFieldEnd();
 				}
 				if (struct.api != null) {
@@ -4370,8 +4370,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetSuccess()) {
-					java.nio.ByteBuffer elem251 = struct.success;
-					oprot.writeBinary(elem251);
+					java.nio.ByteBuffer elem286 = struct.success;
+					oprot.writeBinary(elem286);
 				}
 				if (struct.isSetApi()) {
 					struct.api.write(oprot);
@@ -4877,16 +4877,16 @@ public class FFoo {
 
 				oprot.writeStructBegin(STRUCT_DESC);
 				oprot.writeFieldBegin(OPT_NUM_FIELD_DESC);
-				int elem252 = struct.opt_num;
-				oprot.writeI32(elem252);
+				int elem287 = struct.opt_num;
+				oprot.writeI32(elem287);
 				oprot.writeFieldEnd();
 				oprot.writeFieldBegin(DEFAULT_NUM_FIELD_DESC);
-				int elem253 = struct.default_num;
-				oprot.writeI32(elem253);
+				int elem288 = struct.default_num;
+				oprot.writeI32(elem288);
 				oprot.writeFieldEnd();
 				oprot.writeFieldBegin(REQ_NUM_FIELD_DESC);
-				int elem254 = struct.req_num;
-				oprot.writeI32(elem254);
+				int elem289 = struct.req_num;
+				oprot.writeI32(elem289);
 				oprot.writeFieldEnd();
 				oprot.writeFieldStop();
 				oprot.writeStructEnd();
@@ -4905,8 +4905,8 @@ public class FFoo {
 			@Override
 			public void write(org.apache.thrift.protocol.TProtocol prot, param_modifiers_args struct) throws org.apache.thrift.TException {
 				TTupleProtocol oprot = (TTupleProtocol) prot;
-				int elem255 = struct.req_num;
-				oprot.writeI32(elem255);
+				int elem290 = struct.req_num;
+				oprot.writeI32(elem290);
 				BitSet optionals = new BitSet();
 				if (struct.isSetOpt_num()) {
 					optionals.set(0);
@@ -4916,12 +4916,12 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetOpt_num()) {
-					int elem256 = struct.opt_num;
-					oprot.writeI32(elem256);
+					int elem291 = struct.opt_num;
+					oprot.writeI32(elem291);
 				}
 				if (struct.isSetDefault_num()) {
-					int elem257 = struct.default_num;
-					oprot.writeI32(elem257);
+					int elem292 = struct.default_num;
+					oprot.writeI32(elem292);
 				}
 			}
 
@@ -5253,8 +5253,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.isSetSuccess()) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					long elem258 = struct.success;
-					oprot.writeI64(elem258);
+					long elem293 = struct.success;
+					oprot.writeI64(elem293);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -5280,8 +5280,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					long elem259 = struct.success;
-					oprot.writeI64(elem259);
+					long elem294 = struct.success;
+					oprot.writeI64(elem294);
 				}
 			}
 
@@ -5393,16 +5393,16 @@ public class FFoo {
 		public underlying_types_test_args(underlying_types_test_args other) {
 			if (other.isSetList_type()) {
 				this.list_type = new ArrayList<Long>(other.list_type.size());
-				for (long elem260 : other.list_type) {
-					long elem261 = elem260;
-					this.list_type.add(elem261);
+				for (long elem295 : other.list_type) {
+					long elem296 = elem295;
+					this.list_type.add(elem296);
 				}
 			}
 			if (other.isSetSet_type()) {
 				this.set_type = new HashSet<Long>(other.set_type.size());
-				for (long elem262 : other.set_type) {
-					long elem263 = elem262;
-					this.set_type.add(elem263);
+				for (long elem297 : other.set_type) {
+					long elem298 = elem297;
+					this.set_type.add(elem298);
 				}
 			}
 		}
@@ -5704,11 +5704,11 @@ public class FFoo {
 					switch (schemeField.id) {
 						case 1: // LIST_TYPE
 							if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-								org.apache.thrift.protocol.TList elem264 = iprot.readListBegin();
-								struct.list_type = new ArrayList<Long>(elem264.size);
-								for (int elem265 = 0; elem265 < elem264.size; ++elem265) {
-									long elem266 = iprot.readI64();
-									struct.list_type.add(elem266);
+								org.apache.thrift.protocol.TList elem299 = iprot.readListBegin();
+								struct.list_type = new ArrayList<Long>(elem299.size);
+								for (int elem300 = 0; elem300 < elem299.size; ++elem300) {
+									long elem301 = iprot.readI64();
+									struct.list_type.add(elem301);
 								}
 								iprot.readListEnd();
 								struct.setList_typeIsSet(true);
@@ -5718,11 +5718,11 @@ public class FFoo {
 							break;
 						case 2: // SET_TYPE
 							if (schemeField.type == org.apache.thrift.protocol.TType.SET) {
-								org.apache.thrift.protocol.TSet elem267 = iprot.readSetBegin();
-								struct.set_type = new HashSet<Long>(2*elem267.size);
-								for (int elem268 = 0; elem268 < elem267.size; ++elem268) {
-									long elem269 = iprot.readI64();
-									struct.set_type.add(elem269);
+								org.apache.thrift.protocol.TSet elem302 = iprot.readSetBegin();
+								struct.set_type = new HashSet<Long>(2*elem302.size);
+								for (int elem303 = 0; elem303 < elem302.size; ++elem303) {
+									long elem304 = iprot.readI64();
+									struct.set_type.add(elem304);
 								}
 								iprot.readSetEnd();
 								struct.setSet_typeIsSet(true);
@@ -5748,9 +5748,9 @@ public class FFoo {
 				if (struct.list_type != null) {
 					oprot.writeFieldBegin(LIST_TYPE_FIELD_DESC);
 					oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.list_type.size()));
-					for (long elem270 : struct.list_type) {
-						long elem271 = elem270;
-						oprot.writeI64(elem271);
+					for (long elem305 : struct.list_type) {
+						long elem306 = elem305;
+						oprot.writeI64(elem306);
 					}
 					oprot.writeListEnd();
 					oprot.writeFieldEnd();
@@ -5758,9 +5758,9 @@ public class FFoo {
 				if (struct.set_type != null) {
 					oprot.writeFieldBegin(SET_TYPE_FIELD_DESC);
 					oprot.writeSetBegin(new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, struct.set_type.size()));
-					for (long elem272 : struct.set_type) {
-						long elem273 = elem272;
-						oprot.writeI64(elem273);
+					for (long elem307 : struct.set_type) {
+						long elem308 = elem307;
+						oprot.writeI64(elem308);
 					}
 					oprot.writeSetEnd();
 					oprot.writeFieldEnd();
@@ -5792,16 +5792,16 @@ public class FFoo {
 				oprot.writeBitSet(optionals, 2);
 				if (struct.isSetList_type()) {
 					oprot.writeI32(struct.list_type.size());
-					for (long elem274 : struct.list_type) {
-						long elem275 = elem274;
-						oprot.writeI64(elem275);
+					for (long elem309 : struct.list_type) {
+						long elem310 = elem309;
+						oprot.writeI64(elem310);
 					}
 				}
 				if (struct.isSetSet_type()) {
 					oprot.writeI32(struct.set_type.size());
-					for (long elem276 : struct.set_type) {
-						long elem277 = elem276;
-						oprot.writeI64(elem277);
+					for (long elem311 : struct.set_type) {
+						long elem312 = elem311;
+						oprot.writeI64(elem312);
 					}
 				}
 			}
@@ -5811,20 +5811,20 @@ public class FFoo {
 				TTupleProtocol iprot = (TTupleProtocol) prot;
 				BitSet incoming = iprot.readBitSet(2);
 				if (incoming.get(0)) {
-					org.apache.thrift.protocol.TList elem278 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-					struct.list_type = new ArrayList<Long>(elem278.size);
-					for (int elem279 = 0; elem279 < elem278.size; ++elem279) {
-						long elem280 = iprot.readI64();
-						struct.list_type.add(elem280);
+					org.apache.thrift.protocol.TList elem313 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+					struct.list_type = new ArrayList<Long>(elem313.size);
+					for (int elem314 = 0; elem314 < elem313.size; ++elem314) {
+						long elem315 = iprot.readI64();
+						struct.list_type.add(elem315);
 					}
 					struct.setList_typeIsSet(true);
 				}
 				if (incoming.get(1)) {
-					org.apache.thrift.protocol.TSet elem281 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-					struct.set_type = new HashSet<Long>(2*elem281.size);
-					for (int elem282 = 0; elem282 < elem281.size; ++elem282) {
-						long elem283 = iprot.readI64();
-						struct.set_type.add(elem283);
+					org.apache.thrift.protocol.TSet elem316 = new org.apache.thrift.protocol.TSet(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+					struct.set_type = new HashSet<Long>(2*elem316.size);
+					for (int elem317 = 0; elem317 < elem316.size; ++elem317) {
+						long elem318 = iprot.readI64();
+						struct.set_type.add(elem318);
 					}
 					struct.setSet_typeIsSet(true);
 				}
@@ -5921,9 +5921,9 @@ public class FFoo {
 		public underlying_types_test_result(underlying_types_test_result other) {
 			if (other.isSetSuccess()) {
 				this.success = new ArrayList<Long>(other.success.size());
-				for (long elem284 : other.success) {
-					long elem285 = elem284;
-					this.success.add(elem285);
+				for (long elem319 : other.success) {
+					long elem320 = elem319;
+					this.success.add(elem320);
 				}
 			}
 		}
@@ -6139,11 +6139,11 @@ public class FFoo {
 					switch (schemeField.id) {
 						case 0: // SUCCESS
 							if (schemeField.type == org.apache.thrift.protocol.TType.LIST) {
-								org.apache.thrift.protocol.TList elem286 = iprot.readListBegin();
-								struct.success = new ArrayList<Long>(elem286.size);
-								for (int elem287 = 0; elem287 < elem286.size; ++elem287) {
-									long elem288 = iprot.readI64();
-									struct.success.add(elem288);
+								org.apache.thrift.protocol.TList elem321 = iprot.readListBegin();
+								struct.success = new ArrayList<Long>(elem321.size);
+								for (int elem322 = 0; elem322 < elem321.size; ++elem322) {
+									long elem323 = iprot.readI64();
+									struct.success.add(elem323);
 								}
 								iprot.readListEnd();
 								struct.setSuccessIsSet(true);
@@ -6169,9 +6169,9 @@ public class FFoo {
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
 					oprot.writeListBegin(new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, struct.success.size()));
-					for (long elem289 : struct.success) {
-						long elem290 = elem289;
-						oprot.writeI64(elem290);
+					for (long elem324 : struct.success) {
+						long elem325 = elem324;
+						oprot.writeI64(elem325);
 					}
 					oprot.writeListEnd();
 					oprot.writeFieldEnd();
@@ -6200,9 +6200,9 @@ public class FFoo {
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
 					oprot.writeI32(struct.success.size());
-					for (long elem291 : struct.success) {
-						long elem292 = elem291;
-						oprot.writeI64(elem292);
+					for (long elem326 : struct.success) {
+						long elem327 = elem326;
+						oprot.writeI64(elem327);
 					}
 				}
 			}
@@ -6212,11 +6212,11 @@ public class FFoo {
 				TTupleProtocol iprot = (TTupleProtocol) prot;
 				BitSet incoming = iprot.readBitSet(1);
 				if (incoming.get(0)) {
-					org.apache.thrift.protocol.TList elem293 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
-					struct.success = new ArrayList<Long>(elem293.size);
-					for (int elem294 = 0; elem294 < elem293.size; ++elem294) {
-						long elem295 = iprot.readI64();
-						struct.success.add(elem295);
+					org.apache.thrift.protocol.TList elem328 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.I64, iprot.readI32());
+					struct.success = new ArrayList<Long>(elem328.size);
+					for (int elem329 = 0; elem329 < elem328.size; ++elem329) {
+						long elem330 = iprot.readI64();
+						struct.success.add(elem330);
 					}
 					struct.setSuccessIsSet(true);
 				}
@@ -7378,8 +7378,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.isSetSuccess()) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					int elem296 = struct.success;
-					oprot.writeI32(elem296);
+					int elem331 = struct.success;
+					oprot.writeI32(elem331);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -7405,8 +7405,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					int elem297 = struct.success;
-					oprot.writeI32(elem297);
+					int elem332 = struct.success;
+					oprot.writeI32(elem332);
 				}
 			}
 
@@ -8449,8 +8449,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.newMessage != null) {
 					oprot.writeFieldBegin(NEW_MESSAGE_FIELD_DESC);
-					String elem298 = struct.newMessage;
-					oprot.writeString(elem298);
+					String elem333 = struct.newMessage;
+					oprot.writeString(elem333);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -8476,8 +8476,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetNewMessage()) {
-					String elem299 = struct.newMessage;
-					oprot.writeString(elem299);
+					String elem334 = struct.newMessage;
+					oprot.writeString(elem334);
 				}
 			}
 
@@ -8804,8 +8804,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					String elem300 = struct.success;
-					oprot.writeString(elem300);
+					String elem335 = struct.success;
+					oprot.writeString(elem335);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -8831,8 +8831,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					String elem301 = struct.success;
-					oprot.writeString(elem301);
+					String elem336 = struct.success;
+					oprot.writeString(elem336);
 				}
 			}
 
@@ -9159,8 +9159,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.messageArgs != null) {
 					oprot.writeFieldBegin(MESSAGE_ARGS_FIELD_DESC);
-					String elem302 = struct.messageArgs;
-					oprot.writeString(elem302);
+					String elem337 = struct.messageArgs;
+					oprot.writeString(elem337);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -9186,8 +9186,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetMessageArgs()) {
-					String elem303 = struct.messageArgs;
-					oprot.writeString(elem303);
+					String elem338 = struct.messageArgs;
+					oprot.writeString(elem338);
 				}
 			}
 
@@ -9514,8 +9514,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					String elem304 = struct.success;
-					oprot.writeString(elem304);
+					String elem339 = struct.success;
+					oprot.writeString(elem339);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -9541,8 +9541,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					String elem305 = struct.success;
-					oprot.writeString(elem305);
+					String elem340 = struct.success;
+					oprot.writeString(elem340);
 				}
 			}
 
@@ -9869,8 +9869,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.messageResult != null) {
 					oprot.writeFieldBegin(MESSAGE_RESULT_FIELD_DESC);
-					String elem306 = struct.messageResult;
-					oprot.writeString(elem306);
+					String elem341 = struct.messageResult;
+					oprot.writeString(elem341);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -9896,8 +9896,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetMessageResult()) {
-					String elem307 = struct.messageResult;
-					oprot.writeString(elem307);
+					String elem342 = struct.messageResult;
+					oprot.writeString(elem342);
 				}
 			}
 
@@ -10224,8 +10224,8 @@ public class FFoo {
 				oprot.writeStructBegin(STRUCT_DESC);
 				if (struct.success != null) {
 					oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
-					String elem308 = struct.success;
-					oprot.writeString(elem308);
+					String elem343 = struct.success;
+					oprot.writeString(elem343);
 					oprot.writeFieldEnd();
 				}
 				oprot.writeFieldStop();
@@ -10251,8 +10251,8 @@ public class FFoo {
 				}
 				oprot.writeBitSet(optionals, 1);
 				if (struct.isSetSuccess()) {
-					String elem309 = struct.success;
-					oprot.writeString(elem309);
+					String elem344 = struct.success;
+					oprot.writeString(elem344);
 				}
 			}
 

--- a/test/expected/python.asyncio/actual_base/ttypes.py
+++ b/test/expected/python.asyncio/actual_base/ttypes.py
@@ -114,11 +114,11 @@ class nested_thing(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.things = []
-                    (_, elem67) = iprot.readListBegin()
-                    for _ in range(elem67):
-                        elem68 = thing()
-                        elem68.read(iprot)
-                        self.things.append(elem68)
+                    (_, elem78) = iprot.readListBegin()
+                    for _ in range(elem78):
+                        elem79 = thing()
+                        elem79.read(iprot)
+                        self.things.append(elem79)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -134,8 +134,8 @@ class nested_thing(object):
         if self.things is not None:
             oprot.writeFieldBegin('things', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.things))
-            for elem69 in self.things:
-                elem69.write(oprot)
+            for elem80 in self.things:
+                elem80.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()

--- a/test/expected/python.asyncio/variety/f_Events_publisher.py
+++ b/test/expected/python.asyncio/variety/f_Events_publisher.py
@@ -149,11 +149,11 @@ class EventsPublisher(object):
         oprot.write_request_headers(ctx)
         oprot.writeMessageBegin(op, TMessageType.CALL, 0)
         oprot.writeListBegin(TType.MAP, len(req))
-        for elem59 in req:
-            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(elem59))
-            for elem61, elem60 in elem59.items():
-                oprot.writeI64(elem61)
-                elem60.write(oprot)
+        for elem70 in req:
+            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(elem70))
+            for elem72, elem71 in elem70.items():
+                oprot.writeI64(elem72)
+                elem71.write(oprot)
             oprot.writeMapEnd()
         oprot.writeListEnd()
         oprot.writeMessageEnd()

--- a/test/expected/python.asyncio/variety/f_Events_subscriber.py
+++ b/test/expected/python.asyncio/variety/f_Events_subscriber.py
@@ -198,17 +198,17 @@ class EventsSubscriber(object):
                 iprot.readMessageEnd()
                 raise TApplicationException(TApplicationExceptionType.UNKNOWN_METHOD)
             req = []
-            (_, elem62) = iprot.readListBegin()
-            for _ in range(elem62):
-                elem63 = {}
-                (_, _, elem64) = iprot.readMapBegin()
-                for _ in range(elem64):
-                    elem66 = iprot.readI64()
-                    elem65 = Event()
-                    elem65.read(iprot)
-                    elem63[elem66] = elem65
+            (_, elem73) = iprot.readListBegin()
+            for _ in range(elem73):
+                elem74 = {}
+                (_, _, elem75) = iprot.readMapBegin()
+                for _ in range(elem75):
+                    elem77 = iprot.readI64()
+                    elem76 = Event()
+                    elem76.read(iprot)
+                    elem74[elem77] = elem76
                 iprot.readMapEnd()
-                req.append(elem63)
+                req.append(elem74)
             iprot.readListEnd()
             iprot.readMessageEnd()
             try:

--- a/test/expected/python.asyncio/variety/f_Foo.py
+++ b/test/expected/python.asyncio/variety/f_Foo.py
@@ -1356,11 +1356,11 @@ class oneWay_args(object):
             elif fid == 2:
                 if ftype == TType.MAP:
                     self.req = {}
-                    (_, _, elem45) = iprot.readMapBegin()
-                    for _ in range(elem45):
-                        elem47 = iprot.readI32()
-                        elem46 = iprot.readString()
-                        self.req[elem47] = elem46
+                    (_, _, elem56) = iprot.readMapBegin()
+                    for _ in range(elem56):
+                        elem58 = iprot.readI32()
+                        elem57 = iprot.readString()
+                        self.req[elem58] = elem57
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -1380,9 +1380,9 @@ class oneWay_args(object):
         if self.req is not None:
             oprot.writeFieldBegin('req', TType.MAP, 2)
             oprot.writeMapBegin(TType.I32, TType.STRING, len(self.req))
-            for elem49, elem48 in self.req.items():
-                oprot.writeI32(elem49)
-                oprot.writeString(elem48)
+            for elem60, elem59 in self.req.items():
+                oprot.writeI32(elem60)
+                oprot.writeString(elem59)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1694,20 +1694,20 @@ class underlying_types_test_args(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.list_type = []
-                    (_, elem50) = iprot.readListBegin()
-                    for _ in range(elem50):
-                        elem51 = iprot.readI64()
-                        self.list_type.append(elem51)
+                    (_, elem61) = iprot.readListBegin()
+                    for _ in range(elem61):
+                        elem62 = iprot.readI64()
+                        self.list_type.append(elem62)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.SET:
                     self.set_type = set()
-                    (_, elem52) = iprot.readSetBegin()
-                    for _ in range(elem52):
-                        elem53 = iprot.readI64()
-                        self.set_type.add(elem53)
+                    (_, elem63) = iprot.readSetBegin()
+                    for _ in range(elem63):
+                        elem64 = iprot.readI64()
+                        self.set_type.add(elem64)
                     iprot.readSetEnd()
                 else:
                     iprot.skip(ftype)
@@ -1723,15 +1723,15 @@ class underlying_types_test_args(object):
         if self.list_type is not None:
             oprot.writeFieldBegin('list_type', TType.LIST, 1)
             oprot.writeListBegin(TType.I64, len(self.list_type))
-            for elem54 in self.list_type:
-                oprot.writeI64(elem54)
+            for elem65 in self.list_type:
+                oprot.writeI64(elem65)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.set_type is not None:
             oprot.writeFieldBegin('set_type', TType.SET, 2)
             oprot.writeSetBegin(TType.I64, len(self.set_type))
-            for elem55 in self.set_type:
-                oprot.writeI64(elem55)
+            for elem66 in self.set_type:
+                oprot.writeI64(elem66)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1774,10 +1774,10 @@ class underlying_types_test_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_, elem56) = iprot.readListBegin()
-                    for _ in range(elem56):
-                        elem57 = iprot.readI64()
-                        self.success.append(elem57)
+                    (_, elem67) = iprot.readListBegin()
+                    for _ in range(elem67):
+                        elem68 = iprot.readI64()
+                        self.success.append(elem68)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -1793,8 +1793,8 @@ class underlying_types_test_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.I64, len(self.success))
-            for elem58 in self.success:
-                oprot.writeI64(elem58)
+            for elem69 in self.success:
+                oprot.writeI64(elem69)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()

--- a/test/expected/python.asyncio/variety/ttypes.py
+++ b/test/expected/python.asyncio/variety/ttypes.py
@@ -636,8 +636,14 @@ class EventWrapper(object):
        Deprecated: use something else
      - deprList
        Deprecated: use something else
+     - EventsDefault
+     - EventMapDefault
+     - EventSetDefault
     """
-    def __init__(self, ID=None, Ev=None, Events=None, Events2=None, EventMap=None, Nums=None, Enums=None, aBoolField=None, a_union=None, typedefOfTypedef=None, depr=None, deprBinary=None, deprList=None):
+    _DEFAULT_EventsDefault_MARKER = object()
+    _DEFAULT_EventMapDefault_MARKER = object()
+    _DEFAULT_EventSetDefault_MARKER = object()
+    def __init__(self, ID=None, Ev=None, Events=None, Events2=None, EventMap=None, Nums=None, Enums=None, aBoolField=None, a_union=None, typedefOfTypedef=None, depr=None, deprBinary=None, deprList=None, EventsDefault=_DEFAULT_EventsDefault_MARKER, EventMapDefault=_DEFAULT_EventMapDefault_MARKER, EventSetDefault=_DEFAULT_EventSetDefault_MARKER):
         self.ID = ID
         self.Ev = Ev
         self.Events = Events
@@ -651,6 +657,18 @@ class EventWrapper(object):
         self.depr = depr
         self.deprBinary = deprBinary
         self.deprList = deprList
+        if EventsDefault is self._DEFAULT_EventsDefault_MARKER:
+            EventsDefault = [
+            ]
+        self.EventsDefault = EventsDefault
+        if EventMapDefault is self._DEFAULT_EventMapDefault_MARKER:
+            EventMapDefault = {
+            }
+        self.EventMapDefault = EventMapDefault
+        if EventSetDefault is self._DEFAULT_EventSetDefault_MARKER:
+            EventSetDefault = set([
+            ])
+        self.EventSetDefault = EventSetDefault
 
     def read(self, iprot):
         iprot.readStructBegin()
@@ -764,6 +782,40 @@ class EventWrapper(object):
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
+            elif fid == 14:
+                if ftype == TType.LIST:
+                    self.EventsDefault = []
+                    (_, elem32) = iprot.readListBegin()
+                    for _ in range(elem32):
+                        elem33 = Event()
+                        elem33.read(iprot)
+                        self.EventsDefault.append(elem33)
+                    iprot.readListEnd()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 15:
+                if ftype == TType.MAP:
+                    self.EventMapDefault = {}
+                    (_, _, elem34) = iprot.readMapBegin()
+                    for _ in range(elem34):
+                        elem36 = iprot.readI64()
+                        elem35 = Event()
+                        elem35.read(iprot)
+                        self.EventMapDefault[elem36] = elem35
+                    iprot.readMapEnd()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 16:
+                if ftype == TType.SET:
+                    self.EventSetDefault = set()
+                    (_, elem37) = iprot.readSetBegin()
+                    for _ in range(elem37):
+                        elem38 = Event()
+                        elem38.read(iprot)
+                        self.EventSetDefault.add(elem38)
+                    iprot.readSetEnd()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -784,40 +836,40 @@ class EventWrapper(object):
         if self.Events is not None:
             oprot.writeFieldBegin('Events', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.Events))
-            for elem32 in self.Events:
-                elem32.write(oprot)
+            for elem39 in self.Events:
+                elem39.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.Events2 is not None:
             oprot.writeFieldBegin('Events2', TType.SET, 4)
             oprot.writeSetBegin(TType.STRUCT, len(self.Events2))
-            for elem33 in self.Events2:
-                elem33.write(oprot)
+            for elem40 in self.Events2:
+                elem40.write(oprot)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         if self.EventMap is not None:
             oprot.writeFieldBegin('EventMap', TType.MAP, 5)
             oprot.writeMapBegin(TType.I64, TType.STRUCT, len(self.EventMap))
-            for elem35, elem34 in self.EventMap.items():
-                oprot.writeI64(elem35)
-                elem34.write(oprot)
+            for elem42, elem41 in self.EventMap.items():
+                oprot.writeI64(elem42)
+                elem41.write(oprot)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.Nums is not None:
             oprot.writeFieldBegin('Nums', TType.LIST, 6)
             oprot.writeListBegin(TType.LIST, len(self.Nums))
-            for elem36 in self.Nums:
-                oprot.writeListBegin(TType.I32, len(elem36))
-                for elem37 in elem36:
-                    oprot.writeI32(elem37)
+            for elem43 in self.Nums:
+                oprot.writeListBegin(TType.I32, len(elem43))
+                for elem44 in elem43:
+                    oprot.writeI32(elem44)
                 oprot.writeListEnd()
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.Enums is not None:
             oprot.writeFieldBegin('Enums', TType.LIST, 7)
             oprot.writeListBegin(TType.I32, len(self.Enums))
-            for elem38 in self.Enums:
-                oprot.writeI32(elem38)
+            for elem45 in self.Enums:
+                oprot.writeI32(elem45)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.aBoolField is not None:
@@ -843,9 +895,31 @@ class EventWrapper(object):
         if self.deprList is not None:
             oprot.writeFieldBegin('deprList', TType.LIST, 13)
             oprot.writeListBegin(TType.BOOL, len(self.deprList))
-            for elem39 in self.deprList:
-                oprot.writeBool(elem39)
+            for elem46 in self.deprList:
+                oprot.writeBool(elem46)
             oprot.writeListEnd()
+            oprot.writeFieldEnd()
+        if self.EventsDefault is not None:
+            oprot.writeFieldBegin('EventsDefault', TType.LIST, 14)
+            oprot.writeListBegin(TType.STRUCT, len(self.EventsDefault))
+            for elem47 in self.EventsDefault:
+                elem47.write(oprot)
+            oprot.writeListEnd()
+            oprot.writeFieldEnd()
+        if self.EventMapDefault is not None:
+            oprot.writeFieldBegin('EventMapDefault', TType.MAP, 15)
+            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(self.EventMapDefault))
+            for elem49, elem48 in self.EventMapDefault.items():
+                oprot.writeI64(elem49)
+                elem48.write(oprot)
+            oprot.writeMapEnd()
+            oprot.writeFieldEnd()
+        if self.EventSetDefault is not None:
+            oprot.writeFieldBegin('EventSetDefault', TType.SET, 16)
+            oprot.writeSetBegin(TType.STRUCT, len(self.EventSetDefault))
+            for elem50 in self.EventSetDefault:
+                elem50.write(oprot)
+            oprot.writeSetEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -870,6 +944,9 @@ class EventWrapper(object):
         value = (value * 31) ^ hash(make_hashable(self.depr))
         value = (value * 31) ^ hash(make_hashable(self.deprBinary))
         value = (value * 31) ^ hash(make_hashable(self.deprList))
+        value = (value * 31) ^ hash(make_hashable(self.EventsDefault))
+        value = (value * 31) ^ hash(make_hashable(self.EventMapDefault))
+        value = (value * 31) ^ hash(make_hashable(self.EventSetDefault))
         return value
 
     def __repr__(self):
@@ -1011,11 +1088,11 @@ class TestingUnions(object):
             elif fid == 5:
                 if ftype == TType.MAP:
                     self.Requests = {}
-                    (_, _, elem40) = iprot.readMapBegin()
-                    for _ in range(elem40):
-                        elem42 = iprot.readI32()
-                        elem41 = iprot.readString()
-                        self.Requests[elem42] = elem41
+                    (_, _, elem51) = iprot.readMapBegin()
+                    for _ in range(elem51):
+                        elem53 = iprot.readI32()
+                        elem52 = iprot.readString()
+                        self.Requests[elem53] = elem52
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -1057,9 +1134,9 @@ class TestingUnions(object):
         if self.Requests is not None:
             oprot.writeFieldBegin('Requests', TType.MAP, 5)
             oprot.writeMapBegin(TType.I32, TType.STRING, len(self.Requests))
-            for elem44, elem43 in self.Requests.items():
-                oprot.writeI32(elem44)
-                oprot.writeString(elem43)
+            for elem55, elem54 in self.Requests.items():
+                oprot.writeI32(elem55)
+                oprot.writeString(elem54)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.bin_field_in_union is not None:

--- a/test/expected/python.tornado/actual_base/ttypes.py
+++ b/test/expected/python.tornado/actual_base/ttypes.py
@@ -114,11 +114,11 @@ class nested_thing(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.things = []
-                    (_, elem67) = iprot.readListBegin()
-                    for _ in range(elem67):
-                        elem68 = thing()
-                        elem68.read(iprot)
-                        self.things.append(elem68)
+                    (_, elem78) = iprot.readListBegin()
+                    for _ in range(elem78):
+                        elem79 = thing()
+                        elem79.read(iprot)
+                        self.things.append(elem79)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -134,8 +134,8 @@ class nested_thing(object):
         if self.things is not None:
             oprot.writeFieldBegin('things', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.things))
-            for elem69 in self.things:
-                elem69.write(oprot)
+            for elem80 in self.things:
+                elem80.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()

--- a/test/expected/python.tornado/variety/f_Events_publisher.py
+++ b/test/expected/python.tornado/variety/f_Events_publisher.py
@@ -159,11 +159,11 @@ class EventsPublisher(object):
         oprot.write_request_headers(ctx)
         oprot.writeMessageBegin(op, TMessageType.CALL, 0)
         oprot.writeListBegin(TType.MAP, len(req))
-        for elem59 in req:
-            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(elem59))
-            for elem61, elem60 in elem59.items():
-                oprot.writeI64(elem61)
-                elem60.write(oprot)
+        for elem70 in req:
+            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(elem70))
+            for elem72, elem71 in elem70.items():
+                oprot.writeI64(elem72)
+                elem71.write(oprot)
             oprot.writeMapEnd()
         oprot.writeListEnd()
         oprot.writeMessageEnd()

--- a/test/expected/python.tornado/variety/f_Events_subscriber.py
+++ b/test/expected/python.tornado/variety/f_Events_subscriber.py
@@ -196,17 +196,17 @@ class EventsSubscriber(object):
                 iprot.readMessageEnd()
                 raise TApplicationException(TApplicationExceptionType.UNKNOWN_METHOD)
             req = []
-            (_, elem62) = iprot.readListBegin()
-            for _ in range(elem62):
-                elem63 = {}
-                (_, _, elem64) = iprot.readMapBegin()
-                for _ in range(elem64):
-                    elem66 = iprot.readI64()
-                    elem65 = Event()
-                    elem65.read(iprot)
-                    elem63[elem66] = elem65
+            (_, elem73) = iprot.readListBegin()
+            for _ in range(elem73):
+                elem74 = {}
+                (_, _, elem75) = iprot.readMapBegin()
+                for _ in range(elem75):
+                    elem77 = iprot.readI64()
+                    elem76 = Event()
+                    elem76.read(iprot)
+                    elem74[elem77] = elem76
                 iprot.readMapEnd()
-                req.append(elem63)
+                req.append(elem74)
             iprot.readListEnd()
             iprot.readMessageEnd()
             try:

--- a/test/expected/python.tornado/variety/f_Foo.py
+++ b/test/expected/python.tornado/variety/f_Foo.py
@@ -1361,11 +1361,11 @@ class oneWay_args(object):
             elif fid == 2:
                 if ftype == TType.MAP:
                     self.req = {}
-                    (_, _, elem45) = iprot.readMapBegin()
-                    for _ in range(elem45):
-                        elem47 = iprot.readI32()
-                        elem46 = iprot.readString()
-                        self.req[elem47] = elem46
+                    (_, _, elem56) = iprot.readMapBegin()
+                    for _ in range(elem56):
+                        elem58 = iprot.readI32()
+                        elem57 = iprot.readString()
+                        self.req[elem58] = elem57
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -1385,9 +1385,9 @@ class oneWay_args(object):
         if self.req is not None:
             oprot.writeFieldBegin('req', TType.MAP, 2)
             oprot.writeMapBegin(TType.I32, TType.STRING, len(self.req))
-            for elem49, elem48 in self.req.items():
-                oprot.writeI32(elem49)
-                oprot.writeString(elem48)
+            for elem60, elem59 in self.req.items():
+                oprot.writeI32(elem60)
+                oprot.writeString(elem59)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1699,20 +1699,20 @@ class underlying_types_test_args(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.list_type = []
-                    (_, elem50) = iprot.readListBegin()
-                    for _ in range(elem50):
-                        elem51 = iprot.readI64()
-                        self.list_type.append(elem51)
+                    (_, elem61) = iprot.readListBegin()
+                    for _ in range(elem61):
+                        elem62 = iprot.readI64()
+                        self.list_type.append(elem62)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.SET:
                     self.set_type = set()
-                    (_, elem52) = iprot.readSetBegin()
-                    for _ in range(elem52):
-                        elem53 = iprot.readI64()
-                        self.set_type.add(elem53)
+                    (_, elem63) = iprot.readSetBegin()
+                    for _ in range(elem63):
+                        elem64 = iprot.readI64()
+                        self.set_type.add(elem64)
                     iprot.readSetEnd()
                 else:
                     iprot.skip(ftype)
@@ -1728,15 +1728,15 @@ class underlying_types_test_args(object):
         if self.list_type is not None:
             oprot.writeFieldBegin('list_type', TType.LIST, 1)
             oprot.writeListBegin(TType.I64, len(self.list_type))
-            for elem54 in self.list_type:
-                oprot.writeI64(elem54)
+            for elem65 in self.list_type:
+                oprot.writeI64(elem65)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.set_type is not None:
             oprot.writeFieldBegin('set_type', TType.SET, 2)
             oprot.writeSetBegin(TType.I64, len(self.set_type))
-            for elem55 in self.set_type:
-                oprot.writeI64(elem55)
+            for elem66 in self.set_type:
+                oprot.writeI64(elem66)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1779,10 +1779,10 @@ class underlying_types_test_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_, elem56) = iprot.readListBegin()
-                    for _ in range(elem56):
-                        elem57 = iprot.readI64()
-                        self.success.append(elem57)
+                    (_, elem67) = iprot.readListBegin()
+                    for _ in range(elem67):
+                        elem68 = iprot.readI64()
+                        self.success.append(elem68)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -1798,8 +1798,8 @@ class underlying_types_test_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.I64, len(self.success))
-            for elem58 in self.success:
-                oprot.writeI64(elem58)
+            for elem69 in self.success:
+                oprot.writeI64(elem69)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()

--- a/test/expected/python.tornado/variety/ttypes.py
+++ b/test/expected/python.tornado/variety/ttypes.py
@@ -636,8 +636,14 @@ class EventWrapper(object):
        Deprecated: use something else
      - deprList
        Deprecated: use something else
+     - EventsDefault
+     - EventMapDefault
+     - EventSetDefault
     """
-    def __init__(self, ID=None, Ev=None, Events=None, Events2=None, EventMap=None, Nums=None, Enums=None, aBoolField=None, a_union=None, typedefOfTypedef=None, depr=None, deprBinary=None, deprList=None):
+    _DEFAULT_EventsDefault_MARKER = object()
+    _DEFAULT_EventMapDefault_MARKER = object()
+    _DEFAULT_EventSetDefault_MARKER = object()
+    def __init__(self, ID=None, Ev=None, Events=None, Events2=None, EventMap=None, Nums=None, Enums=None, aBoolField=None, a_union=None, typedefOfTypedef=None, depr=None, deprBinary=None, deprList=None, EventsDefault=_DEFAULT_EventsDefault_MARKER, EventMapDefault=_DEFAULT_EventMapDefault_MARKER, EventSetDefault=_DEFAULT_EventSetDefault_MARKER):
         self.ID = ID
         self.Ev = Ev
         self.Events = Events
@@ -651,6 +657,18 @@ class EventWrapper(object):
         self.depr = depr
         self.deprBinary = deprBinary
         self.deprList = deprList
+        if EventsDefault is self._DEFAULT_EventsDefault_MARKER:
+            EventsDefault = [
+            ]
+        self.EventsDefault = EventsDefault
+        if EventMapDefault is self._DEFAULT_EventMapDefault_MARKER:
+            EventMapDefault = {
+            }
+        self.EventMapDefault = EventMapDefault
+        if EventSetDefault is self._DEFAULT_EventSetDefault_MARKER:
+            EventSetDefault = set([
+            ])
+        self.EventSetDefault = EventSetDefault
 
     def read(self, iprot):
         iprot.readStructBegin()
@@ -764,6 +782,40 @@ class EventWrapper(object):
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
+            elif fid == 14:
+                if ftype == TType.LIST:
+                    self.EventsDefault = []
+                    (_, elem32) = iprot.readListBegin()
+                    for _ in range(elem32):
+                        elem33 = Event()
+                        elem33.read(iprot)
+                        self.EventsDefault.append(elem33)
+                    iprot.readListEnd()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 15:
+                if ftype == TType.MAP:
+                    self.EventMapDefault = {}
+                    (_, _, elem34) = iprot.readMapBegin()
+                    for _ in range(elem34):
+                        elem36 = iprot.readI64()
+                        elem35 = Event()
+                        elem35.read(iprot)
+                        self.EventMapDefault[elem36] = elem35
+                    iprot.readMapEnd()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 16:
+                if ftype == TType.SET:
+                    self.EventSetDefault = set()
+                    (_, elem37) = iprot.readSetBegin()
+                    for _ in range(elem37):
+                        elem38 = Event()
+                        elem38.read(iprot)
+                        self.EventSetDefault.add(elem38)
+                    iprot.readSetEnd()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -784,40 +836,40 @@ class EventWrapper(object):
         if self.Events is not None:
             oprot.writeFieldBegin('Events', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.Events))
-            for elem32 in self.Events:
-                elem32.write(oprot)
+            for elem39 in self.Events:
+                elem39.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.Events2 is not None:
             oprot.writeFieldBegin('Events2', TType.SET, 4)
             oprot.writeSetBegin(TType.STRUCT, len(self.Events2))
-            for elem33 in self.Events2:
-                elem33.write(oprot)
+            for elem40 in self.Events2:
+                elem40.write(oprot)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         if self.EventMap is not None:
             oprot.writeFieldBegin('EventMap', TType.MAP, 5)
             oprot.writeMapBegin(TType.I64, TType.STRUCT, len(self.EventMap))
-            for elem35, elem34 in self.EventMap.items():
-                oprot.writeI64(elem35)
-                elem34.write(oprot)
+            for elem42, elem41 in self.EventMap.items():
+                oprot.writeI64(elem42)
+                elem41.write(oprot)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.Nums is not None:
             oprot.writeFieldBegin('Nums', TType.LIST, 6)
             oprot.writeListBegin(TType.LIST, len(self.Nums))
-            for elem36 in self.Nums:
-                oprot.writeListBegin(TType.I32, len(elem36))
-                for elem37 in elem36:
-                    oprot.writeI32(elem37)
+            for elem43 in self.Nums:
+                oprot.writeListBegin(TType.I32, len(elem43))
+                for elem44 in elem43:
+                    oprot.writeI32(elem44)
                 oprot.writeListEnd()
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.Enums is not None:
             oprot.writeFieldBegin('Enums', TType.LIST, 7)
             oprot.writeListBegin(TType.I32, len(self.Enums))
-            for elem38 in self.Enums:
-                oprot.writeI32(elem38)
+            for elem45 in self.Enums:
+                oprot.writeI32(elem45)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.aBoolField is not None:
@@ -843,9 +895,31 @@ class EventWrapper(object):
         if self.deprList is not None:
             oprot.writeFieldBegin('deprList', TType.LIST, 13)
             oprot.writeListBegin(TType.BOOL, len(self.deprList))
-            for elem39 in self.deprList:
-                oprot.writeBool(elem39)
+            for elem46 in self.deprList:
+                oprot.writeBool(elem46)
             oprot.writeListEnd()
+            oprot.writeFieldEnd()
+        if self.EventsDefault is not None:
+            oprot.writeFieldBegin('EventsDefault', TType.LIST, 14)
+            oprot.writeListBegin(TType.STRUCT, len(self.EventsDefault))
+            for elem47 in self.EventsDefault:
+                elem47.write(oprot)
+            oprot.writeListEnd()
+            oprot.writeFieldEnd()
+        if self.EventMapDefault is not None:
+            oprot.writeFieldBegin('EventMapDefault', TType.MAP, 15)
+            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(self.EventMapDefault))
+            for elem49, elem48 in self.EventMapDefault.items():
+                oprot.writeI64(elem49)
+                elem48.write(oprot)
+            oprot.writeMapEnd()
+            oprot.writeFieldEnd()
+        if self.EventSetDefault is not None:
+            oprot.writeFieldBegin('EventSetDefault', TType.SET, 16)
+            oprot.writeSetBegin(TType.STRUCT, len(self.EventSetDefault))
+            for elem50 in self.EventSetDefault:
+                elem50.write(oprot)
+            oprot.writeSetEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -870,6 +944,9 @@ class EventWrapper(object):
         value = (value * 31) ^ hash(make_hashable(self.depr))
         value = (value * 31) ^ hash(make_hashable(self.deprBinary))
         value = (value * 31) ^ hash(make_hashable(self.deprList))
+        value = (value * 31) ^ hash(make_hashable(self.EventsDefault))
+        value = (value * 31) ^ hash(make_hashable(self.EventMapDefault))
+        value = (value * 31) ^ hash(make_hashable(self.EventSetDefault))
         return value
 
     def __repr__(self):
@@ -1011,11 +1088,11 @@ class TestingUnions(object):
             elif fid == 5:
                 if ftype == TType.MAP:
                     self.Requests = {}
-                    (_, _, elem40) = iprot.readMapBegin()
-                    for _ in range(elem40):
-                        elem42 = iprot.readI32()
-                        elem41 = iprot.readString()
-                        self.Requests[elem42] = elem41
+                    (_, _, elem51) = iprot.readMapBegin()
+                    for _ in range(elem51):
+                        elem53 = iprot.readI32()
+                        elem52 = iprot.readString()
+                        self.Requests[elem53] = elem52
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -1057,9 +1134,9 @@ class TestingUnions(object):
         if self.Requests is not None:
             oprot.writeFieldBegin('Requests', TType.MAP, 5)
             oprot.writeMapBegin(TType.I32, TType.STRING, len(self.Requests))
-            for elem44, elem43 in self.Requests.items():
-                oprot.writeI32(elem44)
-                oprot.writeString(elem43)
+            for elem55, elem54 in self.Requests.items():
+                oprot.writeI32(elem55)
+                oprot.writeString(elem54)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.bin_field_in_union is not None:

--- a/test/expected/python/actual_base/ttypes.py
+++ b/test/expected/python/actual_base/ttypes.py
@@ -114,11 +114,11 @@ class nested_thing(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.things = []
-                    (_, elem62) = iprot.readListBegin()
-                    for _ in range(elem62):
-                        elem63 = thing()
-                        elem63.read(iprot)
-                        self.things.append(elem63)
+                    (_, elem73) = iprot.readListBegin()
+                    for _ in range(elem73):
+                        elem74 = thing()
+                        elem74.read(iprot)
+                        self.things.append(elem74)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -134,8 +134,8 @@ class nested_thing(object):
         if self.things is not None:
             oprot.writeFieldBegin('things', TType.LIST, 1)
             oprot.writeListBegin(TType.STRUCT, len(self.things))
-            for elem64 in self.things:
-                elem64.write(oprot)
+            for elem75 in self.things:
+                elem75.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()

--- a/test/expected/python/variety/f_Events_publisher.py
+++ b/test/expected/python/variety/f_Events_publisher.py
@@ -139,11 +139,11 @@ class EventsPublisher(object):
         oprot.write_request_headers(ctx)
         oprot.writeMessageBegin(op, TMessageType.CALL, 0)
         oprot.writeListBegin(TType.MAP, len(req))
-        for elem59 in req:
-            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(elem59))
-            for elem61, elem60 in elem59.items():
-                oprot.writeI64(elem61)
-                elem60.write(oprot)
+        for elem70 in req:
+            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(elem70))
+            for elem72, elem71 in elem70.items():
+                oprot.writeI64(elem72)
+                elem71.write(oprot)
             oprot.writeMapEnd()
         oprot.writeListEnd()
         oprot.writeMessageEnd()

--- a/test/expected/python/variety/f_Foo.py
+++ b/test/expected/python/variety/f_Foo.py
@@ -1406,11 +1406,11 @@ class oneWay_args(object):
             elif fid == 2:
                 if ftype == TType.MAP:
                     self.req = {}
-                    (_, _, elem45) = iprot.readMapBegin()
-                    for _ in range(elem45):
-                        elem47 = iprot.readI32()
-                        elem46 = iprot.readString()
-                        self.req[elem47] = elem46
+                    (_, _, elem56) = iprot.readMapBegin()
+                    for _ in range(elem56):
+                        elem58 = iprot.readI32()
+                        elem57 = iprot.readString()
+                        self.req[elem58] = elem57
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -1430,9 +1430,9 @@ class oneWay_args(object):
         if self.req is not None:
             oprot.writeFieldBegin('req', TType.MAP, 2)
             oprot.writeMapBegin(TType.I32, TType.STRING, len(self.req))
-            for elem49, elem48 in self.req.items():
-                oprot.writeI32(elem49)
-                oprot.writeString(elem48)
+            for elem60, elem59 in self.req.items():
+                oprot.writeI32(elem60)
+                oprot.writeString(elem59)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1744,20 +1744,20 @@ class underlying_types_test_args(object):
             if fid == 1:
                 if ftype == TType.LIST:
                     self.list_type = []
-                    (_, elem50) = iprot.readListBegin()
-                    for _ in range(elem50):
-                        elem51 = iprot.readI64()
-                        self.list_type.append(elem51)
+                    (_, elem61) = iprot.readListBegin()
+                    for _ in range(elem61):
+                        elem62 = iprot.readI64()
+                        self.list_type.append(elem62)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.SET:
                     self.set_type = set()
-                    (_, elem52) = iprot.readSetBegin()
-                    for _ in range(elem52):
-                        elem53 = iprot.readI64()
-                        self.set_type.add(elem53)
+                    (_, elem63) = iprot.readSetBegin()
+                    for _ in range(elem63):
+                        elem64 = iprot.readI64()
+                        self.set_type.add(elem64)
                     iprot.readSetEnd()
                 else:
                     iprot.skip(ftype)
@@ -1773,15 +1773,15 @@ class underlying_types_test_args(object):
         if self.list_type is not None:
             oprot.writeFieldBegin('list_type', TType.LIST, 1)
             oprot.writeListBegin(TType.I64, len(self.list_type))
-            for elem54 in self.list_type:
-                oprot.writeI64(elem54)
+            for elem65 in self.list_type:
+                oprot.writeI64(elem65)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.set_type is not None:
             oprot.writeFieldBegin('set_type', TType.SET, 2)
             oprot.writeSetBegin(TType.I64, len(self.set_type))
-            for elem55 in self.set_type:
-                oprot.writeI64(elem55)
+            for elem66 in self.set_type:
+                oprot.writeI64(elem66)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1824,10 +1824,10 @@ class underlying_types_test_result(object):
             if fid == 0:
                 if ftype == TType.LIST:
                     self.success = []
-                    (_, elem56) = iprot.readListBegin()
-                    for _ in range(elem56):
-                        elem57 = iprot.readI64()
-                        self.success.append(elem57)
+                    (_, elem67) = iprot.readListBegin()
+                    for _ in range(elem67):
+                        elem68 = iprot.readI64()
+                        self.success.append(elem68)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
@@ -1843,8 +1843,8 @@ class underlying_types_test_result(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.I64, len(self.success))
-            for elem58 in self.success:
-                oprot.writeI64(elem58)
+            for elem69 in self.success:
+                oprot.writeI64(elem69)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()

--- a/test/expected/python/variety/ttypes.py
+++ b/test/expected/python/variety/ttypes.py
@@ -636,8 +636,14 @@ class EventWrapper(object):
        Deprecated: use something else
      - deprList
        Deprecated: use something else
+     - EventsDefault
+     - EventMapDefault
+     - EventSetDefault
     """
-    def __init__(self, ID=None, Ev=None, Events=None, Events2=None, EventMap=None, Nums=None, Enums=None, aBoolField=None, a_union=None, typedefOfTypedef=None, depr=None, deprBinary=None, deprList=None):
+    _DEFAULT_EventsDefault_MARKER = object()
+    _DEFAULT_EventMapDefault_MARKER = object()
+    _DEFAULT_EventSetDefault_MARKER = object()
+    def __init__(self, ID=None, Ev=None, Events=None, Events2=None, EventMap=None, Nums=None, Enums=None, aBoolField=None, a_union=None, typedefOfTypedef=None, depr=None, deprBinary=None, deprList=None, EventsDefault=_DEFAULT_EventsDefault_MARKER, EventMapDefault=_DEFAULT_EventMapDefault_MARKER, EventSetDefault=_DEFAULT_EventSetDefault_MARKER):
         self.ID = ID
         self.Ev = Ev
         self.Events = Events
@@ -651,6 +657,18 @@ class EventWrapper(object):
         self.depr = depr
         self.deprBinary = deprBinary
         self.deprList = deprList
+        if EventsDefault is self._DEFAULT_EventsDefault_MARKER:
+            EventsDefault = [
+            ]
+        self.EventsDefault = EventsDefault
+        if EventMapDefault is self._DEFAULT_EventMapDefault_MARKER:
+            EventMapDefault = {
+            }
+        self.EventMapDefault = EventMapDefault
+        if EventSetDefault is self._DEFAULT_EventSetDefault_MARKER:
+            EventSetDefault = set([
+            ])
+        self.EventSetDefault = EventSetDefault
 
     def read(self, iprot):
         iprot.readStructBegin()
@@ -764,6 +782,40 @@ class EventWrapper(object):
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
+            elif fid == 14:
+                if ftype == TType.LIST:
+                    self.EventsDefault = []
+                    (_, elem32) = iprot.readListBegin()
+                    for _ in range(elem32):
+                        elem33 = Event()
+                        elem33.read(iprot)
+                        self.EventsDefault.append(elem33)
+                    iprot.readListEnd()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 15:
+                if ftype == TType.MAP:
+                    self.EventMapDefault = {}
+                    (_, _, elem34) = iprot.readMapBegin()
+                    for _ in range(elem34):
+                        elem36 = iprot.readI64()
+                        elem35 = Event()
+                        elem35.read(iprot)
+                        self.EventMapDefault[elem36] = elem35
+                    iprot.readMapEnd()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 16:
+                if ftype == TType.SET:
+                    self.EventSetDefault = set()
+                    (_, elem37) = iprot.readSetBegin()
+                    for _ in range(elem37):
+                        elem38 = Event()
+                        elem38.read(iprot)
+                        self.EventSetDefault.add(elem38)
+                    iprot.readSetEnd()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -784,40 +836,40 @@ class EventWrapper(object):
         if self.Events is not None:
             oprot.writeFieldBegin('Events', TType.LIST, 3)
             oprot.writeListBegin(TType.STRUCT, len(self.Events))
-            for elem32 in self.Events:
-                elem32.write(oprot)
+            for elem39 in self.Events:
+                elem39.write(oprot)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.Events2 is not None:
             oprot.writeFieldBegin('Events2', TType.SET, 4)
             oprot.writeSetBegin(TType.STRUCT, len(self.Events2))
-            for elem33 in self.Events2:
-                elem33.write(oprot)
+            for elem40 in self.Events2:
+                elem40.write(oprot)
             oprot.writeSetEnd()
             oprot.writeFieldEnd()
         if self.EventMap is not None:
             oprot.writeFieldBegin('EventMap', TType.MAP, 5)
             oprot.writeMapBegin(TType.I64, TType.STRUCT, len(self.EventMap))
-            for elem35, elem34 in self.EventMap.items():
-                oprot.writeI64(elem35)
-                elem34.write(oprot)
+            for elem42, elem41 in self.EventMap.items():
+                oprot.writeI64(elem42)
+                elem41.write(oprot)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.Nums is not None:
             oprot.writeFieldBegin('Nums', TType.LIST, 6)
             oprot.writeListBegin(TType.LIST, len(self.Nums))
-            for elem36 in self.Nums:
-                oprot.writeListBegin(TType.I32, len(elem36))
-                for elem37 in elem36:
-                    oprot.writeI32(elem37)
+            for elem43 in self.Nums:
+                oprot.writeListBegin(TType.I32, len(elem43))
+                for elem44 in elem43:
+                    oprot.writeI32(elem44)
                 oprot.writeListEnd()
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.Enums is not None:
             oprot.writeFieldBegin('Enums', TType.LIST, 7)
             oprot.writeListBegin(TType.I32, len(self.Enums))
-            for elem38 in self.Enums:
-                oprot.writeI32(elem38)
+            for elem45 in self.Enums:
+                oprot.writeI32(elem45)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.aBoolField is not None:
@@ -843,9 +895,31 @@ class EventWrapper(object):
         if self.deprList is not None:
             oprot.writeFieldBegin('deprList', TType.LIST, 13)
             oprot.writeListBegin(TType.BOOL, len(self.deprList))
-            for elem39 in self.deprList:
-                oprot.writeBool(elem39)
+            for elem46 in self.deprList:
+                oprot.writeBool(elem46)
             oprot.writeListEnd()
+            oprot.writeFieldEnd()
+        if self.EventsDefault is not None:
+            oprot.writeFieldBegin('EventsDefault', TType.LIST, 14)
+            oprot.writeListBegin(TType.STRUCT, len(self.EventsDefault))
+            for elem47 in self.EventsDefault:
+                elem47.write(oprot)
+            oprot.writeListEnd()
+            oprot.writeFieldEnd()
+        if self.EventMapDefault is not None:
+            oprot.writeFieldBegin('EventMapDefault', TType.MAP, 15)
+            oprot.writeMapBegin(TType.I64, TType.STRUCT, len(self.EventMapDefault))
+            for elem49, elem48 in self.EventMapDefault.items():
+                oprot.writeI64(elem49)
+                elem48.write(oprot)
+            oprot.writeMapEnd()
+            oprot.writeFieldEnd()
+        if self.EventSetDefault is not None:
+            oprot.writeFieldBegin('EventSetDefault', TType.SET, 16)
+            oprot.writeSetBegin(TType.STRUCT, len(self.EventSetDefault))
+            for elem50 in self.EventSetDefault:
+                elem50.write(oprot)
+            oprot.writeSetEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -870,6 +944,9 @@ class EventWrapper(object):
         value = (value * 31) ^ hash(make_hashable(self.depr))
         value = (value * 31) ^ hash(make_hashable(self.deprBinary))
         value = (value * 31) ^ hash(make_hashable(self.deprList))
+        value = (value * 31) ^ hash(make_hashable(self.EventsDefault))
+        value = (value * 31) ^ hash(make_hashable(self.EventMapDefault))
+        value = (value * 31) ^ hash(make_hashable(self.EventSetDefault))
         return value
 
     def __repr__(self):
@@ -1011,11 +1088,11 @@ class TestingUnions(object):
             elif fid == 5:
                 if ftype == TType.MAP:
                     self.Requests = {}
-                    (_, _, elem40) = iprot.readMapBegin()
-                    for _ in range(elem40):
-                        elem42 = iprot.readI32()
-                        elem41 = iprot.readString()
-                        self.Requests[elem42] = elem41
+                    (_, _, elem51) = iprot.readMapBegin()
+                    for _ in range(elem51):
+                        elem53 = iprot.readI32()
+                        elem52 = iprot.readString()
+                        self.Requests[elem53] = elem52
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
@@ -1057,9 +1134,9 @@ class TestingUnions(object):
         if self.Requests is not None:
             oprot.writeFieldBegin('Requests', TType.MAP, 5)
             oprot.writeMapBegin(TType.I32, TType.STRING, len(self.Requests))
-            for elem44, elem43 in self.Requests.items():
-                oprot.writeI32(elem44)
-                oprot.writeString(elem43)
+            for elem55, elem54 in self.Requests.items():
+                oprot.writeI32(elem55)
+                oprot.writeString(elem54)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.bin_field_in_union is not None:

--- a/test/idl/variety.frugal
+++ b/test/idl/variety.frugal
@@ -149,6 +149,9 @@ struct EventWrapper {
     11: bool depr (deprecated="use something else"),
     12: binary deprBinary (deprecated="use something else"),
     13: list<bool> deprList (deprecated="use something else"),
+    14: optional list<Event> EventsDefault = []
+    15: optional map<id, Event> EventMapDefault = {}
+    16: optional set<Event> EventSetDefault = []
 }
 
 struct FooArgs {


### PR DESCRIPTION
### Story:
Commits are intended to be reviewed independently.

#1105 inadvertently added `const` keyword to default values for struct fields.  Only add the keyword for `const` fields.

### Acceptance Criteria:
- [x] At least one InfRe Squad 2 member has reviewed and +1'd
- [x] Code has been tested and results documented
- [x] Unit tests have been updated
- [x] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
N/A

### How To Test:
CI

### My Test Results:
N/A

#### Reviewers:
@Workiva/product2
FYI: @mattsanders-wf @corwinsheahan-wf @maxwellpeterson-wf 