### PR TITLE
CPLAT-10449: Add check before calling `manageDisposable`

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -42,7 +42,6 @@ const (
 	tabtabtabtab          = tab + tab + tab + tab
 	tabtabtabtabtab       = tab + tab + tab + tab + tab
 	tabtabtabtabtabtab    = tab + tab + tab + tab + tab + tab
-	tabtabtabtabtabtabtab = tab + tab + tab + tab + tab + tab + tab
 	libraryPrefixOption   = "library_prefix"
 	useVendorOption       = "use_vendor"
 )
@@ -199,6 +198,7 @@ func (g *Generator) addToPubspec(dir string) error {
 			Hosted:  hostedDep{Name: "thrift", URL: "https://pub.workiva.org"},
 			Version: "^0.0.9",
 		},
+		"w_common":   "^1.20.2",
 	}
 
 	if g.Frugal.ContainsFrugalDefinitions() {
@@ -1429,7 +1429,8 @@ func (g *Generator) GenerateServiceImports(file *os.File, s *parser.Service) err
 	imports += "import 'package:collection/collection.dart';\n"
 	imports += "import 'package:logging/logging.dart' as logging;\n"
 	imports += "import 'package:thrift/thrift.dart' as thrift;\n"
-	imports += "import 'package:frugal/frugal.dart' as frugal;\n\n"
+	imports += "import 'package:frugal/frugal.dart' as frugal;\n"
+	imports += "import 'package:w_common/disposable.dart' as disposable;\n\n"
 	// import included packages
 	includes, err := s.ReferencedIncludes()
 	if err != nil {
@@ -1755,10 +1756,10 @@ func (g *Generator) generateClient(service *parser.Service) string {
 
 	// Generate client class
 	if service.Extends != "" {
-		contents += fmt.Sprintf("class %s extends %sClient implements F%s {\n",
+		contents += fmt.Sprintf("class %s extends %sClient with disposable.Disposable implements F%s {\n",
 			clientClassname, g.getServiceExtendsName(service), servTitle)
 	} else {
-		contents += fmt.Sprintf("class %s implements F%s {\n",
+		contents += fmt.Sprintf("class %s extends disposable.Disposable implements F%s {\n",
 			clientClassname, servTitle)
 	}
 	contents += fmt.Sprintf(tab+"static final logging.Logger _frugalLog = logging.Logger('%s');\n", servTitle)
@@ -1770,6 +1771,7 @@ func (g *Generator) generateClient(service *parser.Service) string {
 	} else {
 		contents += tab + fmt.Sprintf("%s(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {\n", clientClassname)
 	}
+	contents += tabtab + "manageDisposable(provider);\n"
 	contents += tabtab + "_transport = provider.transport;\n"
 	contents += tabtab + "_protocolFactory = provider.protocolFactory;\n"
 	contents += tabtab + "var combined = middleware ?? [];\n"

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -194,6 +194,7 @@ func (g *Generator) addToPubspec(dir string) error {
 	deps := map[interface{}]interface{}{
 		"collection": "^1.14.12",
 		"logging":    "^0.11.2",
+		"mockito":    "^4.1.1",
 		"thrift": dep{
 			Hosted:  hostedDep{Name: "thrift", URL: "https://pub.workiva.org"},
 			Version: "^0.0.9",
@@ -1427,6 +1428,7 @@ func (g *Generator) GenerateServiceImports(file *os.File, s *parser.Service) err
 	imports += "import 'dart:typed_data' show Uint8List;\n\n"
 
 	imports += "import 'package:collection/collection.dart';\n"
+	imports += "import 'package:mockito/mockito.dart' show Mock;\n"
 	imports += "import 'package:logging/logging.dart' as logging;\n"
 	imports += "import 'package:thrift/thrift.dart' as thrift;\n"
 	imports += "import 'package:frugal/frugal.dart' as frugal;\n"
@@ -1771,7 +1773,9 @@ func (g *Generator) generateClient(service *parser.Service) string {
 	} else {
 		contents += tab + fmt.Sprintf("%s(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {\n", clientClassname)
 	}
-	contents += tabtab + "manageDisposable(provider);\n"
+	contents += tabtab+ "if (provider != null && provider is disposable.Disposable && provider is! Mock && !provider.isOrWillBeDisposed) {\n"
+	contents += tabtabtab + "manageDisposable(provider);\n"
+	contents += tabtab+ "}\n"
 	contents += tabtab + "_transport = provider.transport;\n"
 	contents += tabtab + "_protocolFactory = provider.protocolFactory;\n"
 	contents += tabtab + "var combined = middleware ?? [];\n"

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -12,6 +12,7 @@ import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
+import 'package:w_common/disposable.dart' as disposable;
 
 import 'package:v1_music/v1_music.dart' as t_v1_music;
 
@@ -31,11 +32,12 @@ FStoreClient fStoreClientFactory(frugal.FServiceProvider provider, {List<frugal.
 
 /// Services are the API for client and server interaction.
 /// Users can buy an album or enter a giveaway for a free album.
-class FStoreClient implements FStore {
+class FStoreClient extends disposable.Disposable implements FStore {
   static final logging.Logger _frugalLog = logging.Logger('Store');
   Map<String, frugal.FMethod> _methods;
 
   FStoreClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {
+    manageDisposable(provider);
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';
+import 'package:mockito/mockito.dart' show Mock;
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
@@ -37,7 +38,9 @@ class FStoreClient extends disposable.Disposable implements FStore {
   Map<String, frugal.FMethod> _methods;
 
   FStoreClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {
-    manageDisposable(provider);
+    if (provider != null && provider is disposable.Disposable && provider is! Mock && !provider.isOrWillBeDisposed) {
+      manageDisposable(provider);
+    }
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];

--- a/examples/dart/gen-dart/v1_music/pubspec.yaml
+++ b/examples/dart/gen-dart/v1_music/pubspec.yaml
@@ -16,3 +16,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.9
+  w_common: 1.20.2

--- a/examples/dart/gen-dart/v1_music/pubspec.yaml
+++ b/examples/dart/gen-dart/v1_music/pubspec.yaml
@@ -11,9 +11,10 @@ dependencies:
       url: https://pub.workiva.org
     version: ^3.9.1
   logging: ^0.11.2
+  mockito: ^4.1.1
   thrift:
     hosted:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.9
-  w_common: 1.20.2
+  w_common: ^1.20.2

--- a/lib/dart/lib/src/frugal.dart
+++ b/lib/dart/lib/src/frugal.dart
@@ -19,7 +19,7 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:mockito/mockito.dart';
+import 'package:mockito/mockito.dart' show Mock;
 import 'package:logging/logging.dart';
 import 'package:thrift/thrift.dart';
 import 'package:uuid/uuid.dart';

--- a/lib/dart/lib/src/frugal.dart
+++ b/lib/dart/lib/src/frugal.dart
@@ -19,6 +19,7 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:mockito/mockito.dart';
 import 'package:logging/logging.dart';
 import 'package:thrift/thrift.dart';
 import 'package:uuid/uuid.dart';

--- a/lib/dart/lib/src/frugal/f_provider.dart
+++ b/lib/dart/lib/src/frugal/f_provider.dart
@@ -51,7 +51,9 @@ class FServiceProvider extends Disposable {
       : _middleware = middleware ?? [] {
     // The transport is created by the messaging-sdk, and goes out of scope
     // besides this reference, so it is safe to manage here.
-    if (this.transport != null && this.transport is! Mock && !this.transport.isOrWillBeDisposed) {
+    if (this.transport != null &&
+        this.transport is! Mock &&
+        !this.transport.isOrWillBeDisposed) {
       manageDisposable(this.transport);
     }
   }

--- a/lib/dart/lib/src/frugal/f_provider.dart
+++ b/lib/dart/lib/src/frugal/f_provider.dart
@@ -19,6 +19,12 @@ part of frugal.src.frugal;
 /// [FProtocolFactory]. This also provides a shim for adding middleware to a
 /// publisher or subscriber.
 class FScopeProvider {
+  /// Creates a new [FScopeProvider].
+  FScopeProvider(this.publisherTransportFactory,
+      this.subscriberTransportFactory, this.protocolFactory,
+      {List<Middleware> middleware})
+      : _middleware = middleware ?? [];
+
   /// [FPublisherTransportFactory] used by the scope.
   final FPublisherTransportFactory publisherTransportFactory;
 
@@ -31,12 +37,6 @@ class FScopeProvider {
   /// Middleware applied to publishers and subscribers.
   final List<Middleware> _middleware;
 
-  /// Creates a new [FScopeProvider].
-  FScopeProvider(this.publisherTransportFactory,
-      this.subscriberTransportFactory, this.protocolFactory,
-      {List<Middleware> middleware: null})
-      : _middleware = middleware ?? [];
-
   /// The middleware stored on this FScopeProvider.
   List<Middleware> get middleware => new List.from(this._middleware);
 }
@@ -44,7 +44,16 @@ class FScopeProvider {
 /// The service equivalent of [FScopeProvider]. It produces [FTransport] and
 /// [FProtocol] instances for use by RPC service clients. The main purpose of
 /// this is to provide a shim for adding middleware to a client.
-class FServiceProvider {
+class FServiceProvider extends Disposable {
+  /// Creates a new [FServiceProvider].
+  FServiceProvider(this.transport, this.protocolFactory,
+      {List<Middleware> middleware})
+      : _middleware = middleware ?? [] {
+    // The transport is created by the messaging-sdk, and goes out of scope
+    // besides this reference, so it is safe to manage here.
+    manageDisposable(this.transport);
+  }
+
   /// [FTransport] used by the service.
   final FTransport transport;
 
@@ -53,11 +62,6 @@ class FServiceProvider {
 
   /// Middleware applied to clients.
   final List<Middleware> _middleware;
-
-  /// Creates a new [FServiceProvider].
-  FServiceProvider(this.transport, this.protocolFactory,
-      {List<Middleware> middleware: null})
-      : _middleware = middleware ?? [];
 
   /// The middleware stored on this FServiceProvider.
   List<Middleware> get middleware => new List.from(this._middleware);

--- a/lib/dart/lib/src/frugal/f_provider.dart
+++ b/lib/dart/lib/src/frugal/f_provider.dart
@@ -51,7 +51,9 @@ class FServiceProvider extends Disposable {
       : _middleware = middleware ?? [] {
     // The transport is created by the messaging-sdk, and goes out of scope
     // besides this reference, so it is safe to manage here.
-    manageDisposable(this.transport);
+    if (this.transport != null && this.transport is! Mock && !this.transport.isOrWillBeDisposed) {
+      manageDisposable(this.transport);
+    }
   }
 
   /// [FTransport] used by the service.

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -3,6 +3,7 @@ authors:
 - Mark Erickson <mark.erickson@workiva.com>
 - Brian Shannan <brian.shannan@workiva.com>
 dependencies:
+  mockito: ^4.1.1
   logging: ^0.11.2
   thrift:
     hosted:
@@ -16,7 +17,6 @@ description: A frugal client for Dart
 dev_dependencies:
   dart_dev: ^3.0.0
   dart_style: ^1.3.1
-  mockito: ^4.1.1
   test: ^1.9.1
 environment:
   sdk: '>=2.4.1 <3.0.0'

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -12,6 +12,7 @@ import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
+import 'package:w_common/disposable.dart' as disposable;
 
 import 'package:actual_base_dart/actual_base_dart.dart' as t_actual_base_dart;
 
@@ -23,11 +24,12 @@ abstract class FBaseFoo {
 FBaseFooClient fBaseFooClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
     FBaseFooClient(provider, middleware);
 
-class FBaseFooClient implements FBaseFoo {
+class FBaseFooClient extends disposable.Disposable implements FBaseFoo {
   static final logging.Logger _frugalLog = logging.Logger('BaseFoo');
   Map<String, frugal.FMethod> _methods;
 
   FBaseFooClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {
+    manageDisposable(provider);
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';
+import 'package:mockito/mockito.dart' show Mock;
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
@@ -29,7 +30,9 @@ class FBaseFooClient extends disposable.Disposable implements FBaseFoo {
   Map<String, frugal.FMethod> _methods;
 
   FBaseFooClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {
-    manageDisposable(provider);
+    if (provider != null && provider is disposable.Disposable && provider is! Mock && !provider.isOrWillBeDisposed) {
+      manageDisposable(provider);
+    }
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';
+import 'package:mockito/mockito.dart' show Mock;
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
@@ -32,7 +33,9 @@ class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient with dispo
 
   FMyServiceClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware])
       : super(provider, middleware) {
-    manageDisposable(provider);
+    if (provider != null && provider is disposable.Disposable && provider is! Mock && !provider.isOrWillBeDisposed) {
+      manageDisposable(provider);
+    }
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -12,6 +12,7 @@ import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
+import 'package:w_common/disposable.dart' as disposable;
 
 import 'package:some_vendored_place/vendor_namespace.dart' as t_vendor_namespace;
 import 'package:excepts/excepts.dart' as t_excepts;
@@ -25,12 +26,13 @@ abstract class FMyService extends t_vendor_namespace.FVendoredBase {
 FMyServiceClient fMyServiceClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
     FMyServiceClient(provider, middleware);
 
-class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient implements FMyService {
+class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient with disposable.Disposable implements FMyService {
   static final logging.Logger _frugalLog = logging.Logger('MyService');
   Map<String, frugal.FMethod> _methods;
 
   FMyServiceClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware])
       : super(provider, middleware) {
+    manageDisposable(provider);
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];

--- a/test/expected/dart/include_vendor/pubspec.yaml
+++ b/test/expected/dart/include_vendor/pubspec.yaml
@@ -23,3 +23,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.9
+  w_common: ^1.20.2

--- a/test/expected/dart/include_vendor/pubspec.yaml
+++ b/test/expected/dart/include_vendor/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
       url: https://pub.workiva.org
     version: ^3.9.1
   logging: ^0.11.2
+  mockito: ^4.1.1
   some_vendored_place:
     hosted:
       name: some_vendored_place

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';
+import 'package:mockito/mockito.dart' show Mock;
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
@@ -65,7 +66,9 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
 
   FFooClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware])
       : super(provider, middleware) {
-    manageDisposable(provider);
+    if (provider != null && provider is disposable.Disposable && provider is! Mock && !provider.isOrWillBeDisposed) {
+      manageDisposable(provider);
+    }
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -12,6 +12,7 @@ import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
+import 'package:w_common/disposable.dart' as disposable;
 
 import 'package:actual_base_dart/actual_base_dart.dart' as t_actual_base_dart;
 import 'package:validStructs/validStructs.dart' as t_validStructs;
@@ -58,12 +59,13 @@ FFooClient fFooClientFactory(frugal.FServiceProvider provider, {List<frugal.Midd
 
 /// This is a thrift service. Frugal will generate bindings that include
 /// a frugal Context for each service call.
-class FFooClient extends t_actual_base_dart.FBaseFooClient implements FFoo {
+class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Disposable implements FFoo {
   static final logging.Logger _frugalLog = logging.Logger('Foo');
   Map<String, frugal.FMethod> _methods;
 
   FFooClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware])
       : super(provider, middleware) {
+    manageDisposable(provider);
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];

--- a/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
+++ b/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';
+import 'package:mockito/mockito.dart' show Mock;
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
@@ -27,7 +28,9 @@ class FVendoredBaseClient extends disposable.Disposable implements FVendoredBase
   Map<String, frugal.FMethod> _methods;
 
   FVendoredBaseClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {
-    manageDisposable(provider);
+    if (provider != null && provider is disposable.Disposable && provider is! Mock && !provider.isOrWillBeDisposed) {
+      manageDisposable(provider);
+    }
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];

--- a/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
+++ b/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
@@ -12,6 +12,7 @@ import 'package:collection/collection.dart';
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
+import 'package:w_common/disposable.dart' as disposable;
 
 import 'package:vendor_namespace/vendor_namespace.dart' as t_vendor_namespace;
 
@@ -21,11 +22,12 @@ abstract class FVendoredBase {}
 FVendoredBaseClient fVendoredBaseClientFactory(frugal.FServiceProvider provider, {List<frugal.Middleware> middleware}) =>
     FVendoredBaseClient(provider, middleware);
 
-class FVendoredBaseClient implements FVendoredBase {
+class FVendoredBaseClient extends disposable.Disposable implements FVendoredBase {
   static final logging.Logger _frugalLog = logging.Logger('VendoredBase');
   Map<String, frugal.FMethod> _methods;
 
   FVendoredBaseClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {
+    manageDisposable(provider);
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];


### PR DESCRIPTION
### Story:
In #1239, the `FServiceProvider` began managing the `transport` it was given. This was released in Frugal 3.9.1, and it broke tests for some downstream consumers which were instantiating `FServiceProvider` using null & mock objects.

This was reverted in Frugal 3.9.2. 

This re-implements the work in #1239, but also guards against managing mock or null objects, or objects which are already disposing. 

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
* Run tests in several major product repos internal to Workiva with/without re-generating some of the client frugal code
* Smoke test running the application in at least one major product repo internal to Workiva with/without re-generating some of the client frugal code.

### My Test Results:
TODO

#### Reviewers:
@Workiva/product2