### PR TITLE
PLC-600 Dart: remove extra _isset_X fields

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -798,7 +798,7 @@ func (g *Generator) generateFieldMethods(s *parser.Struct) string {
 		titleName := strings.Title(field.Name)
 
 		contents += g.generateFieldComment(field, tab)
-		contents += fmt.Sprintf(tab+"%s get %s => this._%s;\n\n", dartType, fName, fName)
+		contents += fmt.Sprintf(tab+"%s get %s => this._%s%s;\n\n", dartType, fName, fName, g.generateInitValue(field))
 		contents += g.generateFieldComment(field, tab)
 		contents += fmt.Sprintf(tab+"set %s(%s %s) {\n", fName, dartType, fName)
 		contents += fmt.Sprintf(tabtab+"this._%s = %s;\n", fName, fName)
@@ -822,7 +822,7 @@ func (g *Generator) generateFieldMethods(s *parser.Struct) string {
 	for _, field := range s.Fields {
 		contents += fmt.Sprintf(tabtabtab+"case %s:\n", strings.ToUpper(field.Name))
 		contents += ignoreDeprecationWarningIfNeeded(tabtabtabtab, field.Annotations)
-		contents += fmt.Sprintf(tabtabtabtab+"return this.%s%s;\n", toFieldName(field.Name), g.generateInitValue(field))
+		contents += fmt.Sprintf(tabtabtabtab+"return this.%s;\n", toFieldName(field.Name))
 	}
 	contents += tabtabtab + "default:\n"
 	contents += tabtabtabtab + "throw ArgumentError(\"Field $fieldID doesn't exist!\");\n"

--- a/examples/dart/gen-dart/v1_music/lib/src/f_album.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_album.dart
@@ -19,12 +19,11 @@ class Album implements thrift.TBase {
 
   List<t_v1_music.Track> _tracks;
   static const int TRACKS = 1;
-  double _duration = 0.0;
+  double _duration;
   static const int DURATION = 2;
   String _aSIN;
   static const int ASIN = 3;
 
-  bool __isset_duration = false;
 
   Album();
 
@@ -34,23 +33,22 @@ class Album implements thrift.TBase {
     this._tracks = tracks;
   }
 
-  bool isSetTracks() => this.tracks != null;
+  bool isSetTracks() => this._tracks != null;
 
   unsetTracks() {
-    this.tracks = null;
+    this._tracks = null;
   }
 
-  double get duration => this._duration;
+  double get duration => this._duration ?? 0.0;
 
   set duration(double duration) {
     this._duration = duration;
-    this.__isset_duration = true;
   }
 
-  bool isSetDuration() => this.__isset_duration;
+  bool isSetDuration() => this._duration != null;
 
   unsetDuration() {
-    this.__isset_duration = false;
+    this._duration = null;
   }
 
   String get aSIN => this._aSIN;
@@ -59,10 +57,10 @@ class Album implements thrift.TBase {
     this._aSIN = aSIN;
   }
 
-  bool isSetASIN() => this.aSIN != null;
+  bool isSetASIN() => this._aSIN != null;
 
   unsetASIN() {
-    this.aSIN = null;
+    this._aSIN = null;
   }
 
   @override
@@ -150,7 +148,6 @@ class Album implements thrift.TBase {
         case DURATION:
           if (field.type == thrift.TType.DOUBLE) {
             this.duration = iprot.readDouble();
-            this.__isset_duration = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -170,7 +167,6 @@ class Album implements thrift.TBase {
     }
     iprot.readStructEnd();
 
-    // check for required fields of primitive type, which can't be checked in the validate method
     validate();
   }
 
@@ -259,7 +255,5 @@ class Album implements thrift.TBase {
   }
 
   validate() {
-    // check for required fields
-    // check that fields of type enum have valid values
   }
 }

--- a/examples/dart/gen-dart/v1_music/lib/src/f_purchasing_error.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_purchasing_error.dart
@@ -18,10 +18,9 @@ class PurchasingError extends Error implements thrift.TBase {
 
   String _message;
   static const int MESSAGE = 1;
-  int _error_code = 0;
+  int _error_code;
   static const int ERROR_CODE = 2;
 
-  bool __isset_error_code = false;
 
   PurchasingError();
 
@@ -31,23 +30,22 @@ class PurchasingError extends Error implements thrift.TBase {
     this._message = message;
   }
 
-  bool isSetMessage() => this.message != null;
+  bool isSetMessage() => this._message != null;
 
   unsetMessage() {
-    this.message = null;
+    this._message = null;
   }
 
-  int get error_code => this._error_code;
+  int get error_code => this._error_code ?? 0;
 
   set error_code(int error_code) {
     this._error_code = error_code;
-    this.__isset_error_code = true;
   }
 
-  bool isSetError_code() => this.__isset_error_code;
+  bool isSetError_code() => this._error_code != null;
 
   unsetError_code() {
-    this.__isset_error_code = false;
+    this._error_code = null;
   }
 
   @override
@@ -116,7 +114,6 @@ class PurchasingError extends Error implements thrift.TBase {
         case ERROR_CODE:
           if (field.type == thrift.TType.I16) {
             this.error_code = iprot.readI16();
-            this.__isset_error_code = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -129,7 +126,6 @@ class PurchasingError extends Error implements thrift.TBase {
     }
     iprot.readStructEnd();
 
-    // check for required fields of primitive type, which can't be checked in the validate method
     validate();
   }
 
@@ -197,7 +193,5 @@ class PurchasingError extends Error implements thrift.TBase {
   }
 
   validate() {
-    // check for required fields
-    // check that fields of type enum have valid values
   }
 }

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -155,10 +155,10 @@ class buyAlbum_args implements thrift.TBase {
     this._aSIN = aSIN;
   }
 
-  bool isSetASIN() => this.aSIN != null;
+  bool isSetASIN() => this._aSIN != null;
 
   unsetASIN() {
-    this.aSIN = null;
+    this._aSIN = null;
   }
 
   String get acct => this._acct;
@@ -167,10 +167,10 @@ class buyAlbum_args implements thrift.TBase {
     this._acct = acct;
   }
 
-  bool isSetAcct() => this.acct != null;
+  bool isSetAcct() => this._acct != null;
 
   unsetAcct() {
-    this.acct = null;
+    this._acct = null;
   }
 
   @override
@@ -251,7 +251,6 @@ class buyAlbum_args implements thrift.TBase {
     }
     iprot.readStructEnd();
 
-    // check for required fields of primitive type, which can't be checked in the validate method
     validate();
   }
 
@@ -325,8 +324,6 @@ class buyAlbum_args implements thrift.TBase {
   }
 
   validate() {
-    // check for required fields
-    // check that fields of type enum have valid values
   }
 }
 // ignore: camel_case_types
@@ -349,10 +346,10 @@ class buyAlbum_result implements thrift.TBase {
     this._success = success;
   }
 
-  bool isSetSuccess() => this.success != null;
+  bool isSetSuccess() => this._success != null;
 
   unsetSuccess() {
-    this.success = null;
+    this._success = null;
   }
 
   t_v1_music.PurchasingError get error => this._error;
@@ -361,10 +358,10 @@ class buyAlbum_result implements thrift.TBase {
     this._error = error;
   }
 
-  bool isSetError() => this.error != null;
+  bool isSetError() => this._error != null;
 
   unsetError() {
-    this.error = null;
+    this._error = null;
   }
 
   @override
@@ -447,7 +444,6 @@ class buyAlbum_result implements thrift.TBase {
     }
     iprot.readStructEnd();
 
-    // check for required fields of primitive type, which can't be checked in the validate method
     validate();
   }
 
@@ -525,8 +521,6 @@ class buyAlbum_result implements thrift.TBase {
   }
 
   validate() {
-    // check for required fields
-    // check that fields of type enum have valid values
   }
 }
 // ignore: camel_case_types
@@ -549,10 +543,10 @@ class enterAlbumGiveaway_args implements thrift.TBase {
     this._email = email;
   }
 
-  bool isSetEmail() => this.email != null;
+  bool isSetEmail() => this._email != null;
 
   unsetEmail() {
-    this.email = null;
+    this._email = null;
   }
 
   String get name => this._name;
@@ -561,10 +555,10 @@ class enterAlbumGiveaway_args implements thrift.TBase {
     this._name = name;
   }
 
-  bool isSetName() => this.name != null;
+  bool isSetName() => this._name != null;
 
   unsetName() {
-    this.name = null;
+    this._name = null;
   }
 
   @override
@@ -645,7 +639,6 @@ class enterAlbumGiveaway_args implements thrift.TBase {
     }
     iprot.readStructEnd();
 
-    // check for required fields of primitive type, which can't be checked in the validate method
     validate();
   }
 
@@ -719,8 +712,6 @@ class enterAlbumGiveaway_args implements thrift.TBase {
   }
 
   validate() {
-    // check for required fields
-    // check that fields of type enum have valid values
   }
 }
 // ignore: camel_case_types
@@ -731,7 +722,6 @@ class enterAlbumGiveaway_result implements thrift.TBase {
   bool _success;
   static const int SUCCESS = 0;
 
-  bool __isset_success = false;
 
   enterAlbumGiveaway_result();
 
@@ -739,13 +729,12 @@ class enterAlbumGiveaway_result implements thrift.TBase {
 
   set success(bool success) {
     this._success = success;
-    this.__isset_success = true;
   }
 
-  bool isSetSuccess() => this.__isset_success;
+  bool isSetSuccess() => this._success != null;
 
   unsetSuccess() {
-    this.__isset_success = false;
+    this._success = null;
   }
 
   @override
@@ -795,7 +784,6 @@ class enterAlbumGiveaway_result implements thrift.TBase {
         case SUCCESS:
           if (field.type == thrift.TType.BOOL) {
             this.success = iprot.readBool();
-            this.__isset_success = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -808,7 +796,6 @@ class enterAlbumGiveaway_result implements thrift.TBase {
     }
     iprot.readStructEnd();
 
-    // check for required fields of primitive type, which can't be checked in the validate method
     validate();
   }
 
@@ -863,7 +850,5 @@ class enterAlbumGiveaway_result implements thrift.TBase {
   }
 
   validate() {
-    // check for required fields
-    // check that fields of type enum have valid values
   }
 }

--- a/examples/dart/gen-dart/v1_music/lib/src/f_track.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_track.dart
@@ -27,14 +27,12 @@ class Track implements thrift.TBase {
   static const int PUBLISHER = 3;
   String _composer;
   static const int COMPOSER = 4;
-  double _duration = 0.0;
+  double _duration;
   static const int DURATION = 5;
   /// [t_v1_music.PerfRightsOrg]
   int _pro;
   static const int PRO = 6;
 
-  bool __isset_duration = false;
-  bool __isset_pro = false;
 
   Track();
 
@@ -44,10 +42,10 @@ class Track implements thrift.TBase {
     this._title = title;
   }
 
-  bool isSetTitle() => this.title != null;
+  bool isSetTitle() => this._title != null;
 
   unsetTitle() {
-    this.title = null;
+    this._title = null;
   }
 
   String get artist => this._artist;
@@ -56,10 +54,10 @@ class Track implements thrift.TBase {
     this._artist = artist;
   }
 
-  bool isSetArtist() => this.artist != null;
+  bool isSetArtist() => this._artist != null;
 
   unsetArtist() {
-    this.artist = null;
+    this._artist = null;
   }
 
   String get publisher => this._publisher;
@@ -68,10 +66,10 @@ class Track implements thrift.TBase {
     this._publisher = publisher;
   }
 
-  bool isSetPublisher() => this.publisher != null;
+  bool isSetPublisher() => this._publisher != null;
 
   unsetPublisher() {
-    this.publisher = null;
+    this._publisher = null;
   }
 
   String get composer => this._composer;
@@ -80,23 +78,22 @@ class Track implements thrift.TBase {
     this._composer = composer;
   }
 
-  bool isSetComposer() => this.composer != null;
+  bool isSetComposer() => this._composer != null;
 
   unsetComposer() {
-    this.composer = null;
+    this._composer = null;
   }
 
-  double get duration => this._duration;
+  double get duration => this._duration ?? 0.0;
 
   set duration(double duration) {
     this._duration = duration;
-    this.__isset_duration = true;
   }
 
-  bool isSetDuration() => this.__isset_duration;
+  bool isSetDuration() => this._duration != null;
 
   unsetDuration() {
-    this.__isset_duration = false;
+    this._duration = null;
   }
 
   /// [t_v1_music.PerfRightsOrg]
@@ -105,13 +102,12 @@ class Track implements thrift.TBase {
   /// [t_v1_music.PerfRightsOrg]
   set pro(int pro) {
     this._pro = pro;
-    this.__isset_pro = true;
   }
 
-  bool isSetPro() => this.__isset_pro;
+  bool isSetPro() => this._pro != null;
 
   unsetPro() {
-    this.__isset_pro = false;
+    this._pro = null;
   }
 
   @override
@@ -249,7 +245,6 @@ class Track implements thrift.TBase {
         case DURATION:
           if (field.type == thrift.TType.DOUBLE) {
             this.duration = iprot.readDouble();
-            this.__isset_duration = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -257,7 +252,6 @@ class Track implements thrift.TBase {
         case PRO:
           if (field.type == thrift.TType.I32) {
             this.pro = iprot.readI32();
-            this.__isset_pro = true;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -270,7 +264,6 @@ class Track implements thrift.TBase {
     }
     iprot.readStructEnd();
 
-    // check for required fields of primitive type, which can't be checked in the validate method
     validate();
   }
 
@@ -408,7 +401,6 @@ class Track implements thrift.TBase {
   }
 
   validate() {
-    // check for required fields
     // check that fields of type enum have valid values
     if (isSetPro() && !t_v1_music.PerfRightsOrg.VALID_VALUES.contains(this.pro)) {
       throw thrift.TProtocolError(thrift.TProtocolErrorType.INVALID_DATA, "The field 'pro' has been assigned the invalid value ${this.pro}");


### PR DESCRIPTION
### Story:
I took the work Todd did: https://github.com/Workiva/frugal/pull/1040 and reimplemented it while solving the bug which caused it to be reverted.

The problem was that primitives were always been returned as having been set, so instead of getting rid of the getters/setters I left them in place and moved the default value from where the variable was created into the getter.  This prevents anything from breaking because of an unexpected null value while still enabling the isSet method to just do a null check rather than needing to store an additional boolean for each value to determine if it is set or not.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master


### How To Test:
Build all the frugal in skaardb and DPC and make sure they place nice with each other

#### Reviewers:
@Workiva/product2