### PR TITLE
CPLAT-10353: Manage frugal service objects

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -42,7 +42,6 @@ const (
 	tabtabtabtab          = tab + tab + tab + tab
 	tabtabtabtabtab       = tab + tab + tab + tab + tab
 	tabtabtabtabtabtab    = tab + tab + tab + tab + tab + tab
-	tabtabtabtabtabtabtab = tab + tab + tab + tab + tab + tab + tab
 	libraryPrefixOption   = "library_prefix"
 	useVendorOption       = "use_vendor"
 )
@@ -199,6 +198,7 @@ func (g *Generator) addToPubspec(dir string) error {
 			Hosted:  hostedDep{Name: "thrift", URL: "https://pub.workiva.org"},
 			Version: "^0.0.9",
 		},
+		"w_common":   "1.20.2",
 	}
 
 	if g.Frugal.ContainsFrugalDefinitions() {
@@ -1429,7 +1429,8 @@ func (g *Generator) GenerateServiceImports(file *os.File, s *parser.Service) err
 	imports += "import 'package:collection/collection.dart';\n"
 	imports += "import 'package:logging/logging.dart' as logging;\n"
 	imports += "import 'package:thrift/thrift.dart' as thrift;\n"
-	imports += "import 'package:frugal/frugal.dart' as frugal;\n\n"
+	imports += "import 'package:frugal/frugal.dart' as frugal;\n"
+	imports += "import 'package:w_common/disposable.dart';\n\n"
 	// import included packages
 	includes, err := s.ReferencedIncludes()
 	if err != nil {
@@ -1731,10 +1732,10 @@ func (g *Generator) generateClient(service *parser.Service) string {
 		contents += g.GenerateInlineComment(service.Comment, "/")
 	}
 	if service.Extends != "" {
-		contents += fmt.Sprintf("class F%sClient extends %sClient implements F%s {\n",
+		contents += fmt.Sprintf("class F%sClient extends %sClient with Disposable implements F%s {\n",
 			servTitle, g.getServiceExtendsName(service), servTitle)
 	} else {
-		contents += fmt.Sprintf("class F%sClient implements F%s {\n",
+		contents += fmt.Sprintf("class F%sClient extends Disposable implements F%s {\n",
 			servTitle, servTitle)
 	}
 	contents += fmt.Sprintf(tab+"static final logging.Logger _frugalLog = logging.Logger('%s');\n", servTitle)
@@ -1746,6 +1747,7 @@ func (g *Generator) generateClient(service *parser.Service) string {
 	} else {
 		contents += tab + fmt.Sprintf("F%sClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {\n", servTitle)
 	}
+	contents += tabtab + "manageDisposable(provider);\n"
 	contents += tabtab + "_transport = provider.transport;\n"
 	contents += tabtab + "_protocolFactory = provider.protocolFactory;\n"
 	contents += tabtab + "var combined = middleware ?? [];\n"

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -198,7 +198,7 @@ func (g *Generator) addToPubspec(dir string) error {
 			Hosted:  hostedDep{Name: "thrift", URL: "https://pub.workiva.org"},
 			Version: "^0.0.9",
 		},
-		"w_common":   "1.20.2",
+		"w_common":   "^1.20.2",
 	}
 
 	if g.Frugal.ContainsFrugalDefinitions() {

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1753,7 +1753,6 @@ func (g *Generator) generateClient(service *parser.Service) string {
 
 	// Generate client class
 	if service.Extends != "" {
-
 		contents += fmt.Sprintf("class %s extends %sClient with disposable.Disposable implements F%s {\n",
 			clientClassname, g.getServiceExtendsName(service), servTitle)
 	} else {

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1430,7 +1430,7 @@ func (g *Generator) GenerateServiceImports(file *os.File, s *parser.Service) err
 	imports += "import 'package:logging/logging.dart' as logging;\n"
 	imports += "import 'package:thrift/thrift.dart' as thrift;\n"
 	imports += "import 'package:frugal/frugal.dart' as frugal;\n"
-	imports += "import 'package:w_common/disposable.dart';\n\n"
+	imports += "import 'package:w_common/disposable.dart' as disposable;\n\n"
 	// import included packages
 	includes, err := s.ReferencedIncludes()
 	if err != nil {
@@ -1732,10 +1732,10 @@ func (g *Generator) generateClient(service *parser.Service) string {
 		contents += g.GenerateInlineComment(service.Comment, "/")
 	}
 	if service.Extends != "" {
-		contents += fmt.Sprintf("class F%sClient extends %sClient with Disposable implements F%s {\n",
+		contents += fmt.Sprintf("class F%sClient extends %sClient with disposable.Disposable implements F%s {\n",
 			servTitle, g.getServiceExtendsName(service), servTitle)
 	} else {
-		contents += fmt.Sprintf("class F%sClient extends Disposable implements F%s {\n",
+		contents += fmt.Sprintf("class F%sClient extends disposable.Disposable implements F%s {\n",
 			servTitle, servTitle)
 	}
 	contents += fmt.Sprintf(tab+"static final logging.Logger _frugalLog = logging.Logger('%s');\n", servTitle)

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -12,7 +12,7 @@ import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
-import 'package:w_common/disposable.dart';
+import 'package:w_common/disposable.dart' as disposable;
 
 import 'package:v1_music/v1_music.dart' as t_v1_music;
 
@@ -29,7 +29,7 @@ abstract class FStore {
 
 /// Services are the API for client and server interaction.
 /// Users can buy an album or enter a giveaway for a free album.
-class FStoreClient extends Disposable implements FStore {
+class FStoreClient extends disposable.Disposable implements FStore {
   static final logging.Logger _frugalLog = logging.Logger('Store');
   Map<String, frugal.FMethod> _methods;
 

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -12,6 +12,7 @@ import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
+import 'package:w_common/disposable.dart';
 
 import 'package:v1_music/v1_music.dart' as t_v1_music;
 
@@ -28,11 +29,12 @@ abstract class FStore {
 
 /// Services are the API for client and server interaction.
 /// Users can buy an album or enter a giveaway for a free album.
-class FStoreClient implements FStore {
+class FStoreClient extends Disposable implements FStore {
   static final logging.Logger _frugalLog = logging.Logger('Store');
   Map<String, frugal.FMethod> _methods;
 
   FStoreClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {
+    manageDisposable(provider);
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];

--- a/examples/dart/gen-dart/v1_music/pubspec.yaml
+++ b/examples/dart/gen-dart/v1_music/pubspec.yaml
@@ -16,3 +16,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.9
+  w_common: 1.20.2

--- a/lib/dart/lib/src/frugal/f_provider.dart
+++ b/lib/dart/lib/src/frugal/f_provider.dart
@@ -19,6 +19,12 @@ part of frugal.src.frugal;
 /// [FProtocolFactory]. This also provides a shim for adding middleware to a
 /// publisher or subscriber.
 class FScopeProvider {
+  /// Creates a new [FScopeProvider].
+  FScopeProvider(this.publisherTransportFactory,
+      this.subscriberTransportFactory, this.protocolFactory,
+      {List<Middleware> middleware})
+      : _middleware = middleware ?? [];
+
   /// [FPublisherTransportFactory] used by the scope.
   final FPublisherTransportFactory publisherTransportFactory;
 
@@ -31,12 +37,6 @@ class FScopeProvider {
   /// Middleware applied to publishers and subscribers.
   final List<Middleware> _middleware;
 
-  /// Creates a new [FScopeProvider].
-  FScopeProvider(this.publisherTransportFactory,
-      this.subscriberTransportFactory, this.protocolFactory,
-      {List<Middleware> middleware: null})
-      : _middleware = middleware ?? [];
-
   /// The middleware stored on this FScopeProvider.
   List<Middleware> get middleware => new List.from(this._middleware);
 }
@@ -44,7 +44,16 @@ class FScopeProvider {
 /// The service equivalent of [FScopeProvider]. It produces [FTransport] and
 /// [FProtocol] instances for use by RPC service clients. The main purpose of
 /// this is to provide a shim for adding middleware to a client.
-class FServiceProvider {
+class FServiceProvider extends Disposable {
+  /// Creates a new [FServiceProvider].
+  FServiceProvider(this.transport, this.protocolFactory,
+      {List<Middleware> middleware})
+      : _middleware = middleware ?? [] {
+    // The transport is created by the messaging-sdk, and goes out of scope
+    // besides this reference, so it is safe to manage here.
+    manageDisposable(this.transport);
+  }
+
   /// [FTransport] used by the service.
   final FTransport transport;
 
@@ -53,11 +62,6 @@ class FServiceProvider {
 
   /// Middleware applied to clients.
   final List<Middleware> _middleware;
-
-  /// Creates a new [FServiceProvider].
-  FServiceProvider(this.transport, this.protocolFactory,
-      {List<Middleware> middleware: null})
-      : _middleware = middleware ?? [];
 
   /// The middleware stored on this FServiceProvider.
   List<Middleware> get middleware => new List.from(this._middleware);

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -12,6 +12,7 @@ import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
+import 'package:w_common/disposable.dart' as disposable;
 
 import 'package:actual_base_dart/actual_base_dart.dart' as t_actual_base_dart;
 
@@ -20,11 +21,12 @@ abstract class FBaseFoo {
   Future basePing(frugal.FContext ctx);
 }
 
-class FBaseFooClient implements FBaseFoo {
+class FBaseFooClient extends disposable.Disposable implements FBaseFoo {
   static final logging.Logger _frugalLog = logging.Logger('BaseFoo');
   Map<String, frugal.FMethod> _methods;
 
   FBaseFooClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {
+    manageDisposable(provider);
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -12,6 +12,7 @@ import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
+import 'package:w_common/disposable.dart' as disposable;
 
 import 'package:some_vendored_place/vendor_namespace.dart' as t_vendor_namespace;
 import 'package:excepts/excepts.dart' as t_excepts;
@@ -22,12 +23,13 @@ abstract class FMyService extends t_vendor_namespace.FVendoredBase {
   Future<t_vendor_namespace.Item> getItem(frugal.FContext ctx);
 }
 
-class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient implements FMyService {
+class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient with disposable.Disposable implements FMyService {
   static final logging.Logger _frugalLog = logging.Logger('MyService');
   Map<String, frugal.FMethod> _methods;
 
   FMyServiceClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware])
       : super(provider, middleware) {
+    manageDisposable(provider);
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];

--- a/test/expected/dart/include_vendor/pubspec.yaml
+++ b/test/expected/dart/include_vendor/pubspec.yaml
@@ -23,3 +23,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.9
+  w_common: ^1.20.2

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -12,6 +12,7 @@ import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
+import 'package:w_common/disposable.dart' as disposable;
 
 import 'package:actual_base_dart/actual_base_dart.dart' as t_actual_base_dart;
 import 'package:validStructs/validStructs.dart' as t_validStructs;
@@ -55,12 +56,13 @@ abstract class FFoo extends t_actual_base_dart.FBaseFoo {
 
 /// This is a thrift service. Frugal will generate bindings that include
 /// a frugal Context for each service call.
-class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
+class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Disposable implements FFoo {
   static final logging.Logger _frugalLog = logging.Logger('Foo');
   Map<String, frugal.FMethod> _methods;
 
   FFooClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware])
       : super(provider, middleware) {
+    manageDisposable(provider);
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];

--- a/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
+++ b/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
@@ -12,17 +12,19 @@ import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
+import 'package:w_common/disposable.dart' as disposable;
 
 import 'package:vendor_namespace/vendor_namespace.dart' as t_vendor_namespace;
 
 
 abstract class FVendoredBase {}
 
-class FVendoredBaseClient implements FVendoredBase {
+class FVendoredBaseClient extends disposable.Disposable implements FVendoredBase {
   static final logging.Logger _frugalLog = logging.Logger('VendoredBase');
   Map<String, frugal.FMethod> _methods;
 
   FVendoredBaseClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {
+    manageDisposable(provider);
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];


### PR DESCRIPTION
### Story:
When using a frugal object to RPCs, the consumer must open and close an `FAsyncTransport` object manually. That object is actually disposable, so we can update the `dispose` method on it to close the transport, which will be done for Workiva private code as part of [CPLAT-9647](https://jira.atl.workiva.net/browse/CPLAT-9647). That work need not be completed before this merges, however, as `FNatsTransport` is already disposable so managing it here will have no harm.

After creation, the only reference to this transport persists in the `FServiceProvider` instance, which is then passed to the frugal client. This PR changes this so we manage the disposal of `FNatsTransport` in the `FServiceProvider` class and manage the disposable of `FServiceProvider` in the frugal generated client code. Then, consumers can simply manage their frugal objects, and once their client code disposes, they'll automatically close the transport when their code disposes.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
TODO

### My Test Results:
TODO

#### Reviewers:
@Workiva/product2 @evanweible-wf @maxwellpeterson-wf 