### PR TITLE
call close dispatcher to prevent thread leak

### DIFF
--- a/lib/java/src/main/java/com/workiva/frugal/transport/FNatsTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FNatsTransport.java
@@ -111,7 +111,7 @@ public class FNatsTransport extends FAsyncTransport {
     @Override
     public void close() {
         if (dispatcher != null) {
-            dispatcher.unsubscribe(subject);
+            conn.closeDispatcher(dispatcher);
             dispatcher = null;
         }
         super.close();

--- a/lib/java/src/test/java/com/workiva/frugal/transport/FNatsTransportTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/transport/FNatsTransportTest.java
@@ -88,7 +88,7 @@ public class FNatsTransportTest {
         transport.setClosedCallback(mockCallback);
         transport.close();
 
-        verify(mockDispatcher).unsubscribe(subject);
+        verify(conn).closeDispatcher(mockDispatcher);
         verify(mockCallback).onClose(null);
         verify(mockQueue).put(mockFrame);
     }


### PR DESCRIPTION
### Story:
transport.close() does not call connection.close(dispatcher) which causes it to leak a thread.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
TODO

### My Test Results:
TODO

#### Reviewers:
@Workiva/product2