### PR TITLE
INFENG-9206 use "this." for fields when possible

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -888,9 +888,11 @@ func (g *Generator) generateReadFieldRec(field *parser.Field, first bool, ind st
 	contents := ""
 
 	prefix := ""
+	thisPrefix := ""
 	dartType := g.getDartTypeFromThriftType(field.Type)
 	if first {
 		prefix = "this."
+		thisPrefix = "this."
 	} else {
 		prefix = dartType + " "
 	}
@@ -960,7 +962,7 @@ func (g *Generator) generateReadFieldRec(field *parser.Field, first bool, ind st
 			contents += fmt.Sprintf(ind+"for(int %s = 0; %s < %s.length; ++%s) {\n", counterElem, counterElem, containerElem, counterElem)
 			contents += valContents
 			contents += ignoreDeprecationWarningIfNeeded(tab+ind, field.Annotations)
-			contents += fmt.Sprintf(tab+ind+"%s.add(%s);\n", fName, valElem)
+			contents += fmt.Sprintf(tab+ind+"%s%s.add(%s);\n", thisPrefix, fName, valElem)
 			contents += ind + "}\n"
 			contents += ind + "iprot.readListEnd();\n"
 		case "set":
@@ -970,7 +972,7 @@ func (g *Generator) generateReadFieldRec(field *parser.Field, first bool, ind st
 			contents += fmt.Sprintf(ind+"for(int %s = 0; %s < %s.length; ++%s) {\n",
 				counterElem, counterElem, containerElem, counterElem)
 			contents += valContents
-			contents += fmt.Sprintf(tab+ind+"%s.add(%s);\n", fName, valElem)
+			contents += fmt.Sprintf(tab+ind+"%s%s.add(%s);\n", thisPrefix, fName, valElem)
 			contents += ind + "}\n"
 			contents += ind + "iprot.readSetEnd();\n"
 		case "map":
@@ -984,7 +986,7 @@ func (g *Generator) generateReadFieldRec(field *parser.Field, first bool, ind st
 			contents += g.generateReadFieldRec(keyField, false, ind+tab)
 			contents += valContents
 			contents += ignoreDeprecationWarningIfNeeded(tab+ind, field.Annotations)
-			contents += fmt.Sprintf(tab+ind+"%s[%s] = %s;\n", fName, keyElem, valElem)
+			contents += fmt.Sprintf(tab+ind+"%s%s[%s] = %s;\n", thisPrefix, fName, keyElem, valElem)
 			contents += ind + "}\n"
 			contents += ind + "iprot.readMapEnd();\n"
 		default:

--- a/test/expected/dart/actual_base/f_nested_thing.dart
+++ b/test/expected/dart/actual_base/f_nested_thing.dart
@@ -76,7 +76,7 @@ class nested_thing implements thrift.TBase {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
             thrift.TList elem94 = iprot.readListBegin();
-            things = new List<t_actual_base_dart.thing>();
+            this.things = new List<t_actual_base_dart.thing>();
             for(int elem96 = 0; elem96 < elem94.length; ++elem96) {
               t_actual_base_dart.thing elem95 = new t_actual_base_dart.thing();
               elem95.read(iprot);
@@ -106,8 +106,8 @@ class nested_thing implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (this.things != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(new thrift.TList(thrift.TType.STRUCT, things.length));
-      for(var elem97 in things) {
+      oprot.writeListBegin(new thrift.TList(thrift.TType.STRUCT, this.things.length));
+      for(var elem97 in this.things) {
         elem97.write(oprot);
       }
       oprot.writeListEnd();
@@ -144,7 +144,7 @@ class nested_thing implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ things.hashCode;
+    value = (value * 31) ^ this.things.hashCode;
     return value;
   }
 

--- a/test/expected/dart/actual_base/f_nested_thing.dart
+++ b/test/expected/dart/actual_base/f_nested_thing.dart
@@ -80,7 +80,7 @@ class nested_thing implements thrift.TBase {
             for(int elem96 = 0; elem96 < elem94.length; ++elem96) {
               t_actual_base_dart.thing elem95 = new t_actual_base_dart.thing();
               elem95.read(iprot);
-              things.add(elem95);
+              this.things.add(elem95);
             }
             iprot.readListEnd();
           } else {

--- a/test/expected/dart/actual_base/f_thing.dart
+++ b/test/expected/dart/actual_base/f_thing.dart
@@ -103,7 +103,7 @@ class thing implements thrift.TBase {
       switch (field.id) {
         case AN_ID:
           if (field.type == thrift.TType.I32) {
-            an_id = iprot.readI32();
+            this.an_id = iprot.readI32();
             this.__isset_an_id = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -111,7 +111,7 @@ class thing implements thrift.TBase {
           break;
         case A_STRING:
           if (field.type == thrift.TType.STRING) {
-            a_string = iprot.readString();
+            this.a_string = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -134,11 +134,11 @@ class thing implements thrift.TBase {
 
     oprot.writeStructBegin(_STRUCT_DESC);
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(an_id);
+    oprot.writeI32(this.an_id);
     oprot.writeFieldEnd();
     if (this.a_string != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(a_string);
+      oprot.writeString(this.a_string);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -177,8 +177,8 @@ class thing implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ an_id.hashCode;
-    value = (value * 31) ^ a_string.hashCode;
+    value = (value * 31) ^ this.an_id.hashCode;
+    value = (value * 31) ^ this.a_string.hashCode;
     return value;
   }
 

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -267,7 +267,7 @@ class getItem_result implements thrift.TBase {
       switch (field.id) {
         case SUCCESS:
           if (field.type == thrift.TType.STRUCT) {
-            success = new t_vendor_namespace.Item();
+            this.success = new t_vendor_namespace.Item();
             success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -275,7 +275,7 @@ class getItem_result implements thrift.TBase {
           break;
         case D:
           if (field.type == thrift.TType.STRUCT) {
-            d = new t_excepts.InvalidData();
+            this.d = new t_excepts.InvalidData();
             d.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -300,12 +300,12 @@ class getItem_result implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetSuccess() && this.success != null) {
       oprot.writeFieldBegin(_SUCCESS_FIELD_DESC);
-      success.write(oprot);
+      this.success.write(oprot);
       oprot.writeFieldEnd();
     }
     if (isSetD() && this.d != null) {
       oprot.writeFieldBegin(_D_FIELD_DESC);
-      d.write(oprot);
+      this.d.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -352,8 +352,8 @@ class getItem_result implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ success.hashCode;
-    value = (value * 31) ^ d.hashCode;
+    value = (value * 31) ^ this.success.hashCode;
+    value = (value * 31) ^ this.d.hashCode;
     return value;
   }
 

--- a/test/expected/dart/include_vendor/f_vendored_references.dart
+++ b/test/expected/dart/include_vendor/f_vendored_references.dart
@@ -109,7 +109,7 @@ class VendoredReferences implements thrift.TBase {
       switch (field.id) {
         case REFERENCE_VENDORED_CONST:
           if (field.type == thrift.TType.I32) {
-            reference_vendored_const = iprot.readI32();
+            this.reference_vendored_const = iprot.readI32();
             this.__isset_reference_vendored_const = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -117,7 +117,7 @@ class VendoredReferences implements thrift.TBase {
           break;
         case REFERENCE_VENDORED_ENUM:
           if (field.type == thrift.TType.I32) {
-            reference_vendored_enum = iprot.readI32();
+            this.reference_vendored_enum = iprot.readI32();
             this.__isset_reference_vendored_enum = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -142,12 +142,12 @@ class VendoredReferences implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetReference_vendored_const()) {
       oprot.writeFieldBegin(_REFERENCE_VENDORED_CONST_FIELD_DESC);
-      oprot.writeI32(reference_vendored_const);
+      oprot.writeI32(this.reference_vendored_const);
       oprot.writeFieldEnd();
     }
     if (isSetReference_vendored_enum()) {
       oprot.writeFieldBegin(_REFERENCE_VENDORED_ENUM_FIELD_DESC);
-      oprot.writeI32(reference_vendored_enum);
+      oprot.writeI32(this.reference_vendored_enum);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -194,8 +194,8 @@ class VendoredReferences implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ reference_vendored_const.hashCode;
-    value = (value * 31) ^ reference_vendored_enum.hashCode;
+    value = (value * 31) ^ this.reference_vendored_const.hashCode;
+    value = (value * 31) ^ this.reference_vendored_enum.hashCode;
     return value;
   }
 
@@ -211,8 +211,8 @@ class VendoredReferences implements thrift.TBase {
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
-    if (isSetReference_vendored_enum() && !t_vendor_namespace.MyEnum.VALID_VALUES.contains(reference_vendored_enum)) {
-      throw new thrift.TProtocolError(thrift.TProtocolErrorType.INVALID_DATA, "The field 'reference_vendored_enum' has been assigned the invalid value $reference_vendored_enum");
+    if (isSetReference_vendored_enum() && !t_vendor_namespace.MyEnum.VALID_VALUES.contains(this.reference_vendored_enum)) {
+      throw new thrift.TProtocolError(thrift.TProtocolErrorType.INVALID_DATA, "The field 'reference_vendored_enum' has been assigned the invalid value ${this.reference_vendored_enum}");
     }
   }
 }

--- a/test/expected/dart/variety/f_awesome_exception.dart
+++ b/test/expected/dart/variety/f_awesome_exception.dart
@@ -152,7 +152,7 @@ class AwesomeException extends Error implements thrift.TBase {
       switch (field.id) {
         case ID:
           if (field.type == thrift.TType.I64) {
-            iD = iprot.readI64();
+            this.iD = iprot.readI64();
             this.__isset_iD = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -160,7 +160,7 @@ class AwesomeException extends Error implements thrift.TBase {
           break;
         case REASON:
           if (field.type == thrift.TType.STRING) {
-            reason = iprot.readString();
+            this.reason = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -168,7 +168,7 @@ class AwesomeException extends Error implements thrift.TBase {
         case DEPR:
           if (field.type == thrift.TType.BOOL) {
             // ignore: deprecated_member_use
-            depr = iprot.readBool();
+            this.depr = iprot.readBool();
             this.__isset_depr = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -192,16 +192,16 @@ class AwesomeException extends Error implements thrift.TBase {
 
     oprot.writeStructBegin(_STRUCT_DESC);
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(iD);
+    oprot.writeI64(this.iD);
     oprot.writeFieldEnd();
     if (this.reason != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(reason);
+      oprot.writeString(this.reason);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
     // ignore: deprecated_member_use
-    oprot.writeBool(depr);
+    oprot.writeBool(this.depr);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -246,10 +246,10 @@ class AwesomeException extends Error implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ iD.hashCode;
-    value = (value * 31) ^ reason.hashCode;
+    value = (value * 31) ^ this.iD.hashCode;
+    value = (value * 31) ^ this.reason.hashCode;
     // ignore: deprecated_member_use
-    value = (value * 31) ^ depr.hashCode;
+    value = (value * 31) ^ this.depr.hashCode;
     return value;
   }
 

--- a/test/expected/dart/variety/f_event.dart
+++ b/test/expected/dart/variety/f_event.dart
@@ -117,7 +117,7 @@ class Event implements thrift.TBase {
       switch (field.id) {
         case ID:
           if (field.type == thrift.TType.I64) {
-            iD = iprot.readI64();
+            this.iD = iprot.readI64();
             this.__isset_iD = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -125,7 +125,7 @@ class Event implements thrift.TBase {
           break;
         case MESSAGE:
           if (field.type == thrift.TType.STRING) {
-            message = iprot.readString();
+            this.message = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -148,11 +148,11 @@ class Event implements thrift.TBase {
 
     oprot.writeStructBegin(_STRUCT_DESC);
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(iD);
+    oprot.writeI64(this.iD);
     oprot.writeFieldEnd();
     if (this.message != null) {
       oprot.writeFieldBegin(_MESSAGE_FIELD_DESC);
-      oprot.writeString(message);
+      oprot.writeString(this.message);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -191,8 +191,8 @@ class Event implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ iD.hashCode;
-    value = (value * 31) ^ message.hashCode;
+    value = (value * 31) ^ this.iD.hashCode;
+    value = (value * 31) ^ this.message.hashCode;
     return value;
   }
 

--- a/test/expected/dart/variety/f_event_wrapper.dart
+++ b/test/expected/dart/variety/f_event_wrapper.dart
@@ -531,7 +531,7 @@ class EventWrapper implements thrift.TBase {
       switch (field.id) {
         case ID:
           if (field.type == thrift.TType.I64) {
-            iD = iprot.readI64();
+            this.iD = iprot.readI64();
             this.__isset_iD = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -539,7 +539,7 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            ev = new t_variety.Event();
+            this.ev = new t_variety.Event();
             ev.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -548,7 +548,7 @@ class EventWrapper implements thrift.TBase {
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
             thrift.TList elem21 = iprot.readListBegin();
-            events = new List<t_variety.Event>();
+            this.events = new List<t_variety.Event>();
             for(int elem23 = 0; elem23 < elem21.length; ++elem23) {
               t_variety.Event elem22 = new t_variety.Event();
               elem22.read(iprot);
@@ -562,7 +562,7 @@ class EventWrapper implements thrift.TBase {
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
             thrift.TSet elem24 = iprot.readSetBegin();
-            events2 = new Set<t_variety.Event>();
+            this.events2 = new Set<t_variety.Event>();
             for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
               t_variety.Event elem25 = new t_variety.Event();
               elem25.read(iprot);
@@ -576,7 +576,7 @@ class EventWrapper implements thrift.TBase {
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
             thrift.TMap elem27 = iprot.readMapBegin();
-            eventMap = new Map<int, t_variety.Event>();
+            this.eventMap = new Map<int, t_variety.Event>();
             for(int elem29 = 0; elem29 < elem27.length; ++elem29) {
               int elem30 = iprot.readI64();
               t_variety.Event elem28 = new t_variety.Event();
@@ -591,7 +591,7 @@ class EventWrapper implements thrift.TBase {
         case NUMS:
           if (field.type == thrift.TType.LIST) {
             thrift.TList elem31 = iprot.readListBegin();
-            nums = new List<List<int>>();
+            this.nums = new List<List<int>>();
             for(int elem36 = 0; elem36 < elem31.length; ++elem36) {
               thrift.TList elem33 = iprot.readListBegin();
               List<int> elem32 = new List<int>();
@@ -610,7 +610,7 @@ class EventWrapper implements thrift.TBase {
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
             thrift.TList elem37 = iprot.readListBegin();
-            enums = new List<int>();
+            this.enums = new List<int>();
             for(int elem39 = 0; elem39 < elem37.length; ++elem39) {
               int elem38 = iprot.readI32();
               enums.add(elem38);
@@ -622,7 +622,7 @@ class EventWrapper implements thrift.TBase {
           break;
         case ABOOLFIELD:
           if (field.type == thrift.TType.BOOL) {
-            aBoolField = iprot.readBool();
+            this.aBoolField = iprot.readBool();
             this.__isset_aBoolField = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -630,7 +630,7 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            a_union = new t_variety.TestingUnions();
+            this.a_union = new t_variety.TestingUnions();
             a_union.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -638,7 +638,7 @@ class EventWrapper implements thrift.TBase {
           break;
         case TYPEDEFOFTYPEDEF:
           if (field.type == thrift.TType.STRING) {
-            typedefOfTypedef = iprot.readString();
+            this.typedefOfTypedef = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -646,7 +646,7 @@ class EventWrapper implements thrift.TBase {
         case DEPR:
           if (field.type == thrift.TType.BOOL) {
             // ignore: deprecated_member_use
-            depr = iprot.readBool();
+            this.depr = iprot.readBool();
             this.__isset_depr = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -655,7 +655,7 @@ class EventWrapper implements thrift.TBase {
         case DEPRBINARY:
           if (field.type == thrift.TType.STRING) {
             // ignore: deprecated_member_use
-            deprBinary = iprot.readBinary();
+            this.deprBinary = iprot.readBinary();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -664,7 +664,7 @@ class EventWrapper implements thrift.TBase {
           if (field.type == thrift.TType.LIST) {
             thrift.TList elem40 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            deprList = new List<bool>();
+            this.deprList = new List<bool>();
             for(int elem42 = 0; elem42 < elem40.length; ++elem42) {
               bool elem41 = iprot.readBool();
               // ignore: deprecated_member_use
@@ -678,7 +678,7 @@ class EventWrapper implements thrift.TBase {
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
             thrift.TList elem43 = iprot.readListBegin();
-            eventsDefault = new List<t_variety.Event>();
+            this.eventsDefault = new List<t_variety.Event>();
             for(int elem45 = 0; elem45 < elem43.length; ++elem45) {
               t_variety.Event elem44 = new t_variety.Event();
               elem44.read(iprot);
@@ -692,7 +692,7 @@ class EventWrapper implements thrift.TBase {
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
             thrift.TMap elem46 = iprot.readMapBegin();
-            eventMapDefault = new Map<int, t_variety.Event>();
+            this.eventMapDefault = new Map<int, t_variety.Event>();
             for(int elem48 = 0; elem48 < elem46.length; ++elem48) {
               int elem49 = iprot.readI64();
               t_variety.Event elem47 = new t_variety.Event();
@@ -707,7 +707,7 @@ class EventWrapper implements thrift.TBase {
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
             thrift.TSet elem50 = iprot.readSetBegin();
-            eventSetDefault = new Set<t_variety.Event>();
+            this.eventSetDefault = new Set<t_variety.Event>();
             for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
               t_variety.Event elem51 = new t_variety.Event();
               elem51.read(iprot);
@@ -737,18 +737,18 @@ class EventWrapper implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(iD);
+      oprot.writeI64(this.iD);
       oprot.writeFieldEnd();
     }
     if (this.ev != null) {
       oprot.writeFieldBegin(_EV_FIELD_DESC);
-      ev.write(oprot);
+      this.ev.write(oprot);
       oprot.writeFieldEnd();
     }
     if (this.events != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(new thrift.TList(thrift.TType.STRUCT, events.length));
-      for(var elem53 in events) {
+      oprot.writeListBegin(new thrift.TList(thrift.TType.STRUCT, this.events.length));
+      for(var elem53 in this.events) {
         elem53.write(oprot);
       }
       oprot.writeListEnd();
@@ -756,8 +756,8 @@ class EventWrapper implements thrift.TBase {
     }
     if (this.events2 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(new thrift.TSet(thrift.TType.STRUCT, events2.length));
-      for(var elem54 in events2) {
+      oprot.writeSetBegin(new thrift.TSet(thrift.TType.STRUCT, this.events2.length));
+      for(var elem54 in this.events2) {
         elem54.write(oprot);
       }
       oprot.writeSetEnd();
@@ -765,8 +765,8 @@ class EventWrapper implements thrift.TBase {
     }
     if (this.eventMap != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(new thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, eventMap.length));
-      for(var elem55 in eventMap.keys) {
+      oprot.writeMapBegin(new thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, this.eventMap.length));
+      for(var elem55 in this.eventMap.keys) {
         oprot.writeI64(elem55);
         eventMap[elem55].write(oprot);
       }
@@ -775,8 +775,8 @@ class EventWrapper implements thrift.TBase {
     }
     if (this.nums != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(new thrift.TList(thrift.TType.LIST, nums.length));
-      for(var elem56 in nums) {
+      oprot.writeListBegin(new thrift.TList(thrift.TType.LIST, this.nums.length));
+      for(var elem56 in this.nums) {
         oprot.writeListBegin(new thrift.TList(thrift.TType.I32, elem56.length));
         for(var elem57 in elem56) {
           oprot.writeI32(elem57);
@@ -788,44 +788,44 @@ class EventWrapper implements thrift.TBase {
     }
     if (this.enums != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(new thrift.TList(thrift.TType.I32, enums.length));
-      for(var elem58 in enums) {
+      oprot.writeListBegin(new thrift.TList(thrift.TType.I32, this.enums.length));
+      for(var elem58 in this.enums) {
         oprot.writeI32(elem58);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(aBoolField);
+    oprot.writeBool(this.aBoolField);
     oprot.writeFieldEnd();
     if (this.a_union != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      a_union.write(oprot);
+      this.a_union.write(oprot);
       oprot.writeFieldEnd();
     }
     if (this.typedefOfTypedef != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(typedefOfTypedef);
+      oprot.writeString(this.typedefOfTypedef);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
     // ignore: deprecated_member_use
-    oprot.writeBool(depr);
+    oprot.writeBool(this.depr);
     oprot.writeFieldEnd();
     // ignore: deprecated_member_use
     if (this.deprBinary != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
     // ignore: deprecated_member_use
-      oprot.writeBinary(deprBinary);
+      oprot.writeBinary(this.deprBinary);
       oprot.writeFieldEnd();
     }
     // ignore: deprecated_member_use
     if (this.deprList != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
     // ignore: deprecated_member_use
-      oprot.writeListBegin(new thrift.TList(thrift.TType.BOOL, deprList.length));
+      oprot.writeListBegin(new thrift.TList(thrift.TType.BOOL, this.deprList.length));
       // ignore: deprecated_member_use
-      for(var elem59 in deprList) {
+      for(var elem59 in this.deprList) {
         oprot.writeBool(elem59);
       }
       oprot.writeListEnd();
@@ -833,8 +833,8 @@ class EventWrapper implements thrift.TBase {
     }
     if (isSetEventsDefault() && this.eventsDefault != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(new thrift.TList(thrift.TType.STRUCT, eventsDefault.length));
-      for(var elem60 in eventsDefault) {
+      oprot.writeListBegin(new thrift.TList(thrift.TType.STRUCT, this.eventsDefault.length));
+      for(var elem60 in this.eventsDefault) {
         elem60.write(oprot);
       }
       oprot.writeListEnd();
@@ -842,8 +842,8 @@ class EventWrapper implements thrift.TBase {
     }
     if (isSetEventMapDefault() && this.eventMapDefault != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(new thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, eventMapDefault.length));
-      for(var elem61 in eventMapDefault.keys) {
+      oprot.writeMapBegin(new thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, this.eventMapDefault.length));
+      for(var elem61 in this.eventMapDefault.keys) {
         oprot.writeI64(elem61);
         eventMapDefault[elem61].write(oprot);
       }
@@ -852,8 +852,8 @@ class EventWrapper implements thrift.TBase {
     }
     if (isSetEventSetDefault() && this.eventSetDefault != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(new thrift.TSet(thrift.TType.STRUCT, eventSetDefault.length));
-      for(var elem62 in eventSetDefault) {
+      oprot.writeSetBegin(new thrift.TSet(thrift.TType.STRUCT, this.eventSetDefault.length));
+      for(var elem62 in this.eventSetDefault) {
         elem62.write(oprot);
       }
       oprot.writeSetEnd();
@@ -1028,25 +1028,25 @@ class EventWrapper implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ iD.hashCode;
-    value = (value * 31) ^ ev.hashCode;
-    value = (value * 31) ^ events.hashCode;
-    value = (value * 31) ^ events2.hashCode;
-    value = (value * 31) ^ eventMap.hashCode;
-    value = (value * 31) ^ nums.hashCode;
-    value = (value * 31) ^ enums.hashCode;
-    value = (value * 31) ^ aBoolField.hashCode;
-    value = (value * 31) ^ a_union.hashCode;
-    value = (value * 31) ^ typedefOfTypedef.hashCode;
+    value = (value * 31) ^ this.iD.hashCode;
+    value = (value * 31) ^ this.ev.hashCode;
+    value = (value * 31) ^ this.events.hashCode;
+    value = (value * 31) ^ this.events2.hashCode;
+    value = (value * 31) ^ this.eventMap.hashCode;
+    value = (value * 31) ^ this.nums.hashCode;
+    value = (value * 31) ^ this.enums.hashCode;
+    value = (value * 31) ^ this.aBoolField.hashCode;
+    value = (value * 31) ^ this.a_union.hashCode;
+    value = (value * 31) ^ this.typedefOfTypedef.hashCode;
     // ignore: deprecated_member_use
-    value = (value * 31) ^ depr.hashCode;
+    value = (value * 31) ^ this.depr.hashCode;
     // ignore: deprecated_member_use
-    value = (value * 31) ^ deprBinary.hashCode;
+    value = (value * 31) ^ this.deprBinary.hashCode;
     // ignore: deprecated_member_use
-    value = (value * 31) ^ deprList.hashCode;
-    value = (value * 31) ^ eventsDefault.hashCode;
-    value = (value * 31) ^ eventMapDefault.hashCode;
-    value = (value * 31) ^ eventSetDefault.hashCode;
+    value = (value * 31) ^ this.deprList.hashCode;
+    value = (value * 31) ^ this.eventsDefault.hashCode;
+    value = (value * 31) ^ this.eventMapDefault.hashCode;
+    value = (value * 31) ^ this.eventSetDefault.hashCode;
     return value;
   }
 
@@ -1095,7 +1095,7 @@ class EventWrapper implements thrift.TBase {
 
   validate() {
     // check for required fields
-    if (ev == null) {
+    if (this.ev == null) {
       throw new thrift.TProtocolError(thrift.TProtocolErrorType.INVALID_DATA, "Required field 'ev' was not present in struct EventWrapper");
     }
     // check that fields of type enum have valid values

--- a/test/expected/dart/variety/f_event_wrapper.dart
+++ b/test/expected/dart/variety/f_event_wrapper.dart
@@ -552,7 +552,7 @@ class EventWrapper implements thrift.TBase {
             for(int elem23 = 0; elem23 < elem21.length; ++elem23) {
               t_variety.Event elem22 = new t_variety.Event();
               elem22.read(iprot);
-              events.add(elem22);
+              this.events.add(elem22);
             }
             iprot.readListEnd();
           } else {
@@ -566,7 +566,7 @@ class EventWrapper implements thrift.TBase {
             for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
               t_variety.Event elem25 = new t_variety.Event();
               elem25.read(iprot);
-              events2.add(elem25);
+              this.events2.add(elem25);
             }
             iprot.readSetEnd();
           } else {
@@ -581,7 +581,7 @@ class EventWrapper implements thrift.TBase {
               int elem30 = iprot.readI64();
               t_variety.Event elem28 = new t_variety.Event();
               elem28.read(iprot);
-              eventMap[elem30] = elem28;
+              this.eventMap[elem30] = elem28;
             }
             iprot.readMapEnd();
           } else {
@@ -600,7 +600,7 @@ class EventWrapper implements thrift.TBase {
                 elem32.add(elem34);
               }
               iprot.readListEnd();
-              nums.add(elem32);
+              this.nums.add(elem32);
             }
             iprot.readListEnd();
           } else {
@@ -613,7 +613,7 @@ class EventWrapper implements thrift.TBase {
             this.enums = new List<int>();
             for(int elem39 = 0; elem39 < elem37.length; ++elem39) {
               int elem38 = iprot.readI32();
-              enums.add(elem38);
+              this.enums.add(elem38);
             }
             iprot.readListEnd();
           } else {
@@ -668,7 +668,7 @@ class EventWrapper implements thrift.TBase {
             for(int elem42 = 0; elem42 < elem40.length; ++elem42) {
               bool elem41 = iprot.readBool();
               // ignore: deprecated_member_use
-              deprList.add(elem41);
+              this.deprList.add(elem41);
             }
             iprot.readListEnd();
           } else {
@@ -682,7 +682,7 @@ class EventWrapper implements thrift.TBase {
             for(int elem45 = 0; elem45 < elem43.length; ++elem45) {
               t_variety.Event elem44 = new t_variety.Event();
               elem44.read(iprot);
-              eventsDefault.add(elem44);
+              this.eventsDefault.add(elem44);
             }
             iprot.readListEnd();
           } else {
@@ -697,7 +697,7 @@ class EventWrapper implements thrift.TBase {
               int elem49 = iprot.readI64();
               t_variety.Event elem47 = new t_variety.Event();
               elem47.read(iprot);
-              eventMapDefault[elem49] = elem47;
+              this.eventMapDefault[elem49] = elem47;
             }
             iprot.readMapEnd();
           } else {
@@ -711,7 +711,7 @@ class EventWrapper implements thrift.TBase {
             for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
               t_variety.Event elem51 = new t_variety.Event();
               elem51.read(iprot);
-              eventSetDefault.add(elem51);
+              this.eventSetDefault.add(elem51);
             }
             iprot.readSetEnd();
           } else {

--- a/test/expected/dart/variety/f_foo_args.dart
+++ b/test/expected/dart/variety/f_foo_args.dart
@@ -133,21 +133,21 @@ class FooArgs implements thrift.TBase {
       switch (field.id) {
         case NEWMESSAGE:
           if (field.type == thrift.TType.STRING) {
-            newMessage = iprot.readString();
+            this.newMessage = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case MESSAGEARGS:
           if (field.type == thrift.TType.STRING) {
-            messageArgs = iprot.readString();
+            this.messageArgs = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case MESSAGERESULT:
           if (field.type == thrift.TType.STRING) {
-            messageResult = iprot.readString();
+            this.messageResult = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -171,17 +171,17 @@ class FooArgs implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (this.newMessage != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(newMessage);
+      oprot.writeString(this.newMessage);
       oprot.writeFieldEnd();
     }
     if (this.messageArgs != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(messageArgs);
+      oprot.writeString(this.messageArgs);
       oprot.writeFieldEnd();
     }
     if (this.messageResult != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(messageResult);
+      oprot.writeString(this.messageResult);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -233,9 +233,9 @@ class FooArgs implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ newMessage.hashCode;
-    value = (value * 31) ^ messageArgs.hashCode;
-    value = (value * 31) ^ messageResult.hashCode;
+    value = (value * 31) ^ this.newMessage.hashCode;
+    value = (value * 31) ^ this.messageArgs.hashCode;
+    value = (value * 31) ^ this.messageResult.hashCode;
     return value;
   }
 

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -857,7 +857,7 @@ class blah_args implements thrift.TBase {
       switch (field.id) {
         case NUM:
           if (field.type == thrift.TType.I32) {
-            num = iprot.readI32();
+            this.num = iprot.readI32();
             this.__isset_num = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -865,14 +865,14 @@ class blah_args implements thrift.TBase {
           break;
         case STR:
           if (field.type == thrift.TType.STRING) {
-            str = iprot.readString();
+            this.str = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENT:
           if (field.type == thrift.TType.STRUCT) {
-            event = new t_variety.Event();
+            this.event = new t_variety.Event();
             event.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -896,16 +896,16 @@ class blah_args implements thrift.TBase {
 
     oprot.writeStructBegin(_STRUCT_DESC);
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(num);
+    oprot.writeI32(this.num);
     oprot.writeFieldEnd();
     if (this.str != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(str);
+      oprot.writeString(this.str);
       oprot.writeFieldEnd();
     }
     if (this.event != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      event.write(oprot);
+      this.event.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -953,9 +953,9 @@ class blah_args implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ num.hashCode;
-    value = (value * 31) ^ str.hashCode;
-    value = (value * 31) ^ event.hashCode;
+    value = (value * 31) ^ this.num.hashCode;
+    value = (value * 31) ^ this.str.hashCode;
+    value = (value * 31) ^ this.event.hashCode;
     return value;
   }
 
@@ -1101,7 +1101,7 @@ class blah_result implements thrift.TBase {
       switch (field.id) {
         case SUCCESS:
           if (field.type == thrift.TType.I64) {
-            success = iprot.readI64();
+            this.success = iprot.readI64();
             this.__isset_success = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -1109,7 +1109,7 @@ class blah_result implements thrift.TBase {
           break;
         case AWE:
           if (field.type == thrift.TType.STRUCT) {
-            awe = new t_variety.AwesomeException();
+            this.awe = new t_variety.AwesomeException();
             awe.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -1117,7 +1117,7 @@ class blah_result implements thrift.TBase {
           break;
         case API:
           if (field.type == thrift.TType.STRUCT) {
-            api = new t_actual_base_dart.api_exception();
+            this.api = new t_actual_base_dart.api_exception();
             api.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -1142,17 +1142,17 @@ class blah_result implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetSuccess()) {
       oprot.writeFieldBegin(_SUCCESS_FIELD_DESC);
-      oprot.writeI64(success);
+      oprot.writeI64(this.success);
       oprot.writeFieldEnd();
     }
     if (isSetAwe() && this.awe != null) {
       oprot.writeFieldBegin(_AWE_FIELD_DESC);
-      awe.write(oprot);
+      this.awe.write(oprot);
       oprot.writeFieldEnd();
     }
     if (isSetApi() && this.api != null) {
       oprot.writeFieldBegin(_API_FIELD_DESC);
-      api.write(oprot);
+      this.api.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1206,9 +1206,9 @@ class blah_result implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ success.hashCode;
-    value = (value * 31) ^ awe.hashCode;
-    value = (value * 31) ^ api.hashCode;
+    value = (value * 31) ^ this.success.hashCode;
+    value = (value * 31) ^ this.awe.hashCode;
+    value = (value * 31) ^ this.api.hashCode;
     return value;
   }
 
@@ -1327,7 +1327,7 @@ class oneWay_args implements thrift.TBase {
       switch (field.id) {
         case ID:
           if (field.type == thrift.TType.I64) {
-            id = iprot.readI64();
+            this.id = iprot.readI64();
             this.__isset_id = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -1336,7 +1336,7 @@ class oneWay_args implements thrift.TBase {
         case REQ:
           if (field.type == thrift.TType.MAP) {
             thrift.TMap elem68 = iprot.readMapBegin();
-            req = new Map<int, String>();
+            this.req = new Map<int, String>();
             for(int elem70 = 0; elem70 < elem68.length; ++elem70) {
               int elem71 = iprot.readI32();
               String elem69 = iprot.readString();
@@ -1365,12 +1365,12 @@ class oneWay_args implements thrift.TBase {
 
     oprot.writeStructBegin(_STRUCT_DESC);
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(id);
+    oprot.writeI64(this.id);
     oprot.writeFieldEnd();
     if (this.req != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(new thrift.TMap(thrift.TType.I32, thrift.TType.STRING, req.length));
-      for(var elem72 in req.keys) {
+      oprot.writeMapBegin(new thrift.TMap(thrift.TType.I32, thrift.TType.STRING, this.req.length));
+      for(var elem72 in this.req.keys) {
         oprot.writeI32(elem72);
         oprot.writeString(req[elem72]);
       }
@@ -1413,8 +1413,8 @@ class oneWay_args implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ id.hashCode;
-    value = (value * 31) ^ req.hashCode;
+    value = (value * 31) ^ this.id.hashCode;
+    value = (value * 31) ^ this.req.hashCode;
     return value;
   }
 
@@ -1529,14 +1529,14 @@ class bin_method_args implements thrift.TBase {
       switch (field.id) {
         case BIN:
           if (field.type == thrift.TType.STRING) {
-            bin = iprot.readBinary();
+            this.bin = iprot.readBinary();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case STR:
           if (field.type == thrift.TType.STRING) {
-            str = iprot.readString();
+            this.str = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -1560,12 +1560,12 @@ class bin_method_args implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (this.bin != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(bin);
+      oprot.writeBinary(this.bin);
       oprot.writeFieldEnd();
     }
     if (this.str != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(str);
+      oprot.writeString(this.str);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1608,8 +1608,8 @@ class bin_method_args implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ bin.hashCode;
-    value = (value * 31) ^ str.hashCode;
+    value = (value * 31) ^ this.bin.hashCode;
+    value = (value * 31) ^ this.str.hashCode;
     return value;
   }
 
@@ -1724,14 +1724,14 @@ class bin_method_result implements thrift.TBase {
       switch (field.id) {
         case SUCCESS:
           if (field.type == thrift.TType.STRING) {
-            success = iprot.readBinary();
+            this.success = iprot.readBinary();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case API:
           if (field.type == thrift.TType.STRUCT) {
-            api = new t_actual_base_dart.api_exception();
+            this.api = new t_actual_base_dart.api_exception();
             api.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -1756,12 +1756,12 @@ class bin_method_result implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetSuccess() && this.success != null) {
       oprot.writeFieldBegin(_SUCCESS_FIELD_DESC);
-      oprot.writeBinary(success);
+      oprot.writeBinary(this.success);
       oprot.writeFieldEnd();
     }
     if (isSetApi() && this.api != null) {
       oprot.writeFieldBegin(_API_FIELD_DESC);
-      api.write(oprot);
+      this.api.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1808,8 +1808,8 @@ class bin_method_result implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ success.hashCode;
-    value = (value * 31) ^ api.hashCode;
+    value = (value * 31) ^ this.success.hashCode;
+    value = (value * 31) ^ this.api.hashCode;
     return value;
   }
 
@@ -1957,7 +1957,7 @@ class param_modifiers_args implements thrift.TBase {
       switch (field.id) {
         case OPT_NUM:
           if (field.type == thrift.TType.I32) {
-            opt_num = iprot.readI32();
+            this.opt_num = iprot.readI32();
             this.__isset_opt_num = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -1965,7 +1965,7 @@ class param_modifiers_args implements thrift.TBase {
           break;
         case DEFAULT_NUM:
           if (field.type == thrift.TType.I32) {
-            default_num = iprot.readI32();
+            this.default_num = iprot.readI32();
             this.__isset_default_num = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -1973,7 +1973,7 @@ class param_modifiers_args implements thrift.TBase {
           break;
         case REQ_NUM:
           if (field.type == thrift.TType.I32) {
-            req_num = iprot.readI32();
+            this.req_num = iprot.readI32();
             this.__isset_req_num = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -2000,13 +2000,13 @@ class param_modifiers_args implements thrift.TBase {
 
     oprot.writeStructBegin(_STRUCT_DESC);
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(opt_num);
+    oprot.writeI32(this.opt_num);
     oprot.writeFieldEnd();
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(default_num);
+    oprot.writeI32(this.default_num);
     oprot.writeFieldEnd();
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(req_num);
+    oprot.writeI32(this.req_num);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -2045,9 +2045,9 @@ class param_modifiers_args implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ opt_num.hashCode;
-    value = (value * 31) ^ default_num.hashCode;
-    value = (value * 31) ^ req_num.hashCode;
+    value = (value * 31) ^ this.opt_num.hashCode;
+    value = (value * 31) ^ this.default_num.hashCode;
+    value = (value * 31) ^ this.req_num.hashCode;
     return value;
   }
 
@@ -2139,7 +2139,7 @@ class param_modifiers_result implements thrift.TBase {
       switch (field.id) {
         case SUCCESS:
           if (field.type == thrift.TType.I64) {
-            success = iprot.readI64();
+            this.success = iprot.readI64();
             this.__isset_success = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -2164,7 +2164,7 @@ class param_modifiers_result implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetSuccess()) {
       oprot.writeFieldBegin(_SUCCESS_FIELD_DESC);
-      oprot.writeI64(success);
+      oprot.writeI64(this.success);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -2196,7 +2196,7 @@ class param_modifiers_result implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ success.hashCode;
+    value = (value * 31) ^ this.success.hashCode;
     return value;
   }
 
@@ -2310,7 +2310,7 @@ class underlying_types_test_args implements thrift.TBase {
         case LIST_TYPE:
           if (field.type == thrift.TType.LIST) {
             thrift.TList elem73 = iprot.readListBegin();
-            list_type = new List<int>();
+            this.list_type = new List<int>();
             for(int elem75 = 0; elem75 < elem73.length; ++elem75) {
               int elem74 = iprot.readI64();
               list_type.add(elem74);
@@ -2323,7 +2323,7 @@ class underlying_types_test_args implements thrift.TBase {
         case SET_TYPE:
           if (field.type == thrift.TType.SET) {
             thrift.TSet elem76 = iprot.readSetBegin();
-            set_type = new Set<int>();
+            this.set_type = new Set<int>();
             for(int elem78 = 0; elem78 < elem76.length; ++elem78) {
               int elem77 = iprot.readI64();
               set_type.add(elem77);
@@ -2352,8 +2352,8 @@ class underlying_types_test_args implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (this.list_type != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(new thrift.TList(thrift.TType.I64, list_type.length));
-      for(var elem79 in list_type) {
+      oprot.writeListBegin(new thrift.TList(thrift.TType.I64, this.list_type.length));
+      for(var elem79 in this.list_type) {
         oprot.writeI64(elem79);
       }
       oprot.writeListEnd();
@@ -2361,8 +2361,8 @@ class underlying_types_test_args implements thrift.TBase {
     }
     if (this.set_type != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(new thrift.TSet(thrift.TType.I64, set_type.length));
-      for(var elem80 in set_type) {
+      oprot.writeSetBegin(new thrift.TSet(thrift.TType.I64, this.set_type.length));
+      for(var elem80 in this.set_type) {
         oprot.writeI64(elem80);
       }
       oprot.writeSetEnd();
@@ -2408,8 +2408,8 @@ class underlying_types_test_args implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ list_type.hashCode;
-    value = (value * 31) ^ set_type.hashCode;
+    value = (value * 31) ^ this.list_type.hashCode;
+    value = (value * 31) ^ this.set_type.hashCode;
     return value;
   }
 
@@ -2498,7 +2498,7 @@ class underlying_types_test_result implements thrift.TBase {
         case SUCCESS:
           if (field.type == thrift.TType.LIST) {
             thrift.TList elem81 = iprot.readListBegin();
-            success = new List<int>();
+            this.success = new List<int>();
             for(int elem83 = 0; elem83 < elem81.length; ++elem83) {
               int elem82 = iprot.readI64();
               success.add(elem82);
@@ -2527,8 +2527,8 @@ class underlying_types_test_result implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetSuccess() && this.success != null) {
       oprot.writeFieldBegin(_SUCCESS_FIELD_DESC);
-      oprot.writeListBegin(new thrift.TList(thrift.TType.I64, success.length));
-      for(var elem84 in success) {
+      oprot.writeListBegin(new thrift.TList(thrift.TType.I64, this.success.length));
+      for(var elem84 in this.success) {
         oprot.writeI64(elem84);
       }
       oprot.writeListEnd();
@@ -2567,7 +2567,7 @@ class underlying_types_test_result implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ success.hashCode;
+    value = (value * 31) ^ this.success.hashCode;
     return value;
   }
 
@@ -2743,7 +2743,7 @@ class getThing_result implements thrift.TBase {
       switch (field.id) {
         case SUCCESS:
           if (field.type == thrift.TType.STRUCT) {
-            success = new t_validStructs.Thing();
+            this.success = new t_validStructs.Thing();
             success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -2768,7 +2768,7 @@ class getThing_result implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetSuccess() && this.success != null) {
       oprot.writeFieldBegin(_SUCCESS_FIELD_DESC);
-      success.write(oprot);
+      this.success.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -2804,7 +2804,7 @@ class getThing_result implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ success.hashCode;
+    value = (value * 31) ^ this.success.hashCode;
     return value;
   }
 
@@ -2982,7 +2982,7 @@ class getMyInt_result implements thrift.TBase {
       switch (field.id) {
         case SUCCESS:
           if (field.type == thrift.TType.I32) {
-            success = iprot.readI32();
+            this.success = iprot.readI32();
             this.__isset_success = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -3007,7 +3007,7 @@ class getMyInt_result implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetSuccess()) {
       oprot.writeFieldBegin(_SUCCESS_FIELD_DESC);
-      oprot.writeI32(success);
+      oprot.writeI32(this.success);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -3039,7 +3039,7 @@ class getMyInt_result implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ success.hashCode;
+    value = (value * 31) ^ this.success.hashCode;
     return value;
   }
 
@@ -3125,7 +3125,7 @@ class use_subdir_struct_args implements thrift.TBase {
       switch (field.id) {
         case A:
           if (field.type == thrift.TType.STRUCT) {
-            a = new t_subdir_include_ns.A();
+            this.a = new t_subdir_include_ns.A();
             a.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -3150,7 +3150,7 @@ class use_subdir_struct_args implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (this.a != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      a.write(oprot);
+      this.a.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -3184,7 +3184,7 @@ class use_subdir_struct_args implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ a.hashCode;
+    value = (value * 31) ^ this.a.hashCode;
     return value;
   }
 
@@ -3270,7 +3270,7 @@ class use_subdir_struct_result implements thrift.TBase {
       switch (field.id) {
         case SUCCESS:
           if (field.type == thrift.TType.STRUCT) {
-            success = new t_subdir_include_ns.A();
+            this.success = new t_subdir_include_ns.A();
             success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -3295,7 +3295,7 @@ class use_subdir_struct_result implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetSuccess() && this.success != null) {
       oprot.writeFieldBegin(_SUCCESS_FIELD_DESC);
-      success.write(oprot);
+      this.success.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -3331,7 +3331,7 @@ class use_subdir_struct_result implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ success.hashCode;
+    value = (value * 31) ^ this.success.hashCode;
     return value;
   }
 
@@ -3417,7 +3417,7 @@ class sayHelloWith_args implements thrift.TBase {
       switch (field.id) {
         case NEWMESSAGE:
           if (field.type == thrift.TType.STRING) {
-            newMessage = iprot.readString();
+            this.newMessage = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -3441,7 +3441,7 @@ class sayHelloWith_args implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (this.newMessage != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(newMessage);
+      oprot.writeString(this.newMessage);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -3475,7 +3475,7 @@ class sayHelloWith_args implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ newMessage.hashCode;
+    value = (value * 31) ^ this.newMessage.hashCode;
     return value;
   }
 
@@ -3561,7 +3561,7 @@ class sayHelloWith_result implements thrift.TBase {
       switch (field.id) {
         case SUCCESS:
           if (field.type == thrift.TType.STRING) {
-            success = iprot.readString();
+            this.success = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -3585,7 +3585,7 @@ class sayHelloWith_result implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetSuccess() && this.success != null) {
       oprot.writeFieldBegin(_SUCCESS_FIELD_DESC);
-      oprot.writeString(success);
+      oprot.writeString(this.success);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -3621,7 +3621,7 @@ class sayHelloWith_result implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ success.hashCode;
+    value = (value * 31) ^ this.success.hashCode;
     return value;
   }
 
@@ -3707,7 +3707,7 @@ class whatDoYouSay_args implements thrift.TBase {
       switch (field.id) {
         case MESSAGEARGS:
           if (field.type == thrift.TType.STRING) {
-            messageArgs = iprot.readString();
+            this.messageArgs = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -3731,7 +3731,7 @@ class whatDoYouSay_args implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (this.messageArgs != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(messageArgs);
+      oprot.writeString(this.messageArgs);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -3765,7 +3765,7 @@ class whatDoYouSay_args implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ messageArgs.hashCode;
+    value = (value * 31) ^ this.messageArgs.hashCode;
     return value;
   }
 
@@ -3851,7 +3851,7 @@ class whatDoYouSay_result implements thrift.TBase {
       switch (field.id) {
         case SUCCESS:
           if (field.type == thrift.TType.STRING) {
-            success = iprot.readString();
+            this.success = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -3875,7 +3875,7 @@ class whatDoYouSay_result implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetSuccess() && this.success != null) {
       oprot.writeFieldBegin(_SUCCESS_FIELD_DESC);
-      oprot.writeString(success);
+      oprot.writeString(this.success);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -3911,7 +3911,7 @@ class whatDoYouSay_result implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ success.hashCode;
+    value = (value * 31) ^ this.success.hashCode;
     return value;
   }
 
@@ -3997,7 +3997,7 @@ class sayAgain_args implements thrift.TBase {
       switch (field.id) {
         case MESSAGERESULT:
           if (field.type == thrift.TType.STRING) {
-            messageResult = iprot.readString();
+            this.messageResult = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -4021,7 +4021,7 @@ class sayAgain_args implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (this.messageResult != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(messageResult);
+      oprot.writeString(this.messageResult);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -4055,7 +4055,7 @@ class sayAgain_args implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ messageResult.hashCode;
+    value = (value * 31) ^ this.messageResult.hashCode;
     return value;
   }
 
@@ -4141,7 +4141,7 @@ class sayAgain_result implements thrift.TBase {
       switch (field.id) {
         case SUCCESS:
           if (field.type == thrift.TType.STRING) {
-            success = iprot.readString();
+            this.success = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -4165,7 +4165,7 @@ class sayAgain_result implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetSuccess() && this.success != null) {
       oprot.writeFieldBegin(_SUCCESS_FIELD_DESC);
-      oprot.writeString(success);
+      oprot.writeString(this.success);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -4201,7 +4201,7 @@ class sayAgain_result implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ success.hashCode;
+    value = (value * 31) ^ this.success.hashCode;
     return value;
   }
 

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -1340,7 +1340,7 @@ class oneWay_args implements thrift.TBase {
             for(int elem70 = 0; elem70 < elem68.length; ++elem70) {
               int elem71 = iprot.readI32();
               String elem69 = iprot.readString();
-              req[elem71] = elem69;
+              this.req[elem71] = elem69;
             }
             iprot.readMapEnd();
           } else {
@@ -2313,7 +2313,7 @@ class underlying_types_test_args implements thrift.TBase {
             this.list_type = new List<int>();
             for(int elem75 = 0; elem75 < elem73.length; ++elem75) {
               int elem74 = iprot.readI64();
-              list_type.add(elem74);
+              this.list_type.add(elem74);
             }
             iprot.readListEnd();
           } else {
@@ -2326,7 +2326,7 @@ class underlying_types_test_args implements thrift.TBase {
             this.set_type = new Set<int>();
             for(int elem78 = 0; elem78 < elem76.length; ++elem78) {
               int elem77 = iprot.readI64();
-              set_type.add(elem77);
+              this.set_type.add(elem77);
             }
             iprot.readSetEnd();
           } else {
@@ -2501,7 +2501,7 @@ class underlying_types_test_result implements thrift.TBase {
             this.success = new List<int>();
             for(int elem83 = 0; elem83 < elem81.length; ++elem83) {
               int elem82 = iprot.readI64();
-              success.add(elem82);
+              this.success.add(elem82);
             }
             iprot.readListEnd();
           } else {

--- a/test/expected/dart/variety/f_test_base.dart
+++ b/test/expected/dart/variety/f_test_base.dart
@@ -79,7 +79,7 @@ class TestBase implements thrift.TBase {
       switch (field.id) {
         case BASE_STRUCT:
           if (field.type == thrift.TType.STRUCT) {
-            base_struct = new t_actual_base_dart.thing();
+            this.base_struct = new t_actual_base_dart.thing();
             base_struct.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -104,7 +104,7 @@ class TestBase implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (this.base_struct != null) {
       oprot.writeFieldBegin(_BASE_STRUCT_FIELD_DESC);
-      base_struct.write(oprot);
+      this.base_struct.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -138,7 +138,7 @@ class TestBase implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ base_struct.hashCode;
+    value = (value * 31) ^ this.base_struct.hashCode;
     return value;
   }
 

--- a/test/expected/dart/variety/f_test_lowercase.dart
+++ b/test/expected/dart/variety/f_test_lowercase.dart
@@ -81,7 +81,7 @@ class TestLowercase implements thrift.TBase {
       switch (field.id) {
         case LOWERCASEINT:
           if (field.type == thrift.TType.I32) {
-            lowercaseInt = iprot.readI32();
+            this.lowercaseInt = iprot.readI32();
             this.__isset_lowercaseInt = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -105,7 +105,7 @@ class TestLowercase implements thrift.TBase {
 
     oprot.writeStructBegin(_STRUCT_DESC);
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
-    oprot.writeI32(lowercaseInt);
+    oprot.writeI32(this.lowercaseInt);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -134,7 +134,7 @@ class TestLowercase implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ lowercaseInt.hashCode;
+    value = (value * 31) ^ this.lowercaseInt.hashCode;
     return value;
   }
 

--- a/test/expected/dart/variety/f_testing_defaults.dart
+++ b/test/expected/dart/variety/f_testing_defaults.dart
@@ -586,7 +586,7 @@ class TestingDefaults implements thrift.TBase {
       switch (field.id) {
         case ID2:
           if (field.type == thrift.TType.I64) {
-            iD2 = iprot.readI64();
+            this.iD2 = iprot.readI64();
             this.__isset_iD2 = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -594,7 +594,7 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
-            ev1 = new t_variety.Event();
+            this.ev1 = new t_variety.Event();
             ev1.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -602,7 +602,7 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
-            ev2 = new t_variety.Event();
+            this.ev2 = new t_variety.Event();
             ev2.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -610,7 +610,7 @@ class TestingDefaults implements thrift.TBase {
           break;
         case ID:
           if (field.type == thrift.TType.I64) {
-            iD = iprot.readI64();
+            this.iD = iprot.readI64();
             this.__isset_iD = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -618,14 +618,14 @@ class TestingDefaults implements thrift.TBase {
           break;
         case THING:
           if (field.type == thrift.TType.STRING) {
-            thing = iprot.readString();
+            this.thing = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case THING2:
           if (field.type == thrift.TType.STRING) {
-            thing2 = iprot.readString();
+            this.thing2 = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -633,7 +633,7 @@ class TestingDefaults implements thrift.TBase {
         case LISTFIELD:
           if (field.type == thrift.TType.LIST) {
             thrift.TList elem0 = iprot.readListBegin();
-            listfield = new List<int>();
+            this.listfield = new List<int>();
             for(int elem2 = 0; elem2 < elem0.length; ++elem2) {
               int elem1 = iprot.readI32();
               listfield.add(elem1);
@@ -645,7 +645,7 @@ class TestingDefaults implements thrift.TBase {
           break;
         case ID3:
           if (field.type == thrift.TType.I64) {
-            iD3 = iprot.readI64();
+            this.iD3 = iprot.readI64();
             this.__isset_iD3 = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -653,28 +653,28 @@ class TestingDefaults implements thrift.TBase {
           break;
         case BIN_FIELD:
           if (field.type == thrift.TType.STRING) {
-            bin_field = iprot.readBinary();
+            this.bin_field = iprot.readBinary();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case BIN_FIELD2:
           if (field.type == thrift.TType.STRING) {
-            bin_field2 = iprot.readBinary();
+            this.bin_field2 = iprot.readBinary();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case BIN_FIELD3:
           if (field.type == thrift.TType.STRING) {
-            bin_field3 = iprot.readBinary();
+            this.bin_field3 = iprot.readBinary();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case BIN_FIELD4:
           if (field.type == thrift.TType.STRING) {
-            bin_field4 = iprot.readBinary();
+            this.bin_field4 = iprot.readBinary();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -682,7 +682,7 @@ class TestingDefaults implements thrift.TBase {
         case LIST2:
           if (field.type == thrift.TType.LIST) {
             thrift.TList elem3 = iprot.readListBegin();
-            list2 = new List<int>();
+            this.list2 = new List<int>();
             for(int elem5 = 0; elem5 < elem3.length; ++elem5) {
               int elem4 = iprot.readI32();
               list2.add(elem4);
@@ -695,7 +695,7 @@ class TestingDefaults implements thrift.TBase {
         case LIST3:
           if (field.type == thrift.TType.LIST) {
             thrift.TList elem6 = iprot.readListBegin();
-            list3 = new List<int>();
+            this.list3 = new List<int>();
             for(int elem8 = 0; elem8 < elem6.length; ++elem8) {
               int elem7 = iprot.readI32();
               list3.add(elem7);
@@ -708,7 +708,7 @@ class TestingDefaults implements thrift.TBase {
         case LIST4:
           if (field.type == thrift.TType.LIST) {
             thrift.TList elem9 = iprot.readListBegin();
-            list4 = new List<int>();
+            this.list4 = new List<int>();
             for(int elem11 = 0; elem11 < elem9.length; ++elem11) {
               int elem10 = iprot.readI32();
               list4.add(elem10);
@@ -721,7 +721,7 @@ class TestingDefaults implements thrift.TBase {
         case A_MAP:
           if (field.type == thrift.TType.MAP) {
             thrift.TMap elem12 = iprot.readMapBegin();
-            a_map = new Map<String, String>();
+            this.a_map = new Map<String, String>();
             for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
               String elem15 = iprot.readString();
               String elem13 = iprot.readString();
@@ -734,7 +734,7 @@ class TestingDefaults implements thrift.TBase {
           break;
         case STATUS:
           if (field.type == thrift.TType.I32) {
-            status = iprot.readI32();
+            this.status = iprot.readI32();
             this.__isset_status = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -742,7 +742,7 @@ class TestingDefaults implements thrift.TBase {
           break;
         case BASE_STATUS:
           if (field.type == thrift.TType.I32) {
-            base_status = iprot.readI32();
+            this.base_status = iprot.readI32();
             this.__isset_base_status = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -773,68 +773,68 @@ class TestingDefaults implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetID2()) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
-      oprot.writeI64(iD2);
+      oprot.writeI64(this.iD2);
       oprot.writeFieldEnd();
     }
     if (this.ev1 != null) {
       oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      ev1.write(oprot);
+      this.ev1.write(oprot);
       oprot.writeFieldEnd();
     }
     if (this.ev2 != null) {
       oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      ev2.write(oprot);
+      this.ev2.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(iD);
+    oprot.writeI64(this.iD);
     oprot.writeFieldEnd();
     if (this.thing != null) {
       oprot.writeFieldBegin(_THING_FIELD_DESC);
-      oprot.writeString(thing);
+      oprot.writeString(this.thing);
       oprot.writeFieldEnd();
     }
     if (isSetThing2() && this.thing2 != null) {
       oprot.writeFieldBegin(_THING2_FIELD_DESC);
-      oprot.writeString(thing2);
+      oprot.writeString(this.thing2);
       oprot.writeFieldEnd();
     }
     if (this.listfield != null) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
-      oprot.writeListBegin(new thrift.TList(thrift.TType.I32, listfield.length));
-      for(var elem16 in listfield) {
+      oprot.writeListBegin(new thrift.TList(thrift.TType.I32, this.listfield.length));
+      for(var elem16 in this.listfield) {
         oprot.writeI32(elem16);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
-    oprot.writeI64(iD3);
+    oprot.writeI64(this.iD3);
     oprot.writeFieldEnd();
     if (this.bin_field != null) {
       oprot.writeFieldBegin(_BIN_FIELD_FIELD_DESC);
-      oprot.writeBinary(bin_field);
+      oprot.writeBinary(this.bin_field);
       oprot.writeFieldEnd();
     }
     if (isSetBin_field2() && this.bin_field2 != null) {
       oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
-      oprot.writeBinary(bin_field2);
+      oprot.writeBinary(this.bin_field2);
       oprot.writeFieldEnd();
     }
     if (this.bin_field3 != null) {
       oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
-      oprot.writeBinary(bin_field3);
+      oprot.writeBinary(this.bin_field3);
       oprot.writeFieldEnd();
     }
     if (isSetBin_field4() && this.bin_field4 != null) {
       oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
-      oprot.writeBinary(bin_field4);
+      oprot.writeBinary(this.bin_field4);
       oprot.writeFieldEnd();
     }
     if (isSetList2() && this.list2 != null) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
-      oprot.writeListBegin(new thrift.TList(thrift.TType.I32, list2.length));
-      for(var elem17 in list2) {
+      oprot.writeListBegin(new thrift.TList(thrift.TType.I32, this.list2.length));
+      for(var elem17 in this.list2) {
         oprot.writeI32(elem17);
       }
       oprot.writeListEnd();
@@ -842,8 +842,8 @@ class TestingDefaults implements thrift.TBase {
     }
     if (isSetList3() && this.list3 != null) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
-      oprot.writeListBegin(new thrift.TList(thrift.TType.I32, list3.length));
-      for(var elem18 in list3) {
+      oprot.writeListBegin(new thrift.TList(thrift.TType.I32, this.list3.length));
+      for(var elem18 in this.list3) {
         oprot.writeI32(elem18);
       }
       oprot.writeListEnd();
@@ -851,8 +851,8 @@ class TestingDefaults implements thrift.TBase {
     }
     if (this.list4 != null) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
-      oprot.writeListBegin(new thrift.TList(thrift.TType.I32, list4.length));
-      for(var elem19 in list4) {
+      oprot.writeListBegin(new thrift.TList(thrift.TType.I32, this.list4.length));
+      for(var elem19 in this.list4) {
         oprot.writeI32(elem19);
       }
       oprot.writeListEnd();
@@ -860,8 +860,8 @@ class TestingDefaults implements thrift.TBase {
     }
     if (isSetA_map() && this.a_map != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
-      oprot.writeMapBegin(new thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, a_map.length));
-      for(var elem20 in a_map.keys) {
+      oprot.writeMapBegin(new thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, this.a_map.length));
+      for(var elem20 in this.a_map.keys) {
         oprot.writeString(elem20);
         oprot.writeString(a_map[elem20]);
       }
@@ -869,10 +869,10 @@ class TestingDefaults implements thrift.TBase {
       oprot.writeFieldEnd();
     }
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(status);
+    oprot.writeI32(this.status);
     oprot.writeFieldEnd();
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(base_status);
+    oprot.writeI32(this.base_status);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -1068,24 +1068,24 @@ class TestingDefaults implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ iD2.hashCode;
-    value = (value * 31) ^ ev1.hashCode;
-    value = (value * 31) ^ ev2.hashCode;
-    value = (value * 31) ^ iD.hashCode;
-    value = (value * 31) ^ thing.hashCode;
-    value = (value * 31) ^ thing2.hashCode;
-    value = (value * 31) ^ listfield.hashCode;
-    value = (value * 31) ^ iD3.hashCode;
-    value = (value * 31) ^ bin_field.hashCode;
-    value = (value * 31) ^ bin_field2.hashCode;
-    value = (value * 31) ^ bin_field3.hashCode;
-    value = (value * 31) ^ bin_field4.hashCode;
-    value = (value * 31) ^ list2.hashCode;
-    value = (value * 31) ^ list3.hashCode;
-    value = (value * 31) ^ list4.hashCode;
-    value = (value * 31) ^ a_map.hashCode;
-    value = (value * 31) ^ status.hashCode;
-    value = (value * 31) ^ base_status.hashCode;
+    value = (value * 31) ^ this.iD2.hashCode;
+    value = (value * 31) ^ this.ev1.hashCode;
+    value = (value * 31) ^ this.ev2.hashCode;
+    value = (value * 31) ^ this.iD.hashCode;
+    value = (value * 31) ^ this.thing.hashCode;
+    value = (value * 31) ^ this.thing2.hashCode;
+    value = (value * 31) ^ this.listfield.hashCode;
+    value = (value * 31) ^ this.iD3.hashCode;
+    value = (value * 31) ^ this.bin_field.hashCode;
+    value = (value * 31) ^ this.bin_field2.hashCode;
+    value = (value * 31) ^ this.bin_field3.hashCode;
+    value = (value * 31) ^ this.bin_field4.hashCode;
+    value = (value * 31) ^ this.list2.hashCode;
+    value = (value * 31) ^ this.list3.hashCode;
+    value = (value * 31) ^ this.list4.hashCode;
+    value = (value * 31) ^ this.a_map.hashCode;
+    value = (value * 31) ^ this.status.hashCode;
+    value = (value * 31) ^ this.base_status.hashCode;
     return value;
   }
 
@@ -1133,11 +1133,11 @@ class TestingDefaults implements thrift.TBase {
   validate() {
     // check for required fields
     // check that fields of type enum have valid values
-    if (isSetStatus() && !t_variety.HealthCondition.VALID_VALUES.contains(status)) {
-      throw new thrift.TProtocolError(thrift.TProtocolErrorType.INVALID_DATA, "The field 'status' has been assigned the invalid value $status");
+    if (isSetStatus() && !t_variety.HealthCondition.VALID_VALUES.contains(this.status)) {
+      throw new thrift.TProtocolError(thrift.TProtocolErrorType.INVALID_DATA, "The field 'status' has been assigned the invalid value ${this.status}");
     }
-    if (isSetBase_status() && !t_actual_base_dart.base_health_condition.VALID_VALUES.contains(base_status)) {
-      throw new thrift.TProtocolError(thrift.TProtocolErrorType.INVALID_DATA, "The field 'base_status' has been assigned the invalid value $base_status");
+    if (isSetBase_status() && !t_actual_base_dart.base_health_condition.VALID_VALUES.contains(this.base_status)) {
+      throw new thrift.TProtocolError(thrift.TProtocolErrorType.INVALID_DATA, "The field 'base_status' has been assigned the invalid value ${this.base_status}");
     }
   }
 }

--- a/test/expected/dart/variety/f_testing_defaults.dart
+++ b/test/expected/dart/variety/f_testing_defaults.dart
@@ -636,7 +636,7 @@ class TestingDefaults implements thrift.TBase {
             this.listfield = new List<int>();
             for(int elem2 = 0; elem2 < elem0.length; ++elem2) {
               int elem1 = iprot.readI32();
-              listfield.add(elem1);
+              this.listfield.add(elem1);
             }
             iprot.readListEnd();
           } else {
@@ -685,7 +685,7 @@ class TestingDefaults implements thrift.TBase {
             this.list2 = new List<int>();
             for(int elem5 = 0; elem5 < elem3.length; ++elem5) {
               int elem4 = iprot.readI32();
-              list2.add(elem4);
+              this.list2.add(elem4);
             }
             iprot.readListEnd();
           } else {
@@ -698,7 +698,7 @@ class TestingDefaults implements thrift.TBase {
             this.list3 = new List<int>();
             for(int elem8 = 0; elem8 < elem6.length; ++elem8) {
               int elem7 = iprot.readI32();
-              list3.add(elem7);
+              this.list3.add(elem7);
             }
             iprot.readListEnd();
           } else {
@@ -711,7 +711,7 @@ class TestingDefaults implements thrift.TBase {
             this.list4 = new List<int>();
             for(int elem11 = 0; elem11 < elem9.length; ++elem11) {
               int elem10 = iprot.readI32();
-              list4.add(elem10);
+              this.list4.add(elem10);
             }
             iprot.readListEnd();
           } else {
@@ -725,7 +725,7 @@ class TestingDefaults implements thrift.TBase {
             for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
               String elem15 = iprot.readString();
               String elem13 = iprot.readString();
-              a_map[elem15] = elem13;
+              this.a_map[elem15] = elem13;
             }
             iprot.readMapEnd();
           } else {

--- a/test/expected/dart/variety/f_testing_unions.dart
+++ b/test/expected/dart/variety/f_testing_unions.dart
@@ -294,7 +294,7 @@ class TestingUnions implements thrift.TBase {
             for(int elem65 = 0; elem65 < elem63.length; ++elem65) {
               int elem66 = iprot.readI32();
               String elem64 = iprot.readString();
-              requests[elem66] = elem64;
+              this.requests[elem66] = elem64;
             }
             iprot.readMapEnd();
           } else {

--- a/test/expected/dart/variety/f_testing_unions.dart
+++ b/test/expected/dart/variety/f_testing_unions.dart
@@ -258,7 +258,7 @@ class TestingUnions implements thrift.TBase {
       switch (field.id) {
         case ANID:
           if (field.type == thrift.TType.I64) {
-            anID = iprot.readI64();
+            this.anID = iprot.readI64();
             this.__isset_anID = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -266,14 +266,14 @@ class TestingUnions implements thrift.TBase {
           break;
         case ASTRING:
           if (field.type == thrift.TType.STRING) {
-            aString = iprot.readString();
+            this.aString = iprot.readString();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case SOMEOTHERTHING:
           if (field.type == thrift.TType.I32) {
-            someotherthing = iprot.readI32();
+            this.someotherthing = iprot.readI32();
             this.__isset_someotherthing = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -281,7 +281,7 @@ class TestingUnions implements thrift.TBase {
           break;
         case ANINT16:
           if (field.type == thrift.TType.I16) {
-            anInt16 = iprot.readI16();
+            this.anInt16 = iprot.readI16();
             this.__isset_anInt16 = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -290,7 +290,7 @@ class TestingUnions implements thrift.TBase {
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
             thrift.TMap elem63 = iprot.readMapBegin();
-            requests = new Map<int, String>();
+            this.requests = new Map<int, String>();
             for(int elem65 = 0; elem65 < elem63.length; ++elem65) {
               int elem66 = iprot.readI32();
               String elem64 = iprot.readString();
@@ -303,7 +303,7 @@ class TestingUnions implements thrift.TBase {
           break;
         case BIN_FIELD_IN_UNION:
           if (field.type == thrift.TType.STRING) {
-            bin_field_in_union = iprot.readBinary();
+            this.bin_field_in_union = iprot.readBinary();
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -311,7 +311,7 @@ class TestingUnions implements thrift.TBase {
         case DEPR:
           if (field.type == thrift.TType.BOOL) {
             // ignore: deprecated_member_use
-            depr = iprot.readBool();
+            this.depr = iprot.readBool();
             this.__isset_depr = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
@@ -336,28 +336,28 @@ class TestingUnions implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(anID);
+      oprot.writeI64(this.anID);
       oprot.writeFieldEnd();
     }
     if (isSetAString() && this.aString != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(aString);
+      oprot.writeString(this.aString);
       oprot.writeFieldEnd();
     }
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(someotherthing);
+      oprot.writeI32(this.someotherthing);
       oprot.writeFieldEnd();
     }
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(anInt16);
+      oprot.writeI16(this.anInt16);
       oprot.writeFieldEnd();
     }
     if (isSetRequests() && this.requests != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(new thrift.TMap(thrift.TType.I32, thrift.TType.STRING, requests.length));
-      for(var elem67 in requests.keys) {
+      oprot.writeMapBegin(new thrift.TMap(thrift.TType.I32, thrift.TType.STRING, this.requests.length));
+      for(var elem67 in this.requests.keys) {
         oprot.writeI32(elem67);
         oprot.writeString(requests[elem67]);
       }
@@ -366,14 +366,14 @@ class TestingUnions implements thrift.TBase {
     }
     if (isSetBin_field_in_union() && this.bin_field_in_union != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(bin_field_in_union);
+      oprot.writeBinary(this.bin_field_in_union);
       oprot.writeFieldEnd();
     }
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
     // ignore: deprecated_member_use
-      oprot.writeBool(depr);
+      oprot.writeBool(this.depr);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -461,14 +461,14 @@ class TestingUnions implements thrift.TBase {
   @override
   int get hashCode {
     var value = 17;
-    value = (value * 31) ^ anID.hashCode;
-    value = (value * 31) ^ aString.hashCode;
-    value = (value * 31) ^ someotherthing.hashCode;
-    value = (value * 31) ^ anInt16.hashCode;
-    value = (value * 31) ^ requests.hashCode;
-    value = (value * 31) ^ bin_field_in_union.hashCode;
+    value = (value * 31) ^ this.anID.hashCode;
+    value = (value * 31) ^ this.aString.hashCode;
+    value = (value * 31) ^ this.someotherthing.hashCode;
+    value = (value * 31) ^ this.anInt16.hashCode;
+    value = (value * 31) ^ this.requests.hashCode;
+    value = (value * 31) ^ this.bin_field_in_union.hashCode;
     // ignore: deprecated_member_use
-    value = (value * 31) ^ depr.hashCode;
+    value = (value * 31) ^ this.depr.hashCode;
     return value;
   }
 


### PR DESCRIPTION
Sometimes field names defined in users IDLs can collide with variables names the dart generator uses. We should reference variable names with a `this.` when appropriate to avoid that.

@Workiva/product2 @todbachman-wf 