### PR TITLE
CPLAT-6852: Add disposable type name(s)

### DIFF
--- a/lib/dart/lib/src/frugal/transport/monitor_runner.dart
+++ b/lib/dart/lib/src/frugal/transport/monitor_runner.dart
@@ -16,6 +16,9 @@ part of frugal.src.frugal;
 /// Runs an [FTransportMonitor] when a transport is closed.
 @Deprecated('3.0.0')
 class MonitorRunner extends Disposable {
+  @override
+  String get disposableTypeName => 'MonitorRunner';
+
   final Logger _log = new Logger('FTransportMonitor');
   FTransportMonitor _monitor;
   FTransport _transport;

--- a/lib/dart/lib/src/frugal/transport/t_framed_transport.dart
+++ b/lib/dart/lib/src/frugal/transport/t_framed_transport.dart
@@ -16,6 +16,9 @@ part of frugal.src.frugal;
 /// A framed implementation of [TTransport]. Has stream for consuming
 /// entire frames. Disallows direct reads.
 class _TFramedTransport extends TTransport with Disposable {
+  @override
+  String get disposableTypeName => '_TFramedTransport';
+
   final Logger log = new Logger('frugal.transport._TFramedTransport');
   static const int _headerByteCount = 4;
 

--- a/lib/dart/test/transport/f_transport_test.dart
+++ b/lib/dart/test/transport/f_transport_test.dart
@@ -46,6 +46,9 @@ void main() {
 }
 
 class _FTransportImpl extends FTransport {
+  @override
+  String get disposableTypeName => '_FTransportImpl';
+
   // Default implementations of non-implemented methods
   List<Error> errors = [];
   int openCalls = 0;
@@ -76,4 +79,7 @@ class _FTransportImpl extends FTransport {
 }
 
 /// Mock transport monitor.
-class MockTransportMonitor extends FTransportMonitor with Mock {}
+class MockTransportMonitor extends FTransportMonitor with Mock {
+  @override
+  String get disposableTypeName => 'MockTransportMonitor';
+}


### PR DESCRIPTION
Some of the classes that extend or mixin `Disposable` missing `disposableTypeName` override.
     This PR will add missing overrides, where it's necessary