### PR TITLE
Fix Travis CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
-dist: trusty
-group: deprecated-2017Q3
+dist: bionic
 language: go
 git:
   depth: 1
@@ -17,12 +16,14 @@ before_install:
   # No need to install dart yet as we can't run the tests until thrift publishes dart to pub
   # - sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
   # - sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-  - sudo add-apt-repository -y ppa:openjdk-r/ppa
   - sudo add-apt-repository -y ppa:masterminds/glide
-  - sudo apt-get update -qq
-  - sudo apt-get -y install python3-pip python-dev build-essential openjdk-8-jdk maven glide
+  - sudo apt update
+  - sudo apt -y install python3-pip python-dev python-virtualenv build-essential glide openjdk-8-jdk
+  # The travis image comes with openjdk11 which has some bugs with checkstyle and javadoc.
+  # Force openjdk1.8 until we can upgrade to 11 or 13
+  - export PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin:$PATH
+  - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
   # sudo apt-get -y install dart
-  - pip install -U virtualenv
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_install:
   - sudo apt -y install python3-pip python-dev python-virtualenv build-essential glide openjdk-8-jdk
   # The travis image comes with openjdk11 which has some bugs with checkstyle and javadoc.
   # Force openjdk1.8 until we can upgrade to 11 or 13
-  - export PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin:$PATH
   - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
   # sudo apt-get -y install dart
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ unit-go:
 	cd lib/go && GO111MODULE=on go mod vendor && go test -v -race 
 
 unit-java:
-	mvn -f lib/java/pom.xml checkstyle:check clean verify
+	mvn -f lib/java/pom.xml clean verify
 
 unit-py2:
 	virtualenv -p /usr/bin/python /tmp/frugal && \


### PR DESCRIPTION
### Story:
Travis was failing originally installing virtualenv from pip. I fixed that by using the apt package for virtualenv and updated to the bionic image (not related, but seemed like a good idea). 

Next, java checkstyle was failing because openjdk 11 and maven are now baked into the go image and apt installing openjdk8 doesn't update the `JAVA_HOME` for some reason. So checkstyle and javadoc were failing - it looks like there are known bugs with those and certain versions of jdk 11. I started down the rabbit hole of updating those but the PR started to blow up, so I opted to just pin to jdk 8 for now.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

#### Reviewers:
@Workiva/product2