### PR TITLE
INFENG-9845: Remove dart1 in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.36 as build
+FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.38 as build
 
 ARG GIT_BRANCH
 ARG GIT_MERGE_BRANCH

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   w_transport: '>=2.9.4 <4.0.0'
 description: A frugal client for Dart
 dev_dependencies:
-  coverage: '>=0.10.0 <0.13.0'
+  coverage: '>=0.10.0 <1.0.0'
   dart_dev: ^2.0.0
   dart_style: ^1.0.9
   mockito: '>=2.2.2 <4.0.0'

--- a/lib/dart/test/transport/f_adapter_transport_test.dart
+++ b/lib/dart/test/transport/f_adapter_transport_test.dart
@@ -30,11 +30,11 @@ void main() {
       messageStream = new StreamController.broadcast();
 
       socket = new MockSocket();
-      when(socket.onState).thenReturn(stateStream.stream);
-      when(socket.onError).thenReturn(errorStream.stream);
-      when(socket.onMessage).thenReturn(messageStream.stream);
+      when(socket.onState).thenAnswer((_) => stateStream.stream);
+      when(socket.onError).thenAnswer((_) => errorStream.stream);
+      when(socket.onMessage).thenAnswer((_) => messageStream.stream);
       socketTransport = new MockSocketTransport();
-      when(socketTransport.socket).thenReturn(socket);
+      when(socketTransport.socket).thenAnswer((_) => socket);
       transport = new FAdapterTransport(socketTransport);
     });
 
@@ -45,8 +45,8 @@ void main() {
     });
 
     test('oneway happy path', () async {
-      when(socket.isClosed).thenReturn(true);
-      when(socket.open()).thenReturn(new Future.value());
+      when(socket.isClosed).thenAnswer((_) => true);
+      when(socket.open()).thenAnswer((_) => new Future.value());
       await transport.open();
       verify(socket.open()).called(1);
 
@@ -58,8 +58,8 @@ void main() {
     });
 
     test('requests happy path', () async {
-      when(socket.isClosed).thenReturn(true);
-      when(socket.open()).thenReturn(new Future.value());
+      when(socket.isClosed).thenAnswer((_) => true);
+      when(socket.open()).thenAnswer((_) => new Future.value());
       await transport.open();
       verify(socket.open()).called(1);
 
@@ -87,8 +87,8 @@ void main() {
     });
 
     test('requests time out without a response', () async {
-      when(socket.isClosed).thenReturn(true);
-      when(socket.open()).thenReturn(new Future.value());
+      when(socket.isClosed).thenAnswer((_) => true);
+      when(socket.open()).thenAnswer((_) => new Future.value());
       await transport.open();
       verify(socket.open()).called(1);
 
@@ -107,8 +107,8 @@ void main() {
     });
 
     test('request is cancelled if the transport is closed', () async {
-      when(socket.isClosed).thenReturn(true);
-      when(socket.open()).thenReturn(new Future.value());
+      when(socket.isClosed).thenAnswer((_) => true);
+      when(socket.open()).thenAnswer((_) => new Future.value());
       await transport.open();
       verify(socket.open()).called(1);
 
@@ -127,8 +127,8 @@ void main() {
 
     test('test socket error triggers transport close', () async {
       // Open the transport
-      when(socket.isClosed).thenReturn(true);
-      when(socket.open()).thenReturn(new Future.value());
+      when(socket.isClosed).thenAnswer((_) => true);
+      when(socket.open()).thenAnswer((_) => new Future.value());
       await transport.open();
       var monitor = new MockTransportMonitor();
       transport.monitor = monitor;

--- a/lib/dart/test/transport/f_http_transport_test.dart
+++ b/lib/dart/test/transport/f_http_transport_test.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:convert' show BASE64;
+import 'dart:convert' show base64;
 import 'dart:convert' show Utf8Codec;
 import 'dart:typed_data' show Uint8List;
 
@@ -32,11 +32,11 @@ void main() {
     };
     Uint8List transportRequest =
         new Uint8List.fromList([0, 0, 0, 5, 1, 2, 3, 4, 5]);
-    String transportRequestB64 = BASE64.encode(transportRequest);
+    String transportRequestB64 = base64.encode(transportRequest);
     Uint8List transportResponse = new Uint8List.fromList([6, 7, 8, 9]);
     Uint8List transportResponseFramed =
         new Uint8List.fromList([0, 0, 0, 4, 6, 7, 8, 9]);
-    String transportResponseB64 = BASE64.encode(transportResponseFramed);
+    String transportResponseB64 = base64.encode(transportResponseFramed);
 
     setUp(() {
       client = new Client();
@@ -151,7 +151,7 @@ void main() {
     test('Test transport does not execute frame on oneway requests', () async {
       Uint8List responseBytes = new Uint8List.fromList([0, 0, 0, 0]);
       Response response =
-          new MockResponse.ok(body: BASE64.encode(responseBytes));
+          new MockResponse.ok(body: base64.encode(responseBytes));
       MockTransports.http.expect('POST', transport.uri, respondWith: response);
       var result = await transport.request(new FContext(), transportRequest);
       expect(result, null);
@@ -161,7 +161,7 @@ void main() {
         () async {
       Uint8List responseBytes = new Uint8List.fromList([0, 0, 0, 1]);
       Response response =
-          new MockResponse.ok(body: BASE64.encode(responseBytes));
+          new MockResponse.ok(body: base64.encode(responseBytes));
       MockTransports.http.expect('POST', transport.uri, respondWith: response);
       expect(transport.request(new FContext(), transportRequest),
           throwsA(new isInstanceOf<TTransportError>()));

--- a/lib/dart/test/transport/f_http_transport_test.dart
+++ b/lib/dart/test/transport/f_http_transport_test.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
-import 'dart:convert' show base64;
 import 'dart:convert' show Utf8Codec;
 import 'dart:typed_data' show Uint8List;
 
+import 'package:dart2_constant/convert.dart' as convert;
 import 'package:frugal/frugal.dart';
 import 'package:test/test.dart';
 import 'package:thrift/thrift.dart';
@@ -32,11 +32,12 @@ void main() {
     };
     Uint8List transportRequest =
         new Uint8List.fromList([0, 0, 0, 5, 1, 2, 3, 4, 5]);
-    String transportRequestB64 = base64.encode(transportRequest);
+    String transportRequestB64 = convert.base64.encode(transportRequest);
     Uint8List transportResponse = new Uint8List.fromList([6, 7, 8, 9]);
     Uint8List transportResponseFramed =
         new Uint8List.fromList([0, 0, 0, 4, 6, 7, 8, 9]);
-    String transportResponseB64 = base64.encode(transportResponseFramed);
+    String transportResponseB64 =
+        convert.base64.encode(transportResponseFramed);
 
     setUp(() {
       client = new Client();
@@ -151,7 +152,7 @@ void main() {
     test('Test transport does not execute frame on oneway requests', () async {
       Uint8List responseBytes = new Uint8List.fromList([0, 0, 0, 0]);
       Response response =
-          new MockResponse.ok(body: base64.encode(responseBytes));
+          new MockResponse.ok(body: convert.base64.encode(responseBytes));
       MockTransports.http.expect('POST', transport.uri, respondWith: response);
       var result = await transport.request(new FContext(), transportRequest);
       expect(result, null);
@@ -161,7 +162,7 @@ void main() {
         () async {
       Uint8List responseBytes = new Uint8List.fromList([0, 0, 0, 1]);
       Response response =
-          new MockResponse.ok(body: base64.encode(responseBytes));
+          new MockResponse.ok(body: convert.base64.encode(responseBytes));
       MockTransports.http.expect('POST', transport.uri, respondWith: response);
       expect(transport.request(new FContext(), transportRequest),
           throwsA(new isInstanceOf<TTransportError>()));

--- a/scripts/smithy/smithy_dart.sh
+++ b/scripts/smithy/smithy_dart.sh
@@ -7,7 +7,7 @@ tar -C lib/dart -czf $FRUGAL_HOME/frugal.pub.tgz .
 
 # Compile library code
 cd $FRUGAL_HOME/lib/dart
-pub get
+timeout 5m pub get
 
 #generate test runner
 pub run dart_dev gen-test-runner
@@ -15,10 +15,4 @@ pub run dart_dev gen-test-runner
 # Run the tests
 pub run dart_dev test
 
-# Run coverage
-pub run dart_dev coverage --no-html
-
 pub run dart_dev format --check
-pub run dart_dev analyze --fatal-lints
-
-$FRUGAL_HOME/scripts/smithy/codecov.sh $FRUGAL_HOME/lib/dart/coverage/coverage.lcov dartlibrarytest

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -8,7 +8,7 @@ run:  # local tests only, never run in Skynet
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.36
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.38
 
 env:
   - IN_SKYNET_CLI=true
@@ -41,7 +41,7 @@ requires:
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.36
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.38
 
 env:
   - PYTHONIOENCODING=utf-8

--- a/test/integration/dart/test_client/pubspec.yaml
+++ b/test/integration/dart/test_client/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
   frugal_test:
     path: ../gen-dart/frugal_test
 dev_dependencies:
-  test: "^0.12.0"
+  test: "^1.3.0"
 dependency_overrides:
   frugal:
     path:  ../../../../lib/dart


### PR DESCRIPTION
### Story:
Frugal still uses dart1 in both workiva-build and skynet. Switch to dart2. 

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
CI passes.

### My Test Results:
CI passed.

#### Reviewers:
@Workiva/product2