### PR TITLE
Update python context timeout docstrings to reflect the correct units

### DIFF
--- a/lib/python/frugal/context.py
+++ b/lib/python/frugal/context.py
@@ -168,7 +168,7 @@ class FContext(object):
         Sets the timeout for the FContext.
 
         Args:
-            timeout: number of seconds
+            timeout: number of milliseconds
         """
         self._request_headers[_TIMEOUT_HEADER] = str(timeout)
 
@@ -185,7 +185,7 @@ class FContext(object):
         Sets the timeout for the FContext.
 
         Args:
-            timeout: number of seconds
+            timeout: number of milliseconds
         """
         # TODO: check the type of timeout
         self._request_headers[_TIMEOUT_HEADER] = str(timeout)


### PR DESCRIPTION
### Story:
The docstrings for the python context timeouts had incorrect units. Fix it.

#### Reviewers:
@Workiva/product2