### PR TITLE
Fix ArrayList type

### DIFF
--- a/compiler/generator/java/generator.go
+++ b/compiler/generator/java/generator.go
@@ -2422,7 +2422,7 @@ func (g *Generator) generatePublisherClient(scope *parser.Scope, indent string) 
 
 	contents += indent + tab + "public Client(FScopeProvider provider, ServiceMiddleware... middleware) {\n"
 	contents += indent + tabtab + fmt.Sprintf("target = new Internal%sPublisher(provider);\n", scopeTitle)
-	contents += indent + tabtab + "List<ServiceMiddleware> combined = Arrays.asList(middleware);\n"
+	contents += indent + tabtab + "List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));\n"
 	contents += indent + tabtab + "combined.addAll(provider.getMiddleware());\n"
 	contents += indent + tabtab + "middleware = combined.toArray(new ServiceMiddleware[0]);\n"
 	contents += indent + tabtab + "proxy = InvocationHandler.composeMiddleware(target, Iface.class, middleware);\n"
@@ -2617,7 +2617,7 @@ func (g *Generator) generateSubscriberClient(scope *parser.Scope, indent string)
 
 	contents += indent + tab + "public Client(FScopeProvider provider, ServiceMiddleware... middleware) {\n"
 	contents += indent + tabtab + "this.provider = provider;\n"
-	contents += indent + tabtab + "List<ServiceMiddleware> combined = Arrays.asList(middleware);\n"
+	contents += indent + tabtab + "List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));\n"
 	contents += indent + tabtab + "combined.addAll(provider.getMiddleware());\n"
 	contents += indent + tabtab + "this.middleware = combined.toArray(new ServiceMiddleware[0]);\n"
 	contents += indent + tab + "}\n\n"
@@ -2822,7 +2822,7 @@ func (g *Generator) generateClient(service *parser.Service, indent string) strin
 		contents += indent + tabtab + "super(provider, middleware);\n"
 	}
 	contents += indent + tabtab + "Iface client = new InternalClient(provider);\n"
-	contents += indent + tabtab + "List<ServiceMiddleware> combined = Arrays.asList(middleware);\n"
+	contents += indent + tabtab + "List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));\n"
 	contents += indent + tabtab + "combined.addAll(provider.getMiddleware());\n"
 	contents += indent + tabtab + "middleware = combined.toArray(new ServiceMiddleware[0]);\n"
 	contents += indent + tabtab + "proxy = InvocationHandler.composeMiddleware(client, Iface.class, middleware);\n"

--- a/test/expected/java/actual_base/FBaseFoo.java
+++ b/test/expected/java/actual_base/FBaseFoo.java
@@ -71,7 +71,7 @@ public class FBaseFoo {
 
 		public Client(FServiceProvider provider, ServiceMiddleware... middleware) {
 			Iface client = new InternalClient(provider);
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			middleware = combined.toArray(new ServiceMiddleware[0]);
 			proxy = InvocationHandler.composeMiddleware(client, Iface.class, middleware);

--- a/test/expected/java/boxed_primitives/FFoo.java
+++ b/test/expected/java/boxed_primitives/FFoo.java
@@ -109,7 +109,7 @@ public class FFoo {
 		public Client(FServiceProvider provider, ServiceMiddleware... middleware) {
 			super(provider, middleware);
 			Iface client = new InternalClient(provider);
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			middleware = combined.toArray(new ServiceMiddleware[0]);
 			proxy = InvocationHandler.composeMiddleware(client, Iface.class, middleware);

--- a/test/expected/java/deprecated_logging/FFoo.java
+++ b/test/expected/java/deprecated_logging/FFoo.java
@@ -109,7 +109,7 @@ public class FFoo {
 		public Client(FServiceProvider provider, ServiceMiddleware... middleware) {
 			super(provider, middleware);
 			Iface client = new InternalClient(provider);
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			middleware = combined.toArray(new ServiceMiddleware[0]);
 			proxy = InvocationHandler.composeMiddleware(client, Iface.class, middleware);

--- a/test/expected/java/valid_vendor/FMyService.java
+++ b/test/expected/java/valid_vendor/FMyService.java
@@ -72,7 +72,7 @@ public class FMyService {
 		public Client(FServiceProvider provider, ServiceMiddleware... middleware) {
 			super(provider, middleware);
 			Iface client = new InternalClient(provider);
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			middleware = combined.toArray(new ServiceMiddleware[0]);
 			proxy = InvocationHandler.composeMiddleware(client, Iface.class, middleware);

--- a/test/expected/java/valid_vendor/MyScopePublisher.java
+++ b/test/expected/java/valid_vendor/MyScopePublisher.java
@@ -60,7 +60,7 @@ public class MyScopePublisher {
 
 		public Client(FScopeProvider provider, ServiceMiddleware... middleware) {
 			target = new InternalMyScopePublisher(provider);
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			middleware = combined.toArray(new ServiceMiddleware[0]);
 			proxy = InvocationHandler.composeMiddleware(target, Iface.class, middleware);

--- a/test/expected/java/valid_vendor/MyScopeSubscriber.java
+++ b/test/expected/java/valid_vendor/MyScopeSubscriber.java
@@ -70,7 +70,7 @@ public class MyScopeSubscriber {
 
 		public Client(FScopeProvider provider, ServiceMiddleware... middleware) {
 			this.provider = provider;
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			this.middleware = combined.toArray(new ServiceMiddleware[0]);
 		}

--- a/test/expected/java/valid_vendor_no_path/FMyService.java
+++ b/test/expected/java/valid_vendor_no_path/FMyService.java
@@ -72,7 +72,7 @@ public class FMyService {
 		public Client(FServiceProvider provider, ServiceMiddleware... middleware) {
 			super(provider, middleware);
 			Iface client = new InternalClient(provider);
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			middleware = combined.toArray(new ServiceMiddleware[0]);
 			proxy = InvocationHandler.composeMiddleware(client, Iface.class, middleware);

--- a/test/expected/java/valid_vendor_no_path/MyScopePublisher.java
+++ b/test/expected/java/valid_vendor_no_path/MyScopePublisher.java
@@ -60,7 +60,7 @@ public class MyScopePublisher {
 
 		public Client(FScopeProvider provider, ServiceMiddleware... middleware) {
 			target = new InternalMyScopePublisher(provider);
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			middleware = combined.toArray(new ServiceMiddleware[0]);
 			proxy = InvocationHandler.composeMiddleware(target, Iface.class, middleware);

--- a/test/expected/java/valid_vendor_no_path/MyScopeSubscriber.java
+++ b/test/expected/java/valid_vendor_no_path/MyScopeSubscriber.java
@@ -70,7 +70,7 @@ public class MyScopeSubscriber {
 
 		public Client(FScopeProvider provider, ServiceMiddleware... middleware) {
 			this.provider = provider;
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			this.middleware = combined.toArray(new ServiceMiddleware[0]);
 		}

--- a/test/expected/java/variety/EventsPublisher.java
+++ b/test/expected/java/variety/EventsPublisher.java
@@ -79,7 +79,7 @@ public class EventsPublisher {
 
 		public Client(FScopeProvider provider, ServiceMiddleware... middleware) {
 			target = new InternalEventsPublisher(provider);
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			middleware = combined.toArray(new ServiceMiddleware[0]);
 			proxy = InvocationHandler.composeMiddleware(target, Iface.class, middleware);

--- a/test/expected/java/variety/EventsSubscriber.java
+++ b/test/expected/java/variety/EventsSubscriber.java
@@ -122,7 +122,7 @@ public class EventsSubscriber {
 
 		public Client(FScopeProvider provider, ServiceMiddleware... middleware) {
 			this.provider = provider;
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			this.middleware = combined.toArray(new ServiceMiddleware[0]);
 		}

--- a/test/expected/java/variety/FFoo.java
+++ b/test/expected/java/variety/FFoo.java
@@ -109,7 +109,7 @@ public class FFoo {
 		public Client(FServiceProvider provider, ServiceMiddleware... middleware) {
 			super(provider, middleware);
 			Iface client = new InternalClient(provider);
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			middleware = combined.toArray(new ServiceMiddleware[0]);
 			proxy = InvocationHandler.composeMiddleware(client, Iface.class, middleware);

--- a/test/expected/java/variety_async/FFoo.java
+++ b/test/expected/java/variety_async/FFoo.java
@@ -109,7 +109,7 @@ public class FFoo {
 		public Client(FServiceProvider provider, ServiceMiddleware... middleware) {
 			super(provider, middleware);
 			Iface client = new InternalClient(provider);
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			middleware = combined.toArray(new ServiceMiddleware[0]);
 			proxy = InvocationHandler.composeMiddleware(client, Iface.class, middleware);

--- a/test/expected/java/vendored_but_no_use_vendor/FMyService.java
+++ b/test/expected/java/vendored_but_no_use_vendor/FMyService.java
@@ -72,7 +72,7 @@ public class FMyService {
 		public Client(FServiceProvider provider, ServiceMiddleware... middleware) {
 			super(provider, middleware);
 			Iface client = new InternalClient(provider);
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			middleware = combined.toArray(new ServiceMiddleware[0]);
 			proxy = InvocationHandler.composeMiddleware(client, Iface.class, middleware);

--- a/test/expected/java/vendored_but_no_use_vendor/FVendoredBase.java
+++ b/test/expected/java/vendored_but_no_use_vendor/FVendoredBase.java
@@ -69,7 +69,7 @@ public class FVendoredBase {
 
 		public Client(FServiceProvider provider, ServiceMiddleware... middleware) {
 			Iface client = new InternalClient(provider);
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			middleware = combined.toArray(new ServiceMiddleware[0]);
 			proxy = InvocationHandler.composeMiddleware(client, Iface.class, middleware);

--- a/test/expected/java/vendored_but_no_use_vendor/MyScopePublisher.java
+++ b/test/expected/java/vendored_but_no_use_vendor/MyScopePublisher.java
@@ -60,7 +60,7 @@ public class MyScopePublisher {
 
 		public Client(FScopeProvider provider, ServiceMiddleware... middleware) {
 			target = new InternalMyScopePublisher(provider);
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			middleware = combined.toArray(new ServiceMiddleware[0]);
 			proxy = InvocationHandler.composeMiddleware(target, Iface.class, middleware);

--- a/test/expected/java/vendored_but_no_use_vendor/MyScopeSubscriber.java
+++ b/test/expected/java/vendored_but_no_use_vendor/MyScopeSubscriber.java
@@ -70,7 +70,7 @@ public class MyScopeSubscriber {
 
 		public Client(FScopeProvider provider, ServiceMiddleware... middleware) {
 			this.provider = provider;
-			List<ServiceMiddleware> combined = Arrays.asList(middleware);
+			List<ServiceMiddleware> combined = new ArrayList<ServiceMiddleware>(Arrays.asList(middleware));
 			combined.addAll(provider.getMiddleware());
 			this.middleware = combined.toArray(new ServiceMiddleware[0]);
 		}


### PR DESCRIPTION
### Bug:
When trying to add a middleware to `FScopeProvider` in messaging-sdk, I ran the service and hit this error

```
Exception in thread "UserSync" java.lang.UnsupportedOperationException
at java.util.AbstractList.add(AbstractList.java:148)
at java.util.AbstractList.add(AbstractList.java:108)
at java.util.AbstractCollection.addAll(AbstractCollection.java:344)
at com.workiva.frugal.event_framework.v1.events.EventSubscriber$Client.<init>(EventSubscriber.java:100)
at com.workiva.graph.userSync.IdentitySubscriber.subscribe(IdentitySubscriber.java:69)
at com.workiva.graph.userSync.UserSync.run(UserSync.kt:26)
at com.workiva.graph.userSync.Main$main$1.invoke(Main.kt:29)
at com.workiva.graph.userSync.Main$main$1.invoke(Main.kt:17)
at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30)
```

Looking at the generated `EventSubscriber`, I see this 
```java
public Client(FScopeProvider provider, ServiceMiddleware... middleware) {
    this.provider = provider;
    List<ServiceMiddleware> combined = Arrays.asList(middleware);
    combined.addAll(provider.getMiddleware());
    this.middleware = combined.toArray(new ServiceMiddleware[0]);
}
```

the `combined.addAll(provider.getMiddleware());` line fails because `Arrays.asList()` returns a fixed-size list https://stackoverflow.com/questions/25624251/list-addall-throwing-unsupportedoperationexception-when-trying-to-add-another-li

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [x] Code has been tested and results documented
- [x] Unit tests have been updated
- [x] Updates to documentation if necessary
- [x] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### How To Test:
Generate code and verify it is correct

### My Test Results:
Unit tests

#### Reviewers:
@Workiva/product2