### PR TITLE
INFENG-9265 Ignore the v prefix on tags

### DIFF
--- a/scripts/update.py
+++ b/scripts/update.py
@@ -19,7 +19,7 @@ _VERSION_MATCH = '.*?\..*?\..*?'
 def main(args):
     root = os.getcwd().rstrip('/')
     if args.version:
-        update_frugal_version(args.version, root)
+        update_frugal_version(args.version.strip('v'), root)
         update_expected_tests(root)
 
 


### PR DESCRIPTION
### Story:
We're going to start tagging frugal with the v prefix to make go mod happy. When we update all the files we don't want the v to get added.

### Acceptance Criteria:
- [x] At least one InfRe Squad 2 member has reviewed and +1'd
- [x] Code has been tested and results documented
- [x] Unit tests have been updated
- [x] Updates to documentation if necessary
- [x] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
```
python scripts/update.py --version v3.4.9
```

### My Test Results:
TODO

#### Reviewers:
@Workiva/product2