### PR TITLE
Add JSON generator

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Workiva/frugal/compiler/generator/gopherjs"
 	"github.com/Workiva/frugal/compiler/generator/html"
 	"github.com/Workiva/frugal/compiler/generator/java"
+	"github.com/Workiva/frugal/compiler/generator/json"
 	"github.com/Workiva/frugal/compiler/generator/python"
 	"github.com/Workiva/frugal/compiler/globals"
 	"github.com/Workiva/frugal/compiler/parser"
@@ -165,6 +166,8 @@ func getProgramGenerator(lang string, options map[string]string) (generator.Prog
 		g = generator.NewProgramGenerator(gopherjs.NewGenerator(options), false)
 	case "java":
 		g = generator.NewProgramGenerator(java.NewGenerator(options), true)
+	case "json":
+		g = json.NewGenerator(options)
 	case "py":
 		g = generator.NewProgramGenerator(python.NewGenerator(options), true)
 	case "html":

--- a/compiler/generator/generator.go
+++ b/compiler/generator/generator.go
@@ -71,6 +71,9 @@ var Languages = LanguageOptions{
 		"use_vendor":                  "Use specified import references for vendored includes and do not generate code for them",
 		"suppress_deprecated_logging": "Suppress decrecated API usage warning logging",
 	},
+	"json": Options{
+		"indent": "Add newlines and indentation",
+	},
 	"dart": Options{
 		"library_prefix": "Generate code that can be used within an existing library. " +
 			"Use a dot-separated string, e.g. \"my_parent_lib.src.gen\"",

--- a/compiler/generator/json/generator.go
+++ b/compiler/generator/json/generator.go
@@ -124,9 +124,6 @@ type scope struct {
 	Operations map[string]*frugalType `json:"o,omitempty"`
 }
 
-type operation struct {
-}
-
 type method struct {
 	Params  map[int]*field `json:"p,omitempty"`
 	Results map[int]*field `json:"r,omitempty"`

--- a/compiler/generator/json/generator.go
+++ b/compiler/generator/json/generator.go
@@ -31,7 +31,7 @@ type Generator struct {
 	generated bool
 }
 
-var gen *Generator
+var _ generator.ProgramGenerator = (*Generator)(nil)
 
 // NewGenerator returns a generator for JSON descriptor files.
 func NewGenerator(options map[string]string) generator.ProgramGenerator {

--- a/compiler/generator/json/generator.go
+++ b/compiler/generator/json/generator.go
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2020 Workiva
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package json
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/Workiva/frugal/compiler/generator"
+	"github.com/Workiva/frugal/compiler/parser"
+)
+
+const (
+	defaultOutputDir = "gen-json"
+)
+
+// Generator generates JSON descriptor files.
+type Generator struct {
+	options   map[string]string
+	generated bool
+}
+
+var gen *Generator
+
+// NewGenerator returns a generator for JSON descriptor files.
+func NewGenerator(options map[string]string) generator.ProgramGenerator {
+	return &Generator{
+		options: options,
+	}
+}
+
+// GetOutputDir returns the dir unchanged.
+func (*Generator) GetOutputDir(dir string, frugal *parser.Frugal) string {
+	return dir
+}
+
+// DefaultOutputDir returns "gen-json".
+func (*Generator) DefaultOutputDir() string {
+	return defaultOutputDir
+}
+
+// UseVendor returns false.
+func (*Generator) UseVendor() bool {
+	return false
+}
+
+// Generate writes a type library to the output directory.
+func (g *Generator) Generate(pf *parser.Frugal, outputDir string) error {
+	if g.generated {
+		return nil
+	}
+	g.generated = true
+
+	f, err := os.OpenFile(outputDir+"/frugal.json", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	frugals := collectFrugals(pf, []*parser.Frugal{}, map[string]struct{}{})
+	ff := toFiles(frugals)
+
+	enc := json.NewEncoder(f)
+	if _, ok := g.options["indent"]; ok {
+		enc.SetIndent("", "  ")
+	}
+
+	return enc.Encode(ff)
+}
+
+// collectFrugals returns all recursively referenced parser.Frugal.
+func collectFrugals(pf *parser.Frugal, frugals []*parser.Frugal, used map[string]struct{}) []*parser.Frugal {
+	if _, ok := used[pf.Name]; ok {
+		return frugals
+	}
+	used[pf.Name] = struct{}{}
+	frugals = append(frugals, pf)
+
+	for _, include := range pf.OrderedIncludes() {
+		inclFrugal := pf.ParsedIncludes[include.Name]
+		frugals = collectFrugals(inclFrugal, frugals, used)
+	}
+
+	return frugals
+}
+
+type frugalFile struct {
+	Services map[string]*service    `json:"s,omitempty"`
+	Scopes   map[string]*scope      `json:"c,omitempty"`
+	Types    map[string]*frugalType `json:"t,omitempty"`
+}
+
+type frugalType struct {
+	Annotations  map[string]string `json:"a,omitempty"`
+	Base         string            `json:"b,omitempty"`
+	Key          *frugalType       `json:"k,omitempty"`
+	Value        *frugalType       `json:"v,omitempty"`
+	Name         string            `json:"n,omitempty"`
+	EnumValues   map[int][]string  `json:"e,omitempty"`
+	StructFields map[int]*field    `json:"s,omitempty"`
+	UnionFields  map[int]*field    `json:"u,omitempty"`
+}
+
+type service struct {
+	Methods map[string]*method `json:"m"`
+}
+
+type scope struct {
+	Prefix     string                 `json:"p"`
+	Operations map[string]*frugalType `json:"o,omitempty"`
+}
+
+type operation struct {
+}
+
+type method struct {
+	Params  map[int]*field `json:"p,omitempty"`
+	Results map[int]*field `json:"r,omitempty"`
+}
+
+type field struct {
+	Name string      `json:"n,omitempty"`
+	Type interface{} `json:"t"`
+}
+
+func toFiles(frugals []*parser.Frugal) map[string]*frugalFile {
+	files := map[string]*frugalFile{}
+	for _, pf := range frugals {
+		files[pf.Name] = toFile(pf)
+	}
+	return files
+}
+
+func toFile(pf *parser.Frugal) *frugalFile {
+	f := &frugalFile{
+		Types:    map[string]*frugalType{},
+		Services: map[string]*service{},
+		Scopes:   map[string]*scope{},
+	}
+
+	for _, ps := range pf.Services {
+		f.Services[ps.Name] = toService(ps)
+	}
+	for _, ps := range pf.Scopes {
+		f.Scopes[ps.Name] = toScope(ps)
+	}
+
+	for _, pt := range pf.Typedefs {
+		f.Types[pt.Name] = toType(pt.Type)
+	}
+
+	for _, pe := range pf.Enums {
+		f.Types[pe.Name] = toEnum(pe)
+	}
+
+	for _, ps := range pf.Structs {
+		f.Types[ps.Name] = toStructType(ps)
+	}
+	for _, pu := range pf.Unions {
+		f.Types[pu.Name] = toStructType(pu)
+	}
+	for _, pe := range pf.Exceptions {
+		f.Types[pe.Name] = toStructType(pe)
+	}
+
+	return f
+}
+
+func toService(ps *parser.Service) *service {
+	s := &service{
+		Methods: map[string]*method{},
+	}
+
+	for _, pm := range ps.Methods {
+		s.Methods[pm.Name] = toMethod(pm)
+	}
+
+	return s
+}
+
+func toMethod(pm *parser.Method) *method {
+	m := &method{
+		Params:  map[int]*field{},
+		Results: map[int]*field{},
+	}
+
+	for _, pf := range pm.Arguments {
+		m.Params[pf.ID] = toField(pf)
+	}
+
+	if pm.ReturnType != nil {
+		m.Results[0] = &field{Type: toType(pm.ReturnType)}
+	}
+	for _, pf := range pm.Exceptions {
+		m.Results[pf.ID] = toField(pf)
+	}
+
+	return m
+}
+
+func toField(pf *parser.Field) *field {
+	return &field{
+		Name: pf.Name,
+		Type: toType(pf.Type),
+	}
+}
+
+func toScope(ps *parser.Scope) *scope {
+	s := &scope{
+		Prefix:     ps.Prefix.String,
+		Operations: map[string]*frugalType{},
+	}
+
+	for _, po := range ps.Operations {
+		s.Operations[po.Name] = toType(po.Type)
+	}
+
+	return s
+}
+
+var baseTypes = map[string]struct{}{
+	"bool":   struct{}{},
+	"byte":   struct{}{},
+	"i8":     struct{}{},
+	"i16":    struct{}{},
+	"i32":    struct{}{},
+	"i64":    struct{}{},
+	"double": struct{}{},
+	"string": struct{}{},
+	"binary": struct{}{},
+}
+
+func toType(pt *parser.Type) *frugalType {
+	t := toRawType(pt)
+	if len(pt.Annotations) != 0 {
+		t.Annotations = map[string]string{}
+		for _, pa := range pt.Annotations {
+			t.Annotations[pa.Name] = pa.Value
+		}
+	}
+	return t
+}
+
+func toRawType(pt *parser.Type) *frugalType {
+	if pt.IsContainer() {
+		switch {
+		case pt.Name == "list":
+			return &frugalType{Value: toType(pt.ValueType)}
+		case pt.Name == "set":
+			return &frugalType{Key: toType(pt.ValueType)}
+		case pt.Name == "map":
+			return &frugalType{
+				Key:   toType(pt.KeyType),
+				Value: toType(pt.ValueType),
+			}
+		}
+		panic("unknown container type " + pt.Name)
+	}
+
+	if _, ok := baseTypes[pt.Name]; ok {
+		return &frugalType{Base: pt.Name}
+	}
+	return &frugalType{Name: pt.Name}
+}
+
+func toStructFields(ps *parser.Struct) map[int]*field {
+	fields := map[int]*field{}
+	for _, pf := range ps.Fields {
+		fields[pf.ID] = &field{
+			Name: pf.Name,
+			Type: toType(pf.Type),
+		}
+	}
+	return fields
+}
+
+func toStructType(ps *parser.Struct) *frugalType {
+	return &frugalType{StructFields: toStructFields(ps)}
+}
+
+func toUnionType(ps *parser.Struct) *frugalType {
+	return &frugalType{UnionFields: toStructFields(ps)}
+}
+
+func toEnum(pe *parser.Enum) *frugalType {
+	values := map[int][]string{}
+	for _, pev := range pe.Values {
+		values[pev.Value] = append(values[pev.Value], pev.Name)
+	}
+	return &frugalType{EnumValues: values}
+}

--- a/compiler/generator/json/generator.go
+++ b/compiler/generator/json/generator.go
@@ -27,7 +27,10 @@ const (
 
 // Generator generates JSON descriptor files.
 type Generator struct {
-	options   map[string]string
+	options map[string]string
+	// generated is true if Generate has been called. Generate is called once
+	// per included file, but the output contains all transitive dependencies,
+	// so there is nothing to do except for the second and subsequent calls.
 	generated bool
 }
 

--- a/documentation/json.md
+++ b/documentation/json.md
@@ -1,0 +1,42 @@
+# JSON output
+The `-gen json` option can be used to generate a summary of a Frugal file and
+included files in a JSON format for easier automated analysis.
+
+## File format
+The top-level object is a map of namespace names (the basename of a file) to an
+object describing that file:
+* `s`: an object containing a map of service name to descriptor
+* `c`: an object containing a map of scope names to descriptor
+* `t`: an object containing a map of typedef, enum, struct, union, and exception to type descriptor
+
+## Service
+A service descriptor is an object:
+* `m`: an object containing a map of method name to method descriptor
+
+### Service method
+A service method descriptor is an object:
+* `p`: an object containing a map of parameter field id (1-based) to field descriptor
+* `r`: an object containing a map of result field id (0 for success, 1 for exceptions) to field descriptor
+
+## Field
+A field descriptor is an object:
+* `n`: the field name, or absent for the success result of a service method
+* `t`: the type descriptor
+
+## Scope
+A scope descriptor is an object:
+* `p`: the prefix as a string optionally containing one or more `{var}`.
+* `o`: an object containing a map of operation name to type descriptor
+
+## Type
+A type descriptor is an object:
+* `a`: an object containing a map of annotation name to value
+* One of:
+    * `b`: a base type name (for example, `i32`)
+    * `k` and `v`: for a `map` type, the key and value type descriptors, respectively
+    * `k`: for a `set` type, the element type descriptor
+    * `v`: for a `list` type, the element type descriptor
+    * `n`: the name of a named type, which will contain a `.` if the type is in another namespace
+    * `e`: for an `enum` type, an object containing a map of value to list of names for that value
+    * `s`: for a `struct` type, an object containing a map of field id to field descriptor
+    * `u`: for a `union` type, an object containing a map of field id to field descriptor

--- a/test/expected/frugal.json
+++ b/test/expected/frugal.json
@@ -1,0 +1,791 @@
+{
+  "ValidTypes": {
+    "t": {
+      "MyInt": {
+        "b": "i32"
+      }
+    }
+  },
+  "base": {
+    "s": {
+      "BaseFoo": {
+        "m": {
+          "basePing": {}
+        }
+      }
+    },
+    "t": {
+      "api_exception": {},
+      "base_health_condition": {
+        "e": {
+          "1": [
+            "PASS"
+          ],
+          "2": [
+            "WARN"
+          ],
+          "3": [
+            "FAIL"
+          ],
+          "4": [
+            "UNKNOWN"
+          ]
+        }
+      },
+      "nested_thing": {
+        "s": {
+          "1": {
+            "n": "things",
+            "t": {
+              "v": {
+                "n": "thing"
+              }
+            }
+          }
+        }
+      },
+      "thing": {
+        "s": {
+          "1": {
+            "n": "an_id",
+            "t": {
+              "b": "i32"
+            }
+          },
+          "2": {
+            "n": "a_string",
+            "t": {
+              "b": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "intermediate_include": {
+    "s": {
+      "IntermediateFoo": {
+        "m": {
+          "IntermeidateFoo": {}
+        }
+      }
+    }
+  },
+  "subdir_include": {
+    "t": {
+      "A": {}
+    }
+  },
+  "validStructs": {
+    "t": {
+      "Thing": {}
+    }
+  },
+  "variety": {
+    "s": {
+      "Foo": {
+        "m": {
+          "Ping": {},
+          "bin_method": {
+            "p": {
+              "1": {
+                "n": "bin",
+                "t": {
+                  "b": "binary"
+                }
+              },
+              "2": {
+                "n": "Str",
+                "t": {
+                  "b": "string"
+                }
+              }
+            },
+            "r": {
+              "0": {
+                "t": {
+                  "b": "binary"
+                }
+              },
+              "1": {
+                "n": "api",
+                "t": {
+                  "n": "base.api_exception"
+                }
+              }
+            }
+          },
+          "blah": {
+            "p": {
+              "1": {
+                "n": "num",
+                "t": {
+                  "b": "i32"
+                }
+              },
+              "2": {
+                "n": "Str",
+                "t": {
+                  "b": "string"
+                }
+              },
+              "3": {
+                "n": "event",
+                "t": {
+                  "n": "Event"
+                }
+              }
+            },
+            "r": {
+              "0": {
+                "t": {
+                  "b": "i64"
+                }
+              },
+              "1": {
+                "n": "awe",
+                "t": {
+                  "n": "AwesomeException"
+                }
+              },
+              "2": {
+                "n": "api",
+                "t": {
+                  "n": "base.api_exception"
+                }
+              }
+            }
+          },
+          "getMyInt": {
+            "r": {
+              "0": {
+                "t": {
+                  "n": "ValidTypes.MyInt"
+                }
+              }
+            }
+          },
+          "getThing": {
+            "r": {
+              "0": {
+                "t": {
+                  "n": "validStructs.Thing"
+                }
+              }
+            }
+          },
+          "oneWay": {
+            "p": {
+              "1": {
+                "n": "id",
+                "t": {
+                  "n": "id"
+                }
+              },
+              "2": {
+                "n": "req",
+                "t": {
+                  "n": "request"
+                }
+              }
+            }
+          },
+          "param_modifiers": {
+            "p": {
+              "1": {
+                "n": "opt_num",
+                "t": {
+                  "b": "i32"
+                }
+              },
+              "2": {
+                "n": "default_num",
+                "t": {
+                  "b": "i32"
+                }
+              },
+              "3": {
+                "n": "req_num",
+                "t": {
+                  "b": "i32"
+                }
+              }
+            },
+            "r": {
+              "0": {
+                "t": {
+                  "b": "i64"
+                }
+              }
+            }
+          },
+          "sayAgain": {
+            "p": {
+              "1": {
+                "n": "messageResult",
+                "t": {
+                  "b": "string"
+                }
+              }
+            },
+            "r": {
+              "0": {
+                "t": {
+                  "b": "string"
+                }
+              }
+            }
+          },
+          "sayHelloWith": {
+            "p": {
+              "1": {
+                "n": "newMessage",
+                "t": {
+                  "b": "string"
+                }
+              }
+            },
+            "r": {
+              "0": {
+                "t": {
+                  "b": "string"
+                }
+              }
+            }
+          },
+          "underlying_types_test": {
+            "p": {
+              "1": {
+                "n": "list_type",
+                "t": {
+                  "v": {
+                    "n": "id"
+                  }
+                }
+              },
+              "2": {
+                "n": "set_type",
+                "t": {
+                  "k": {
+                    "n": "id"
+                  }
+                }
+              }
+            },
+            "r": {
+              "0": {
+                "t": {
+                  "v": {
+                    "n": "id"
+                  }
+                }
+              }
+            }
+          },
+          "use_subdir_struct": {
+            "p": {
+              "1": {
+                "n": "a",
+                "t": {
+                  "n": "subdir_include.A"
+                }
+              }
+            },
+            "r": {
+              "0": {
+                "t": {
+                  "n": "subdir_include.A"
+                }
+              }
+            }
+          },
+          "whatDoYouSay": {
+            "p": {
+              "1": {
+                "n": "messageArgs",
+                "t": {
+                  "b": "string"
+                }
+              }
+            },
+            "r": {
+              "0": {
+                "t": {
+                  "b": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "FooTransitiveDeps": {
+        "m": {
+          "ping": {}
+        }
+      }
+    },
+    "c": {
+      "Events": {
+        "p": "foo.{user}",
+        "o": {
+          "EventCreated": {
+            "n": "Event"
+          },
+          "SomeInt": {
+            "b": "i64"
+          },
+          "SomeList": {
+            "v": {
+              "k": {
+                "n": "id"
+              },
+              "v": {
+                "n": "Event"
+              }
+            }
+          },
+          "SomeStr": {
+            "b": "string"
+          }
+        }
+      }
+    },
+    "t": {
+      "AwesomeException": {
+        "s": {
+          "1": {
+            "n": "ID",
+            "t": {
+              "n": "id"
+            }
+          },
+          "2": {
+            "n": "Reason",
+            "t": {
+              "b": "string"
+            }
+          },
+          "3": {
+            "n": "depr",
+            "t": {
+              "b": "bool"
+            }
+          }
+        }
+      },
+      "Event": {
+        "s": {
+          "1": {
+            "n": "ID",
+            "t": {
+              "n": "id"
+            }
+          },
+          "2": {
+            "n": "Message",
+            "t": {
+              "b": "string"
+            }
+          }
+        }
+      },
+      "EventWrapper": {
+        "s": {
+          "1": {
+            "n": "ID",
+            "t": {
+              "n": "id"
+            }
+          },
+          "10": {
+            "n": "typedefOfTypedef",
+            "t": {
+              "n": "t2_string"
+            }
+          },
+          "11": {
+            "n": "depr",
+            "t": {
+              "b": "bool"
+            }
+          },
+          "12": {
+            "n": "deprBinary",
+            "t": {
+              "b": "binary"
+            }
+          },
+          "13": {
+            "n": "deprList",
+            "t": {
+              "v": {
+                "b": "bool"
+              }
+            }
+          },
+          "14": {
+            "n": "EventsDefault",
+            "t": {
+              "v": {
+                "n": "Event"
+              }
+            }
+          },
+          "15": {
+            "n": "EventMapDefault",
+            "t": {
+              "k": {
+                "n": "id"
+              },
+              "v": {
+                "n": "Event"
+              }
+            }
+          },
+          "16": {
+            "n": "EventSetDefault",
+            "t": {
+              "k": {
+                "n": "Event"
+              }
+            }
+          },
+          "2": {
+            "n": "Ev",
+            "t": {
+              "n": "Event"
+            }
+          },
+          "3": {
+            "n": "Events",
+            "t": {
+              "v": {
+                "n": "Event"
+              }
+            }
+          },
+          "4": {
+            "n": "Events2",
+            "t": {
+              "k": {
+                "n": "Event"
+              }
+            }
+          },
+          "5": {
+            "n": "EventMap",
+            "t": {
+              "k": {
+                "n": "id"
+              },
+              "v": {
+                "n": "Event"
+              }
+            }
+          },
+          "6": {
+            "n": "Nums",
+            "t": {
+              "v": {
+                "v": {
+                  "n": "int"
+                }
+              }
+            }
+          },
+          "7": {
+            "n": "Enums",
+            "t": {
+              "v": {
+                "n": "ItsAnEnum"
+              }
+            }
+          },
+          "8": {
+            "n": "aBoolField",
+            "t": {
+              "b": "bool"
+            }
+          },
+          "9": {
+            "n": "a_union",
+            "t": {
+              "n": "TestingUnions"
+            }
+          }
+        }
+      },
+      "FooArgs": {
+        "s": {
+          "1": {
+            "n": "newMessage",
+            "t": {
+              "b": "string"
+            }
+          },
+          "2": {
+            "n": "messageArgs",
+            "t": {
+              "b": "string"
+            }
+          },
+          "3": {
+            "n": "messageResult",
+            "t": {
+              "b": "string"
+            }
+          }
+        }
+      },
+      "HealthCondition": {
+        "e": {
+          "1": [
+            "PASS"
+          ],
+          "2": [
+            "WARN"
+          ],
+          "3": [
+            "FAIL"
+          ],
+          "4": [
+            "UNKNOWN"
+          ]
+        }
+      },
+      "ItsAnEnum": {
+        "e": {
+          "2": [
+            "FIRST"
+          ],
+          "3": [
+            "SECOND"
+          ],
+          "4": [
+            "THIRD"
+          ],
+          "5": [
+            "fourth"
+          ],
+          "6": [
+            "Fifth"
+          ],
+          "7": [
+            "sIxItH"
+          ]
+        }
+      },
+      "TestBase": {
+        "s": {
+          "1": {
+            "n": "base_struct",
+            "t": {
+              "n": "base.thing"
+            }
+          }
+        }
+      },
+      "TestLowercase": {
+        "s": {
+          "1": {
+            "n": "lowercaseInt",
+            "t": {
+              "b": "i32"
+            }
+          }
+        }
+      },
+      "TestingDefaults": {
+        "s": {
+          "1": {
+            "n": "ID2",
+            "t": {
+              "n": "id"
+            }
+          },
+          "10": {
+            "n": "bin_field2",
+            "t": {
+              "b": "binary"
+            }
+          },
+          "11": {
+            "n": "bin_field3",
+            "t": {
+              "b": "binary"
+            }
+          },
+          "12": {
+            "n": "bin_field4",
+            "t": {
+              "b": "binary"
+            }
+          },
+          "13": {
+            "n": "list2",
+            "t": {
+              "v": {
+                "n": "int"
+              }
+            }
+          },
+          "14": {
+            "n": "list3",
+            "t": {
+              "v": {
+                "n": "int"
+              }
+            }
+          },
+          "15": {
+            "n": "list4",
+            "t": {
+              "v": {
+                "n": "int"
+              }
+            }
+          },
+          "16": {
+            "n": "a_map",
+            "t": {
+              "k": {
+                "b": "string"
+              },
+              "v": {
+                "b": "string"
+              }
+            }
+          },
+          "17": {
+            "n": "status",
+            "t": {
+              "n": "HealthCondition"
+            }
+          },
+          "18": {
+            "n": "base_status",
+            "t": {
+              "n": "base.base_health_condition"
+            }
+          },
+          "2": {
+            "n": "ev1",
+            "t": {
+              "n": "Event"
+            }
+          },
+          "3": {
+            "n": "ev2",
+            "t": {
+              "n": "Event"
+            }
+          },
+          "4": {
+            "n": "ID",
+            "t": {
+              "n": "id"
+            }
+          },
+          "5": {
+            "n": "thing",
+            "t": {
+              "b": "string"
+            }
+          },
+          "6": {
+            "n": "thing2",
+            "t": {
+              "b": "string"
+            }
+          },
+          "7": {
+            "n": "listfield",
+            "t": {
+              "v": {
+                "n": "int"
+              }
+            }
+          },
+          "8": {
+            "n": "ID3",
+            "t": {
+              "n": "id"
+            }
+          },
+          "9": {
+            "n": "bin_field",
+            "t": {
+              "b": "binary"
+            }
+          }
+        }
+      },
+      "TestingUnions": {
+        "s": {
+          "1": {
+            "n": "AnID",
+            "t": {
+              "n": "id"
+            }
+          },
+          "2": {
+            "n": "aString",
+            "t": {
+              "b": "string"
+            }
+          },
+          "3": {
+            "n": "someotherthing",
+            "t": {
+              "n": "int"
+            }
+          },
+          "4": {
+            "n": "AnInt16",
+            "t": {
+              "b": "i16"
+            }
+          },
+          "5": {
+            "n": "Requests",
+            "t": {
+              "n": "request"
+            }
+          },
+          "6": {
+            "n": "bin_field_in_union",
+            "t": {
+              "b": "binary"
+            }
+          },
+          "7": {
+            "n": "depr",
+            "t": {
+              "b": "bool"
+            }
+          }
+        }
+      },
+      "id": {
+        "b": "i64"
+      },
+      "int": {
+        "b": "i32"
+      },
+      "request": {
+        "k": {
+          "n": "int"
+        },
+        "v": {
+          "b": "string"
+        }
+      },
+      "t1_string": {
+        "b": "string"
+      },
+      "t2_string": {
+        "n": "t1_string"
+      }
+    }
+  }
+}

--- a/test/json_test.go
+++ b/test/json_test.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Workiva
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Workiva/frugal/compiler"
+	"github.com/Workiva/frugal/compiler/globals"
+)
+
+func TestValidJsonFrugalCompiler(t *testing.T) {
+	defer globals.Reset()
+	nowBefore := globals.Now
+	defer func() {
+		globals.Now = nowBefore
+	}()
+	globals.Now = time.Date(2015, 11, 24, 0, 0, 0, 0, time.UTC)
+
+	options := compiler.Options{
+		File:    frugalGenFile,
+		Gen:     "json:indent",
+		Out:     outputDir,
+		Delim:   delim,
+		Recurse: true,
+	}
+	if err := compiler.Compile(options); err != nil {
+		t.Fatal("Unexpected error", err)
+	}
+
+	files := []FileComparisonPair{
+		{"expected/frugal.json", filepath.Join(outputDir, "frugal.json")},
+	}
+
+	copyAllFiles(t, files)
+	compareAllFiles(t, files)
+}


### PR DESCRIPTION
### Story:
We would like to be able to introspect Frugal files without the complexity of actually parsing the Frugal file format.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
A new `-gen json` output mode is added that produces a lightweight JSON format.  The key names are deliberately kept short to minimize the size of the file since we would like to use the output in very space-constrained storage where compression is not an option.

### How To Test:
Unit test added for `variety.frugal`.

### My Test Results:

#### Reviewers:
@Workiva/product2