### PR TITLE
dart: Add dartdoc reference for enum field type

### DIFF
--- a/test/expected/dart/include_vendor/f_vendored_references.dart
+++ b/test/expected/dart/include_vendor/f_vendored_references.dart
@@ -18,6 +18,7 @@ class VendoredReferences implements thrift.TBase {
 
   int _reference_vendored_const;
   static const int REFERENCE_VENDORED_CONST = 1;
+  /// [t_vendor_namespace.MyEnum]
   int _reference_vendored_enum;
   static const int REFERENCE_VENDORED_ENUM = 2;
 
@@ -42,8 +43,10 @@ class VendoredReferences implements thrift.TBase {
     this.__isset_reference_vendored_const = false;
   }
 
+  /// [t_vendor_namespace.MyEnum]
   int get reference_vendored_enum => this._reference_vendored_enum;
 
+  /// [t_vendor_namespace.MyEnum]
   set reference_vendored_enum(int reference_vendored_enum) {
     this._reference_vendored_enum = reference_vendored_enum;
     this.__isset_reference_vendored_enum = true;

--- a/test/expected/dart/variety/f_testing_defaults.dart
+++ b/test/expected/dart/variety/f_testing_defaults.dart
@@ -67,8 +67,10 @@ class TestingDefaults implements thrift.TBase {
   static const int LIST4 = 15;
   Map<String, String> _a_map;
   static const int A_MAP = 16;
+  /// [t_variety.HealthCondition] Comment for enum field.
   int _status;
   static const int STATUS = 17;
+  /// [t_actual_base_dart.base_health_condition]
   int _base_status;
   static const int BASE_STATUS = 18;
 
@@ -314,8 +316,10 @@ class TestingDefaults implements thrift.TBase {
     this.a_map = null;
   }
 
+  /// [t_variety.HealthCondition] Comment for enum field.
   int get status => this._status;
 
+  /// [t_variety.HealthCondition] Comment for enum field.
   set status(int status) {
     this._status = status;
     this.__isset_status = true;
@@ -327,8 +331,10 @@ class TestingDefaults implements thrift.TBase {
     this.__isset_status = false;
   }
 
+  /// [t_actual_base_dart.base_health_condition]
   int get base_status => this._base_status;
 
+  /// [t_actual_base_dart.base_health_condition]
   set base_status(int base_status) {
     this._base_status = base_status;
     this.__isset_base_status = true;

--- a/test/expected/go/slim/f_types.go
+++ b/test/expected/go/slim/f_types.go
@@ -434,22 +434,23 @@ func (p *Event) String() string {
 }
 
 type TestingDefaults struct {
-	ID2        ID
-	Ev1        *Event
-	Ev2        *Event
-	ID         ID
-	Thing      string
-	Thing2     string
-	Listfield  []Int
-	ID3        ID
-	BinField   []byte
-	BinField2  []byte
-	BinField3  []byte
-	BinField4  []byte
-	List2      *[]Int
-	List3      []Int
-	List4      []Int
-	AMap       *map[string]string
+	ID2       ID
+	Ev1       *Event
+	Ev2       *Event
+	ID        ID
+	Thing     string
+	Thing2    string
+	Listfield []Int
+	ID3       ID
+	BinField  []byte
+	BinField2 []byte
+	BinField3 []byte
+	BinField4 []byte
+	List2     *[]Int
+	List3     []Int
+	List4     []Int
+	AMap      *map[string]string
+	// Comment for enum field.
 	Status     HealthCondition
 	BaseStatus golang.BaseHealthCondition
 }

--- a/test/expected/go/variety/f_types.txt
+++ b/test/expected/go/variety/f_types.txt
@@ -589,22 +589,23 @@ func (p *Event) String() string {
 }
 
 type TestingDefaults struct {
-	ID2        ID                         `thrift:"ID2,1" db:"ID2" json:"ID2,omitempty"`
-	Ev1        *Event                     `thrift:"ev1,2" db:"ev1" json:"ev1"`
-	Ev2        *Event                     `thrift:"ev2,3" db:"ev2" json:"ev2"`
-	ID         ID                         `thrift:"ID,4" db:"ID" json:"ID"`
-	Thing      string                     `thrift:"thing,5" db:"thing" json:"thing"`
-	Thing2     string                     `thrift:"thing2,6" db:"thing2" json:"thing2,omitempty"`
-	Listfield  []Int                      `thrift:"listfield,7" db:"listfield" json:"listfield"`
-	ID3        ID                         `thrift:"ID3,8" db:"ID3" json:"ID3"`
-	BinField   []byte                     `thrift:"bin_field,9" db:"bin_field" json:"bin_field"`
-	BinField2  []byte                     `thrift:"bin_field2,10" db:"bin_field2" json:"bin_field2,omitempty"`
-	BinField3  []byte                     `thrift:"bin_field3,11" db:"bin_field3" json:"bin_field3"`
-	BinField4  []byte                     `thrift:"bin_field4,12" db:"bin_field4" json:"bin_field4,omitempty"`
-	List2      *[]Int                     `thrift:"list2,13" db:"list2" json:"list2,omitempty"`
-	List3      []Int                      `thrift:"list3,14" db:"list3" json:"list3,omitempty"`
-	List4      []Int                      `thrift:"list4,15" db:"list4" json:"list4"`
-	AMap       *map[string]string         `thrift:"a_map,16" db:"a_map" json:"a_map,omitempty"`
+	ID2       ID                 `thrift:"ID2,1" db:"ID2" json:"ID2,omitempty"`
+	Ev1       *Event             `thrift:"ev1,2" db:"ev1" json:"ev1"`
+	Ev2       *Event             `thrift:"ev2,3" db:"ev2" json:"ev2"`
+	ID        ID                 `thrift:"ID,4" db:"ID" json:"ID"`
+	Thing     string             `thrift:"thing,5" db:"thing" json:"thing"`
+	Thing2    string             `thrift:"thing2,6" db:"thing2" json:"thing2,omitempty"`
+	Listfield []Int              `thrift:"listfield,7" db:"listfield" json:"listfield"`
+	ID3       ID                 `thrift:"ID3,8" db:"ID3" json:"ID3"`
+	BinField  []byte             `thrift:"bin_field,9" db:"bin_field" json:"bin_field"`
+	BinField2 []byte             `thrift:"bin_field2,10" db:"bin_field2" json:"bin_field2,omitempty"`
+	BinField3 []byte             `thrift:"bin_field3,11" db:"bin_field3" json:"bin_field3"`
+	BinField4 []byte             `thrift:"bin_field4,12" db:"bin_field4" json:"bin_field4,omitempty"`
+	List2     *[]Int             `thrift:"list2,13" db:"list2" json:"list2,omitempty"`
+	List3     []Int              `thrift:"list3,14" db:"list3" json:"list3,omitempty"`
+	List4     []Int              `thrift:"list4,15" db:"list4" json:"list4"`
+	AMap      *map[string]string `thrift:"a_map,16" db:"a_map" json:"a_map,omitempty"`
+	// Comment for enum field.
 	Status     HealthCondition            `thrift:"status,17,required" db:"status" json:"status"`
 	BaseStatus golang.BaseHealthCondition `thrift:"base_status,18,required" db:"base_status" json:"base_status"`
 }

--- a/test/expected/gopherjs/variety/f_types.go
+++ b/test/expected/gopherjs/variety/f_types.go
@@ -434,22 +434,23 @@ func (p *Event) String() string {
 }
 
 type TestingDefaults struct {
-	ID2        ID
-	Ev1        *Event
-	Ev2        *Event
-	ID         ID
-	Thing      string
-	Thing2     string
-	Listfield  []Int
-	ID3        ID
-	BinField   []byte
-	BinField2  []byte
-	BinField3  []byte
-	BinField4  []byte
-	List2      *[]Int
-	List3      []Int
-	List4      []Int
-	AMap       *map[string]string
+	ID2       ID
+	Ev1       *Event
+	Ev2       *Event
+	ID        ID
+	Thing     string
+	Thing2    string
+	Listfield []Int
+	ID3       ID
+	BinField  []byte
+	BinField2 []byte
+	BinField3 []byte
+	BinField4 []byte
+	List2     *[]Int
+	List3     []Int
+	List4     []Int
+	AMap      *map[string]string
+	// Comment for enum field.
 	Status     HealthCondition
 	BaseStatus golang.BaseHealthCondition
 }

--- a/test/expected/html/standalone/variety.html
+++ b/test/expected/html/standalone/variety.html
@@ -912,7 +912,7 @@ code { line-height: 20px; }
 						<td>17</td>
 						<td>status</td>
 						<td><code><a href="#enum_HealthCondition">HealthCondition</a></code></td>
-						<td></td>
+						<td>Comment for enum field.<br /></td>
 						<td>required</td>
 						<td><code><a href="#enum_HealthCondition">HealthCondition.PASS</a></code></td>
 					</tr>

--- a/test/expected/html/variety.html
+++ b/test/expected/html/variety.html
@@ -727,7 +727,7 @@
 						<td>17</td>
 						<td>status</td>
 						<td><code><a href="#enum_HealthCondition">HealthCondition</a></code></td>
-						<td></td>
+						<td>Comment for enum field.<br /></td>
 						<td>required</td>
 						<td><code><a href="#enum_HealthCondition">HealthCondition.PASS</a></code></td>
 					</tr>

--- a/test/expected/java/boxed_primitives/TestingDefaults.java
+++ b/test/expected/java/boxed_primitives/TestingDefaults.java
@@ -76,6 +76,9 @@ public class TestingDefaults implements org.apache.thrift.TBase<TestingDefaults,
 	public java.util.List<Integer> list3; // optional
 	public java.util.List<Integer> list4;
 	public java.util.Map<String, String> a_map; // optional
+	/**
+	 * Comment for enum field.
+	 */
 	public HealthCondition status; // required
 	public actual_base.java.base_health_condition base_status; // required
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
@@ -96,6 +99,9 @@ public class TestingDefaults implements org.apache.thrift.TBase<TestingDefaults,
 		LIST3((short)14, "list3"),
 		LIST4((short)15, "list4"),
 		A_MAP((short)16, "a_map"),
+		/**
+		 * Comment for enum field.
+		 */
 		STATUS((short)17, "status"),
 		BASE_STATUS((short)18, "base_status")
 		;
@@ -901,10 +907,16 @@ public class TestingDefaults implements org.apache.thrift.TBase<TestingDefaults,
 		}
 	}
 
+	/**
+	 * Comment for enum field.
+	 */
 	public HealthCondition getStatus() {
 		return this.status;
 	}
 
+	/**
+	 * Comment for enum field.
+	 */
 	public TestingDefaults setStatus(HealthCondition status) {
 		this.status = status;
 		return this;

--- a/test/expected/java/variety/TestingDefaults.java
+++ b/test/expected/java/variety/TestingDefaults.java
@@ -76,6 +76,9 @@ public class TestingDefaults implements org.apache.thrift.TBase<TestingDefaults,
 	public java.util.List<Integer> list3; // optional
 	public java.util.List<Integer> list4;
 	public java.util.Map<String, String> a_map; // optional
+	/**
+	 * Comment for enum field.
+	 */
 	public HealthCondition status; // required
 	public actual_base.java.base_health_condition base_status; // required
 	/** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
@@ -96,6 +99,9 @@ public class TestingDefaults implements org.apache.thrift.TBase<TestingDefaults,
 		LIST3((short)14, "list3"),
 		LIST4((short)15, "list4"),
 		A_MAP((short)16, "a_map"),
+		/**
+		 * Comment for enum field.
+		 */
 		STATUS((short)17, "status"),
 		BASE_STATUS((short)18, "base_status")
 		;
@@ -899,10 +905,16 @@ public class TestingDefaults implements org.apache.thrift.TBase<TestingDefaults,
 		}
 	}
 
+	/**
+	 * Comment for enum field.
+	 */
 	public HealthCondition getStatus() {
 		return this.status;
 	}
 
+	/**
+	 * Comment for enum field.
+	 */
 	public TestingDefaults setStatus(HealthCondition status) {
 		this.status = status;
 		return this;

--- a/test/expected/python.asyncio/variety/ttypes.py
+++ b/test/expected/python.asyncio/variety/ttypes.py
@@ -276,7 +276,7 @@ class TestingDefaults(object):
      - list3
      - list4
      - a_map
-     - status
+     - status: Comment for enum field.
      - base_status
     """
     from . import constants

--- a/test/expected/python.tornado/variety/ttypes.py
+++ b/test/expected/python.tornado/variety/ttypes.py
@@ -276,7 +276,7 @@ class TestingDefaults(object):
      - list3
      - list4
      - a_map
-     - status
+     - status: Comment for enum field.
      - base_status
     """
     from . import constants

--- a/test/expected/python/variety/ttypes.py
+++ b/test/expected/python/variety/ttypes.py
@@ -276,7 +276,7 @@ class TestingDefaults(object):
      - list3
      - list4
      - a_map
-     - status
+     - status: Comment for enum field.
      - base_status
     """
     from . import constants

--- a/test/idl/variety.frugal
+++ b/test/idl/variety.frugal
@@ -115,6 +115,7 @@ struct TestingDefaults {
     14: optional list<int> list3,
     15: list<int> list4 = [1,2,3,6],
     16: optional map<string, string> a_map = {"k1": "v1", "k2": "v2"},
+    /**@ Comment for enum field. */
     17: required HealthCondition status = HealthCondition.PASS,
     18: required base.base_health_condition base_status = base.base_health_condition.FAIL,
 }


### PR DESCRIPTION
### Story:
The expected enum type for fields is not easily discoverable in generated Dart code.  Add a dartdoc reference to the enum type.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:

### How To Test:

### My Test Results:

#### Reviewers:
@Workiva/product2