### PR TITLE
Updates for w_transport v4 compatibility

### DIFF
--- a/examples/dart/web/client.dart
+++ b/examples/dart/web/client.dart
@@ -6,7 +6,7 @@ import 'package:v1_music/v1_music.dart' as music;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
 import 'package:w_transport/w_transport.dart' as wt;
-import 'package:w_transport/w_transport_browser.dart'
+import 'package:w_transport/browser.dart'
     show configureWTransportForBrowser;
 
 frugal.FSubscription sub;

--- a/lib/dart/lib/src/frugal/transport/f_http_transport.dart
+++ b/lib/dart/lib/src/frugal/transport/f_http_transport.dart
@@ -27,7 +27,7 @@ class FHttpTransport extends FTransport {
   final Logger _log = new Logger('FHttpTransport');
 
   /// Client used by the transport to make HTTP requests.
-  final wt.Client client;
+  final wt.HttpClient client;
 
   /// URI of the frugal HTTP server.
   final Uri uri;

--- a/lib/dart/test/transport/f_http_transport_test.dart
+++ b/lib/dart/test/transport/f_http_transport_test.dart
@@ -13,7 +13,7 @@ void main() {
   const utf8Codec = const Utf8Codec();
 
   group('FHttpTransport', () {
-    Client client;
+    HttpClient client;
     FHttpTransport transport;
     FHttpTransport transportWithContext;
 
@@ -38,7 +38,7 @@ void main() {
     String transportResponseB64 = base64.encode(transportResponseFramed);
 
     setUp(() {
-      client = new Client();
+      client = new HttpClient();
       transport = new FHttpTransport(client, Uri.parse('http://localhost'),
           responseSizeLimit: 10, additionalHeaders: {'foo': 'bar'});
       transportWithContext = new FHttpTransport(
@@ -182,11 +182,11 @@ void main() {
   });
 
   group('FHttpTransport request size too large', () {
-    Client client;
+    HttpClient client;
     FHttpTransport transport;
 
     setUp(() {
-      client = new Client();
+      client = new HttpClient();
       transport = new FHttpTransport(client, Uri.parse('http://localhost'),
           requestSizeLimit: 10);
     });
@@ -204,7 +204,7 @@ void main() {
 
     setUp(() {
       transport =
-          new FHttpTransport(new Client(), Uri.parse('http://localhost'));
+          new FHttpTransport(new HttpClient(), Uri.parse('http://localhost'));
     });
 
     test('Test transport receives error on 401 response', () async {

--- a/test/integration/dart/test_client/bin/main.dart
+++ b/test/integration/dart/test_client/bin/main.dart
@@ -26,7 +26,7 @@ import 'package:frugal_test_client/test_cases.dart';
 import 'package:frugal_test/frugal_test.dart';
 import 'package:w_transport/w_transport.dart' as wt;
 // ignore: deprecated_member_use
-import 'package:w_transport/w_transport_vm.dart' show configureWTransportForVM;
+import 'package:w_transport/vm.dart' show configureWTransportForVM;
 
 List<FTest> _tests;
 FFrugalTestClient client;


### PR DESCRIPTION
## Description

CPLAT is preparing to release v4 of w_transport soon and this repo contains at least one usage of a deprecated API that will be removed in v4.

This PR includes automated changes from a codemod script to address these deprecated API usages.

## Changes

At least one of the following changes have been made:

### Renamed entry points

```diff
- import 'package:w_transport/w_transport_browser.dart';
+ import 'package:w_transport/browser.dart';
```

```diff
- import 'package:w_transport/w_transport_mock.dart';
+ import 'package:w_transport/mock.dart';
```

```diff
- import 'package:w_transport/w_transport_vm.dart';
+ import 'package:w_transport/vm.dart';
```

### Renamed HTTP Client class

```diff
- Client
+ HttpClient
```

## Testing

The changes made by this automated script are all drop-in replacements, meaning they should not require any additional changes to function properly. Passing static analysis and tests should be sufficient.

- [ ] CI passes

---

If you have any questions about these changes, please reach out to @evanweible-wf