### PR TITLE
CPLAT-10183: Add factories for creating dart frugal objects

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1493,12 +1493,19 @@ func (g *Generator) GeneratePublisher(file *os.File, scope *parser.Scope) error 
 	if scope.Comment != nil {
 		publishers += g.GenerateInlineComment(scope.Comment, "/")
 	}
-	publishers += fmt.Sprintf("class %sPublisher {\n", strings.Title(scope.Name))
+	publisherClassname :=  fmt.Sprintf("%sPublisher", strings.Title(scope.Name))
+
+	// Generate publisher factory
+	publishers += fmt.Sprintf("%sFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) => \n", publisherClassname)
+	publishers += tab + fmt.Sprintf("%s(provider, middleware);\n\n", publisherClassname)
+
+	// Generate publisher class
+	publishers += fmt.Sprintf("class %s {\n", publisherClassname)
 	publishers += tab + "frugal.FPublisherTransport transport;\n"
 	publishers += tab + "frugal.FProtocolFactory protocolFactory;\n"
 	publishers += tab + "Map<String, frugal.FMethod> _methods;\n"
 
-	publishers += fmt.Sprintf(tab+"%sPublisher(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) {\n", strings.Title(scope.Name))
+	publishers += fmt.Sprintf(tab+"%s(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) {\n", publisherClassname)
 	publishers += tabtab + "transport = provider.publisherTransportFactory.getTransport();\n"
 	publishers += tabtab + "protocolFactory = provider.protocolFactory;\n"
 	publishers += tabtab + "var combined = middleware ?? [];\n"
@@ -1593,11 +1600,18 @@ func (g *Generator) GenerateSubscriber(file *os.File, scope *parser.Scope) error
 	if scope.Comment != nil {
 		subscribers += g.GenerateInlineComment(scope.Comment, "/")
 	}
-	subscribers += fmt.Sprintf("class %sSubscriber {\n", strings.Title(scope.Name))
+	subscriberClassname :=  fmt.Sprintf("%sSubscriber", strings.Title(scope.Name))
+
+	// Generate subscriber factory
+	subscribers += fmt.Sprintf("%sFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) => \n", subscriberClassname)
+	subscribers += tab + fmt.Sprintf("%s(provider, middleware);\n\n", subscriberClassname)
+
+	// Generate subscriber class
+	subscribers += fmt.Sprintf("class %s {\n", subscriberClassname)
 	subscribers += tab + "final frugal.FScopeProvider provider;\n"
 	subscribers += tab + "final List<frugal.Middleware> _middleware;\n\n"
 
-	subscribers += tab + fmt.Sprintf("%sSubscriber(this.provider, [List<frugal.Middleware> middleware])\n", strings.Title(scope.Name))
+	subscribers += tab + fmt.Sprintf("%s(this.provider, [List<frugal.Middleware> middleware])\n", subscriberClassname)
 	subscribers += tabtabtab + ": this._middleware = middleware ?? [] {\n"
 	subscribers += tabtab + "this._middleware.addAll(provider.middleware);\n"
 	subscribers += "}\n\n"
@@ -1726,25 +1740,31 @@ func (g *Generator) getServiceExtendsName(service *parser.Service) string {
 
 func (g *Generator) generateClient(service *parser.Service) string {
 	servTitle := strings.Title(service.Name)
+	clientClassname := fmt.Sprintf("F%sClient", servTitle)
 	contents := ""
 	if service.Comment != nil {
 		contents += g.GenerateInlineComment(service.Comment, "/")
 	}
+	// Generate client factory
+	contents += fmt.Sprintf("%sFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) => \n", clientClassname)
+	contents += tab + fmt.Sprintf("%s(provider, middleware);\n\n", clientClassname)
+
+	// Generate client class
 	if service.Extends != "" {
-		contents += fmt.Sprintf("class F%sClient extends %sClient implements F%s {\n",
-			servTitle, g.getServiceExtendsName(service), servTitle)
+		contents += fmt.Sprintf("class %s extends %sClient implements F%s {\n",
+			clientClassname, g.getServiceExtendsName(service), servTitle)
 	} else {
-		contents += fmt.Sprintf("class F%sClient implements F%s {\n",
-			servTitle, servTitle)
+		contents += fmt.Sprintf("class %s implements F%s {\n",
+			clientClassname, servTitle)
 	}
 	contents += fmt.Sprintf(tab+"static final logging.Logger _frugalLog = logging.Logger('%s');\n", servTitle)
 	contents += tab + "Map<String, frugal.FMethod> _methods;\n\n"
 
 	if service.Extends != "" {
-		contents += tab + fmt.Sprintf("F%sClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware])\n", servTitle)
+		contents += tab + fmt.Sprintf("%s(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware])\n", clientClassname)
 		contents += tabtabtab + ": super(provider, middleware) {\n"
 	} else {
-		contents += tab + fmt.Sprintf("F%sClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {\n", servTitle)
+		contents += tab + fmt.Sprintf("%s(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {\n", clientClassname)
 	}
 	contents += tabtab + "_transport = provider.transport;\n"
 	contents += tabtab + "_protocolFactory = provider.protocolFactory;\n"

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1490,15 +1490,15 @@ func (g *Generator) GenerateConstants(file *os.File, name string) error {
 // GeneratePublisher generates the publisher for the given scope.
 func (g *Generator) GeneratePublisher(file *os.File, scope *parser.Scope) error {
 	publishers := ""
-	if scope.Comment != nil {
-		publishers += g.GenerateInlineComment(scope.Comment, "/")
-	}
 	publisherClassname :=  fmt.Sprintf("%sPublisher", strings.Title(scope.Name))
 
 	// Generate publisher factory
-	publishers += fmt.Sprintf("%sFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) => \n", publisherClassname)
-	publishers += tab + fmt.Sprintf("%s(provider, middleware);\n\n", publisherClassname)
+	publishers += fmt.Sprintf("%sFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) =>\n", publisherClassname)
+	publishers += tabtab + fmt.Sprintf("%s(provider, middleware);\n\n", publisherClassname)
 
+	if scope.Comment != nil {
+		publishers += g.GenerateInlineComment(scope.Comment, "/")
+	}
 	// Generate publisher class
 	publishers += fmt.Sprintf("class %s {\n", publisherClassname)
 	publishers += tab + "frugal.FPublisherTransport transport;\n"
@@ -1596,16 +1596,15 @@ func generatePrefixStringTemplate(scope *parser.Scope) string {
 // GenerateSubscriber generates the subscriber for the given scope.
 func (g *Generator) GenerateSubscriber(file *os.File, scope *parser.Scope) error {
 	subscribers := ""
+	subscriberClassname :=  fmt.Sprintf("%sSubscriber", strings.Title(scope.Name))
+
+	// Generate subscriber factory
+	subscribers += fmt.Sprintf("%sFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) =>\n", subscriberClassname)
+	subscribers += tabtab + fmt.Sprintf("%s(provider, middleware);\n\n", subscriberClassname)
 
 	if scope.Comment != nil {
 		subscribers += g.GenerateInlineComment(scope.Comment, "/")
 	}
-	subscriberClassname :=  fmt.Sprintf("%sSubscriber", strings.Title(scope.Name))
-
-	// Generate subscriber factory
-	subscribers += fmt.Sprintf("%sFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) => \n", subscriberClassname)
-	subscribers += tab + fmt.Sprintf("%s(provider, middleware);\n\n", subscriberClassname)
-
 	// Generate subscriber class
 	subscribers += fmt.Sprintf("class %s {\n", subscriberClassname)
 	subscribers += tab + "final frugal.FScopeProvider provider;\n"
@@ -1742,12 +1741,14 @@ func (g *Generator) generateClient(service *parser.Service) string {
 	servTitle := strings.Title(service.Name)
 	clientClassname := fmt.Sprintf("F%sClient", servTitle)
 	contents := ""
+
+	// Generate client factory
+	contents += fmt.Sprintf("%sFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) =>\n", clientClassname)
+	contents += tabtab + fmt.Sprintf("%s(provider, middleware);\n\n", clientClassname)
+
 	if service.Comment != nil {
 		contents += g.GenerateInlineComment(service.Comment, "/")
 	}
-	// Generate client factory
-	contents += fmt.Sprintf("%sFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) => \n", clientClassname)
-	contents += tab + fmt.Sprintf("%s(provider, middleware);\n\n", clientClassname)
 
 	// Generate client class
 	if service.Extends != "" {

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1493,7 +1493,7 @@ func (g *Generator) GeneratePublisher(file *os.File, scope *parser.Scope) error 
 	publisherClassname :=  fmt.Sprintf("%sPublisher", strings.Title(scope.Name))
 
 	// Generate publisher factory
-	publishers += fmt.Sprintf("%sFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) =>\n", publisherClassname)
+	publishers += fmt.Sprintf("%sFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>\n", publisherClassname)
 	publishers += tabtab + fmt.Sprintf("%s(provider, middleware);\n\n", publisherClassname)
 
 	if scope.Comment != nil {
@@ -1599,7 +1599,7 @@ func (g *Generator) GenerateSubscriber(file *os.File, scope *parser.Scope) error
 	subscriberClassname :=  fmt.Sprintf("%sSubscriber", strings.Title(scope.Name))
 
 	// Generate subscriber factory
-	subscribers += fmt.Sprintf("%sFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) =>\n", subscriberClassname)
+	subscribers += fmt.Sprintf("%sFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>\n", subscriberClassname)
 	subscribers += tabtab + fmt.Sprintf("%s(provider, middleware);\n\n", subscriberClassname)
 
 	if scope.Comment != nil {
@@ -1743,7 +1743,7 @@ func (g *Generator) generateClient(service *parser.Service) string {
 	contents := ""
 
 	// Generate client factory
-	contents += fmt.Sprintf("%sFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) =>\n", clientClassname)
+	contents += fmt.Sprintf("%sFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>\n", clientClassname)
 	contents += tabtab + fmt.Sprintf("%s(provider, middleware);\n\n", clientClassname)
 
 	if service.Comment != nil {

--- a/examples/dart/gen-dart/v1_music/lib/src/f_album_winners_scope.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_album_winners_scope.dart
@@ -16,7 +16,7 @@ import 'package:v1_music/v1_music.dart' as t_v1_music;
 
 const String delimiter = '.';
 
-AlbumWinnersPublisherFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) => 
+AlbumWinnersPublisherFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
   AlbumWinnersPublisher(provider, middleware);
 
 /// Scopes are a Frugal extension to the IDL for declaring PubSub
@@ -113,7 +113,7 @@ class AlbumWinnersPublisher {
 }
 
 
-AlbumWinnersSubscriberFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) => 
+AlbumWinnersSubscriberFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
   AlbumWinnersSubscriber(provider, middleware);
 
 /// Scopes are a Frugal extension to the IDL for declaring PubSub

--- a/examples/dart/gen-dart/v1_music/lib/src/f_album_winners_scope.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_album_winners_scope.dart
@@ -19,6 +19,9 @@ const String delimiter = '.';
 /// Scopes are a Frugal extension to the IDL for declaring PubSub
 /// semantics. Subscribers to this scope will be notified if they win a contest.
 /// Scopes must have a prefix.
+AlbumWinnersPublisherFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) => 
+  AlbumWinnersPublisher(provider, middleware);
+
 class AlbumWinnersPublisher {
   frugal.FPublisherTransport transport;
   frugal.FProtocolFactory protocolFactory;
@@ -113,6 +116,9 @@ class AlbumWinnersPublisher {
 /// Scopes are a Frugal extension to the IDL for declaring PubSub
 /// semantics. Subscribers to this scope will be notified if they win a contest.
 /// Scopes must have a prefix.
+AlbumWinnersSubscriberFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) => 
+  AlbumWinnersSubscriber(provider, middleware);
+
 class AlbumWinnersSubscriber {
   final frugal.FScopeProvider provider;
   final List<frugal.Middleware> _middleware;

--- a/examples/dart/gen-dart/v1_music/lib/src/f_album_winners_scope.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_album_winners_scope.dart
@@ -16,12 +16,12 @@ import 'package:v1_music/v1_music.dart' as t_v1_music;
 
 const String delimiter = '.';
 
-/// Scopes are a Frugal extension to the IDL for declaring PubSub
-/// semantics. Subscribers to this scope will be notified if they win a contest.
-/// Scopes must have a prefix.
 AlbumWinnersPublisherFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) => 
   AlbumWinnersPublisher(provider, middleware);
 
+/// Scopes are a Frugal extension to the IDL for declaring PubSub
+/// semantics. Subscribers to this scope will be notified if they win a contest.
+/// Scopes must have a prefix.
 class AlbumWinnersPublisher {
   frugal.FPublisherTransport transport;
   frugal.FProtocolFactory protocolFactory;
@@ -113,12 +113,12 @@ class AlbumWinnersPublisher {
 }
 
 
-/// Scopes are a Frugal extension to the IDL for declaring PubSub
-/// semantics. Subscribers to this scope will be notified if they win a contest.
-/// Scopes must have a prefix.
 AlbumWinnersSubscriberFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) => 
   AlbumWinnersSubscriber(provider, middleware);
 
+/// Scopes are a Frugal extension to the IDL for declaring PubSub
+/// semantics. Subscribers to this scope will be notified if they win a contest.
+/// Scopes must have a prefix.
 class AlbumWinnersSubscriber {
   final frugal.FScopeProvider provider;
   final List<frugal.Middleware> _middleware;

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -26,11 +26,11 @@ abstract class FStore {
   Future<bool> enterAlbumGiveaway(frugal.FContext ctx, String email, String name);
 }
 
-/// Services are the API for client and server interaction.
-/// Users can buy an album or enter a giveaway for a free album.
 FStoreClientFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) => 
   FStoreClient(provider, middleware);
 
+/// Services are the API for client and server interaction.
+/// Users can buy an album or enter a giveaway for a free album.
 class FStoreClient implements FStore {
   static final logging.Logger _frugalLog = logging.Logger('Store');
   Map<String, frugal.FMethod> _methods;

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -26,7 +26,7 @@ abstract class FStore {
   Future<bool> enterAlbumGiveaway(frugal.FContext ctx, String email, String name);
 }
 
-FStoreClientFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) => 
+FStoreClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
   FStoreClient(provider, middleware);
 
 /// Services are the API for client and server interaction.

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -28,6 +28,9 @@ abstract class FStore {
 
 /// Services are the API for client and server interaction.
 /// Users can buy an album or enter a giveaway for a free album.
+FStoreClientFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) => 
+  FStoreClient(provider, middleware);
+
 class FStoreClient implements FStore {
   static final logging.Logger _frugalLog = logging.Logger('Store');
   Map<String, frugal.FMethod> _methods;

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -20,6 +20,9 @@ abstract class FBaseFoo {
   Future basePing(frugal.FContext ctx);
 }
 
+FBaseFooClientFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) =>
+    FBaseFooClient(provider, middleware);
+
 class FBaseFooClient implements FBaseFoo {
   static final logging.Logger _frugalLog = logging.Logger('BaseFoo');
   Map<String, frugal.FMethod> _methods;

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -20,7 +20,7 @@ abstract class FBaseFoo {
   Future basePing(frugal.FContext ctx);
 }
 
-FBaseFooClientFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) =>
+FBaseFooClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
     FBaseFooClient(provider, middleware);
 
 class FBaseFooClient implements FBaseFoo {

--- a/test/expected/dart/include_vendor/f_my_scope_scope.dart
+++ b/test/expected/dart/include_vendor/f_my_scope_scope.dart
@@ -17,7 +17,7 @@ import 'package:include_vendor/include_vendor.dart' as t_include_vendor;
 
 const String delimiter = '.';
 
-MyScopePublisherFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) =>
+MyScopePublisherFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
     MyScopePublisher(provider, middleware);
 
 class MyScopePublisher {
@@ -63,7 +63,7 @@ class MyScopePublisher {
 }
 
 
-MyScopeSubscriberFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) =>
+MyScopeSubscriberFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
     MyScopeSubscriber(provider, middleware);
 
 class MyScopeSubscriber {

--- a/test/expected/dart/include_vendor/f_my_scope_scope.dart
+++ b/test/expected/dart/include_vendor/f_my_scope_scope.dart
@@ -17,6 +17,9 @@ import 'package:include_vendor/include_vendor.dart' as t_include_vendor;
 
 const String delimiter = '.';
 
+MyScopePublisherFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) =>
+    MyScopePublisher(provider, middleware);
+
 class MyScopePublisher {
   frugal.FPublisherTransport transport;
   frugal.FProtocolFactory protocolFactory;
@@ -59,6 +62,9 @@ class MyScopePublisher {
   }
 }
 
+
+MyScopeSubscriberFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) =>
+    MyScopeSubscriber(provider, middleware);
 
 class MyScopeSubscriber {
   final frugal.FScopeProvider provider;

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -22,7 +22,7 @@ abstract class FMyService extends t_vendor_namespace.FVendoredBase {
   Future<t_vendor_namespace.Item> getItem(frugal.FContext ctx);
 }
 
-FMyServiceClientFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) =>
+FMyServiceClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
     FMyServiceClient(provider, middleware);
 
 class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient implements FMyService {

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -22,6 +22,9 @@ abstract class FMyService extends t_vendor_namespace.FVendoredBase {
   Future<t_vendor_namespace.Item> getItem(frugal.FContext ctx);
 }
 
+FMyServiceClientFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) =>
+    FMyServiceClient(provider, middleware);
+
 class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient implements FMyService {
   static final logging.Logger _frugalLog = logging.Logger('MyService');
   Map<String, frugal.FMethod> _methods;

--- a/test/expected/dart/variety/f_events_scope.dart
+++ b/test/expected/dart/variety/f_events_scope.dart
@@ -16,6 +16,9 @@ import 'package:variety/variety.dart' as t_variety;
 
 const String delimiter = '.';
 
+EventsPublisherFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) =>
+    EventsPublisher(provider, middleware);
+
 /// This docstring gets added to the generated code because it has
 /// the @ sign. Prefix specifies topic prefix tokens, which can be static or
 /// variable.
@@ -141,6 +144,9 @@ class EventsPublisher {
   }
 }
 
+
+EventsSubscriberFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) =>
+    EventsSubscriber(provider, middleware);
 
 /// This docstring gets added to the generated code because it has
 /// the @ sign. Prefix specifies topic prefix tokens, which can be static or

--- a/test/expected/dart/variety/f_events_scope.dart
+++ b/test/expected/dart/variety/f_events_scope.dart
@@ -16,7 +16,7 @@ import 'package:variety/variety.dart' as t_variety;
 
 const String delimiter = '.';
 
-EventsPublisherFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) =>
+EventsPublisherFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
     EventsPublisher(provider, middleware);
 
 /// This docstring gets added to the generated code because it has
@@ -145,7 +145,7 @@ class EventsPublisher {
 }
 
 
-EventsSubscriberFactory(frugal.FScopeProvider provider, [List<frugal.Middleware> middleware]) =>
+EventsSubscriberFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
     EventsSubscriber(provider, middleware);
 
 /// This docstring gets added to the generated code because it has

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -53,6 +53,9 @@ abstract class FFoo extends t_actual_base_dart.FBaseFoo {
   Future<String> sayAgain(frugal.FContext ctx, String messageResult);
 }
 
+FFooClientFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) =>
+    FFooClient(provider, middleware);
+
 /// This is a thrift service. Frugal will generate bindings that include
 /// a frugal Context for each service call.
 class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -53,7 +53,7 @@ abstract class FFoo extends t_actual_base_dart.FBaseFoo {
   Future<String> sayAgain(frugal.FContext ctx, String messageResult);
 }
 
-FFooClientFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) =>
+FFooClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
     FFooClient(provider, middleware);
 
 /// This is a thrift service. Frugal will generate bindings that include

--- a/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
+++ b/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
@@ -18,7 +18,7 @@ import 'package:vendor_namespace/vendor_namespace.dart' as t_vendor_namespace;
 
 abstract class FVendoredBase {}
 
-FVendoredBaseClientFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) =>
+FVendoredBaseClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
     FVendoredBaseClient(provider, middleware);
 
 class FVendoredBaseClient implements FVendoredBase {

--- a/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
+++ b/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
@@ -18,6 +18,9 @@ import 'package:vendor_namespace/vendor_namespace.dart' as t_vendor_namespace;
 
 abstract class FVendoredBase {}
 
+FVendoredBaseClientFactory(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) =>
+    FVendoredBaseClient(provider, middleware);
+
 class FVendoredBaseClient implements FVendoredBase {
   static final logging.Logger _frugalLog = logging.Logger('VendoredBase');
   Map<String, frugal.FMethod> _methods;


### PR DESCRIPTION
### Story:
As part of a new client side messaging api proposed in [RFD 274](https://sandbox.wdesk.com/a/QWNjb3VudB82NzE5NTMwMjcyOTQ4MjI0/doc/4a01314bdff4427ebe7d639867a12b8c/r/-1/v/1/sec/4a01314bdff4427ebe7d639867a12b8c_28), consumers supply a factory to the client creation methods to allow the messaging-sdk to construct an instance of their frugal class, obviating the need for some extra boilerplate. 

This PR adds this factory to the dart frugal generation, so consumers get the factory boilerplate for free.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
TODO

### My Test Results:
TODO

#### Reviewers:
@Workiva/product2