### PR TITLE
INFENG-10121: Consume messaging-docker-image 0.0.39

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.38 as build
+FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.39 as build
 
 ARG GIT_BRANCH
 ARG GIT_MERGE_BRANCH

--- a/scripts/skynet/skynet_setup.sh
+++ b/scripts/skynet/skynet_setup.sh
@@ -2,10 +2,6 @@
 
 set -exo pipefail
 
-which glide > /dev/null || {
-    curl https://glide.sh/get | sh
-}
-
 mkdir -p /go/src/github.com/Workiva/
 
 # Symlink frugal to gopath - this allows skynet-cli editing for interactive/directmount
@@ -14,8 +10,8 @@ ln -s /testing/ /go/src/github.com/Workiva/frugal
 # Install frugal
 cd $GOPATH/src/github.com/Workiva/frugal && go install
 
-# Start gnatsd
-gnatsd &
+# Start nats-server
+nats-server &
 
 # Start activemq broker
 cd /opt/activemq/bin

--- a/scripts/skynet/test_cleanup.sh
+++ b/scripts/skynet/test_cleanup.sh
@@ -8,7 +8,7 @@ FRUGAL_HOME=$GOPATH/src/github.com/Workiva/frugal
 tar -czf test_logs.tar.gz test/integration/log
 mv test_logs.tar.gz /testing/artifacts/
 
-pkill gnatsd
+pkill nats-server
 
 # Stop activemq broker
 cd /opt/activemq/bin

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -8,7 +8,7 @@ run:  # local tests only, never run in Skynet
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.38
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.39
 
 env:
   - IN_SKYNET_CLI=true
@@ -41,8 +41,7 @@ requires:
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.38
-
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.0.39
 env:
   - PYTHONIOENCODING=utf-8
 


### PR DESCRIPTION
### Story:
Consume messaging-docker-image 0.0.39 (updates dart to 2.6.1 and nats-server to 2.1.2)

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### How To Test:
CI passes

#### Reviewers:
@Workiva/product2