### PR TITLE
Close transport dispatchers on transport.close

### DIFF
--- a/lib/java/src/main/java/com/workiva/frugal/transport/FNatsTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FNatsTransport.java
@@ -111,7 +111,6 @@ public class FNatsTransport extends FAsyncTransport {
     @Override
     public void close() {
         if (dispatcher != null) {
-            dispatcher.unsubscribe(subject);
             conn.closeDispatcher(dispatcher);
             dispatcher = null;
         }

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FNatsTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FNatsTransport.java
@@ -112,6 +112,7 @@ public class FNatsTransport extends FAsyncTransport {
     public void close() {
         if (dispatcher != null) {
             dispatcher.unsubscribe(subject);
+            conn.closeDispatcher(dispatcher);
             dispatcher = null;
         }
         super.close();


### PR DESCRIPTION
### Story:
Threads are leaked every time FTransport.open and FTransport.close is executed.
Resolve this by calling connection close dispatcher on FTransport.close

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
TODO

### My Test Results:
TODO

#### Reviewers:
@Workiva/product2