### PR TITLE
Add a ignore for unused_import

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1335,7 +1335,8 @@ func (g *Generator) GenerateObjectPackage(file *os.File, name string) error {
 
 // GenerateThriftImports generates necessary imports for Thrift.
 func (g *Generator) GenerateThriftImports() (string, error) {
-	imports := "import 'dart:typed_data' show Uint8List;\n"
+	imports := "// ignore_for_file: unused_import\n"
+	imports += "import 'dart:typed_data' show Uint8List;\n"
 	imports += "import 'package:thrift/thrift.dart' as thrift;\n"
 	// Import the current package
 	imports += g.getImportDeclaration(g.getNamespaceOrName(), g.getPackagePrefix())


### PR DESCRIPTION

### Story:
Sometimes we don't need all the imports listed here and this causes analysis warnings.

Some repos like to fail for this(doc_plat_client for instance), ignoring here lets us do that without requiring complex logic in the generator

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
Can be tested in dpc by:
 - cd into $GOPATH/src/github.com/Workiva/frugal
 - Check out this branch
 - go install
 - cd into $GOPATH/src/github.com/Workiva/doc_plat_client
 - checkout master
 - run make frugal 
 - observe generated dart file changes

### My Test Results:
TODO

#### Reviewers:
@Workiva/product2