### PR TITLE
CPLAT-10346: Add types to frugal factories

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -2175,5 +2175,8 @@ func ignoreDeprecationWarningIfNeeded(tabs string, a parser.Annotations) string 
 }
 
 func lowercaseFirstCharacter(s string) string {
-	return string(unicode.ToLower(rune(s[0]))) + s[1:]
+	if len(s) > 0 {
+		return string(unicode.ToLower(rune(s[0]))) + s[1:]
+	}
+	return ""
 }

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1493,7 +1493,8 @@ func (g *Generator) GeneratePublisher(file *os.File, scope *parser.Scope) error 
 	publisherClassname :=  fmt.Sprintf("%sPublisher", strings.Title(scope.Name))
 
 	// Generate publisher factory
-	publishers += fmt.Sprintf("%sFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>\n", publisherClassname)
+	publishers += fmt.Sprintf("%s %sFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>\n",
+		publisherClassname, lowercaseFirstCharacter(publisherClassname))
 	publishers += tabtab + fmt.Sprintf("%s(provider, middleware);\n\n", publisherClassname)
 
 	if scope.Comment != nil {
@@ -1599,7 +1600,8 @@ func (g *Generator) GenerateSubscriber(file *os.File, scope *parser.Scope) error
 	subscriberClassname :=  fmt.Sprintf("%sSubscriber", strings.Title(scope.Name))
 
 	// Generate subscriber factory
-	subscribers += fmt.Sprintf("%sFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>\n", subscriberClassname)
+	subscribers += fmt.Sprintf("%s %sFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>\n",
+		subscriberClassname, lowercaseFirstCharacter(subscriberClassname))
 	subscribers += tabtab + fmt.Sprintf("%s(provider, middleware);\n\n", subscriberClassname)
 
 	if scope.Comment != nil {
@@ -1743,7 +1745,8 @@ func (g *Generator) generateClient(service *parser.Service) string {
 	contents := ""
 
 	// Generate client factory
-	contents += fmt.Sprintf("%sFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>\n", clientClassname)
+	contents += fmt.Sprintf("%s %sFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>\n",
+		clientClassname, lowercaseFirstCharacter(clientClassname))
 	contents += tabtab + fmt.Sprintf("%s(provider, middleware);\n\n", clientClassname)
 
 	if service.Comment != nil {
@@ -2169,4 +2172,8 @@ func ignoreDeprecationWarningIfNeeded(tabs string, a parser.Annotations) string 
 		return tabs + "// ignore: deprecated_member_use\n"
 	}
 	return ""
+}
+
+func lowercaseFirstCharacter(s string) string {
+	return string(unicode.ToLower(rune(s[0]))) + s[1:]
 }

--- a/examples/dart/gen-dart/v1_music/lib/src/f_album_winners_scope.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_album_winners_scope.dart
@@ -16,8 +16,8 @@ import 'package:v1_music/v1_music.dart' as t_v1_music;
 
 const String delimiter = '.';
 
-AlbumWinnersPublisherFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
-  AlbumWinnersPublisher(provider, middleware);
+AlbumWinnersPublisher albumWinnersPublisherFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
+    AlbumWinnersPublisher(provider, middleware);
 
 /// Scopes are a Frugal extension to the IDL for declaring PubSub
 /// semantics. Subscribers to this scope will be notified if they win a contest.
@@ -113,8 +113,8 @@ class AlbumWinnersPublisher {
 }
 
 
-AlbumWinnersSubscriberFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
-  AlbumWinnersSubscriber(provider, middleware);
+AlbumWinnersSubscriber albumWinnersSubscriberFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
+    AlbumWinnersSubscriber(provider, middleware);
 
 /// Scopes are a Frugal extension to the IDL for declaring PubSub
 /// semantics. Subscribers to this scope will be notified if they win a contest.

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -26,8 +26,8 @@ abstract class FStore {
   Future<bool> enterAlbumGiveaway(frugal.FContext ctx, String email, String name);
 }
 
-FStoreClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
-  FStoreClient(provider, middleware);
+FStoreClient fStoreClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
+    FStoreClient(provider, middleware);
 
 /// Services are the API for client and server interaction.
 /// Users can buy an album or enter a giveaway for a free album.

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -20,7 +20,7 @@ abstract class FBaseFoo {
   Future basePing(frugal.FContext ctx);
 }
 
-FBaseFooClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
+FBaseFooClient fBaseFooClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
     FBaseFooClient(provider, middleware);
 
 class FBaseFooClient implements FBaseFoo {

--- a/test/expected/dart/include_vendor/f_my_scope_scope.dart
+++ b/test/expected/dart/include_vendor/f_my_scope_scope.dart
@@ -17,7 +17,7 @@ import 'package:include_vendor/include_vendor.dart' as t_include_vendor;
 
 const String delimiter = '.';
 
-MyScopePublisherFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
+MyScopePublisher myScopePublisherFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
     MyScopePublisher(provider, middleware);
 
 class MyScopePublisher {
@@ -63,7 +63,7 @@ class MyScopePublisher {
 }
 
 
-MyScopeSubscriberFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
+MyScopeSubscriber myScopeSubscriberFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
     MyScopeSubscriber(provider, middleware);
 
 class MyScopeSubscriber {

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -22,7 +22,7 @@ abstract class FMyService extends t_vendor_namespace.FVendoredBase {
   Future<t_vendor_namespace.Item> getItem(frugal.FContext ctx);
 }
 
-FMyServiceClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
+FMyServiceClient fMyServiceClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
     FMyServiceClient(provider, middleware);
 
 class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient implements FMyService {

--- a/test/expected/dart/variety/f_events_scope.dart
+++ b/test/expected/dart/variety/f_events_scope.dart
@@ -16,7 +16,7 @@ import 'package:variety/variety.dart' as t_variety;
 
 const String delimiter = '.';
 
-EventsPublisherFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
+EventsPublisher eventsPublisherFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
     EventsPublisher(provider, middleware);
 
 /// This docstring gets added to the generated code because it has
@@ -145,7 +145,7 @@ class EventsPublisher {
 }
 
 
-EventsSubscriberFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
+EventsSubscriber eventsSubscriberFactory(frugal.FScopeProvider provider, {List<frugal.Middleware> middleware}) =>
     EventsSubscriber(provider, middleware);
 
 /// This docstring gets added to the generated code because it has

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -53,7 +53,7 @@ abstract class FFoo extends t_actual_base_dart.FBaseFoo {
   Future<String> sayAgain(frugal.FContext ctx, String messageResult);
 }
 
-FFooClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
+FFooClient fFooClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
     FFooClient(provider, middleware);
 
 /// This is a thrift service. Frugal will generate bindings that include

--- a/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
+++ b/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
@@ -18,7 +18,7 @@ import 'package:vendor_namespace/vendor_namespace.dart' as t_vendor_namespace;
 
 abstract class FVendoredBase {}
 
-FVendoredBaseClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
+FVendoredBaseClient fVendoredBaseClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
     FVendoredBaseClient(provider, middleware);
 
 class FVendoredBaseClient implements FVendoredBase {


### PR DESCRIPTION
### Story:
#1228 added factories for dart objects, but these factories didn't specify a return type. To be explicit and safe, we should specify a return type. 

Also, since the factories are methods, they should start with a lower case.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
TODO

### My Test Results:
TODO

#### Reviewers:
@Workiva/product2