### PR TITLE
CPLAT-10460: Leverage onDispose to avoid difficulties with mock objects

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1792,8 +1792,8 @@ func (g *Generator) generateClient(service *parser.Service) string {
 	/// Dispose of the provider if possible
 	contents += tab + "@override\n"
 	contents += tab + "Future<Null> onDispose() async {\n"
-	contents += tabtab + "if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {\n"
-	contents += tabtabtab + "return _provider?.dispose();\n"
+	contents += tabtab + "if (_provider is disposable.Disposable && !(_provider?.isOrWillBeDisposed ?? true))  {\n"
+	contents += tabtabtab + "return _provider.dispose();\n"
 	contents += tabtab + "}\n"
 	contents += tabtab + "return null;\n"
 	contents += tab + "}\n"

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1792,7 +1792,7 @@ func (g *Generator) generateClient(service *parser.Service) string {
 	/// Dispose of the provider if possible
 	contents += tab + "@override\n"
 	contents += tab + "Future<Null> onDispose() async {\n"
-	contents += tabtab + "if (_provider is disposable.Disposable && !(_provider?.isOrWillBeDisposed ?? true))  {\n"
+	contents += tabtab + "if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {\n"
 	contents += tabtabtab + "return _provider.dispose();\n"
 	contents += tabtab + "}\n"
 	contents += tabtab + "return null;\n"

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -53,7 +53,7 @@ class FStoreClient extends disposable.Disposable implements FStore {
 
   @override
   Future<Null> onDispose() async {
-    if (_provider is disposable.Disposable && !(_provider?.isOrWillBeDisposed ?? true))  {
+    if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {
       return _provider.dispose();
     }
     return null;

--- a/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
+++ b/examples/dart/gen-dart/v1_music/lib/src/f_store_service.dart
@@ -53,8 +53,8 @@ class FStoreClient extends disposable.Disposable implements FStore {
 
   @override
   Future<Null> onDispose() async {
-    if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {
-      return _provider?.dispose();
+    if (_provider is disposable.Disposable && !(_provider?.isOrWillBeDisposed ?? true))  {
+      return _provider.dispose();
     }
     return null;
   }

--- a/examples/dart/gen-dart/v1_music/pubspec.yaml
+++ b/examples/dart/gen-dart/v1_music/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
       url: https://pub.workiva.org
     version: ^3.9.1
   logging: ^0.11.2
-  mockito: ^4.1.1
   thrift:
     hosted:
       name: thrift

--- a/lib/dart/lib/src/frugal.dart
+++ b/lib/dart/lib/src/frugal.dart
@@ -19,7 +19,6 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
-import 'package:mockito/mockito.dart' show Mock;
 import 'package:logging/logging.dart';
 import 'package:thrift/thrift.dart';
 import 'package:uuid/uuid.dart';

--- a/lib/dart/lib/src/frugal/f_provider.dart
+++ b/lib/dart/lib/src/frugal/f_provider.dart
@@ -48,14 +48,14 @@ class FServiceProvider extends Disposable {
   /// Creates a new [FServiceProvider].
   FServiceProvider(this.transport, this.protocolFactory,
       {List<Middleware> middleware})
-      : _middleware = middleware ?? [] {
-    // The transport is created by the messaging-sdk, and goes out of scope
-    // besides this reference, so it is safe to manage here.
-    if (this.transport != null &&
-        this.transport is! Mock &&
-        !this.transport.isOrWillBeDisposed) {
-      manageDisposable(this.transport);
+      : _middleware = middleware ?? [];
+
+  @override
+  Future<Null> onDispose() async {
+    if (!transport.isOrWillBeDisposed)  {
+      return transport?.dispose();
     }
+    return null;
   }
 
   /// [FTransport] used by the service.

--- a/lib/dart/lib/src/frugal/f_provider.dart
+++ b/lib/dart/lib/src/frugal/f_provider.dart
@@ -52,8 +52,8 @@ class FServiceProvider extends Disposable {
 
   @override
   Future<Null> onDispose() async {
-    if (!transport.isOrWillBeDisposed) {
-      return transport?.dispose();
+    if (!(transport?.isOrWillBeDisposed ?? true)) {
+      return transport.dispose();
     }
     return null;
   }

--- a/lib/dart/lib/src/frugal/f_provider.dart
+++ b/lib/dart/lib/src/frugal/f_provider.dart
@@ -52,10 +52,9 @@ class FServiceProvider extends Disposable {
 
   @override
   Future<Null> onDispose() async {
-    if (!(transport?.isOrWillBeDisposed ?? true)) {
-      return transport.dispose();
-    }
-    return null;
+    if (transport == null) return null;
+    if (transport.isOrWillBeDisposed) return null;
+    return transport.dispose();
   }
 
   /// [FTransport] used by the service.

--- a/lib/dart/lib/src/frugal/f_provider.dart
+++ b/lib/dart/lib/src/frugal/f_provider.dart
@@ -52,7 +52,7 @@ class FServiceProvider extends Disposable {
 
   @override
   Future<Null> onDispose() async {
-    if (!transport.isOrWillBeDisposed)  {
+    if (!transport.isOrWillBeDisposed) {
       return transport?.dispose();
     }
     return null;

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -44,8 +44,8 @@ class FBaseFooClient extends disposable.Disposable implements FBaseFoo {
 
   @override
   Future<Null> onDispose() async {
-    if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {
-      return _provider?.dispose();
+    if (_provider is disposable.Disposable && !(_provider?.isOrWillBeDisposed ?? true))  {
+      return _provider.dispose();
     }
     return null;
   }

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -44,7 +44,7 @@ class FBaseFooClient extends disposable.Disposable implements FBaseFoo {
 
   @override
   Future<Null> onDispose() async {
-    if (_provider is disposable.Disposable && !(_provider?.isOrWillBeDisposed ?? true))  {
+    if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {
       return _provider.dispose();
     }
     return null;

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -9,7 +9,6 @@ import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';
-import 'package:mockito/mockito.dart' show Mock;
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
@@ -29,10 +28,8 @@ class FBaseFooClient extends disposable.Disposable implements FBaseFoo {
   static final logging.Logger _frugalLog = logging.Logger('BaseFoo');
   Map<String, frugal.FMethod> _methods;
 
-  FBaseFooClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {
-    if (provider != null && provider is disposable.Disposable && provider is! Mock && !provider.isOrWillBeDisposed) {
-      manageDisposable(provider);
-    }
+  FBaseFooClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware])
+      : this._provider = provider {
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];
@@ -41,8 +38,17 @@ class FBaseFooClient extends disposable.Disposable implements FBaseFoo {
     this._methods['basePing'] = frugal.FMethod(this._basePing, 'BaseFoo', 'basePing', combined);
   }
 
+  frugal.FServiceProvider _provider;
   frugal.FTransport _transport;
   frugal.FProtocolFactory _protocolFactory;
+
+  @override
+  Future<Null> onDispose() async {
+    if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {
+      return _provider?.dispose();
+    }
+    return null;
+  }
 
   @override
   Future basePing(frugal.FContext ctx) {

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -47,8 +47,8 @@ class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient with dispo
 
   @override
   Future<Null> onDispose() async {
-    if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {
-      return _provider?.dispose();
+    if (_provider is disposable.Disposable && !(_provider?.isOrWillBeDisposed ?? true))  {
+      return _provider.dispose();
     }
     return null;
   }

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -9,7 +9,6 @@ import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';
-import 'package:mockito/mockito.dart' show Mock;
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
@@ -32,10 +31,8 @@ class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient with dispo
   Map<String, frugal.FMethod> _methods;
 
   FMyServiceClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware])
-      : super(provider, middleware) {
-    if (provider != null && provider is disposable.Disposable && provider is! Mock && !provider.isOrWillBeDisposed) {
-      manageDisposable(provider);
-    }
+      : this._provider = provider,
+        super(provider, middleware) {
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];
@@ -44,8 +41,17 @@ class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient with dispo
     this._methods['getItem'] = frugal.FMethod(this._getItem, 'MyService', 'getItem', combined);
   }
 
+  frugal.FServiceProvider _provider;
   frugal.FTransport _transport;
   frugal.FProtocolFactory _protocolFactory;
+
+  @override
+  Future<Null> onDispose() async {
+    if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {
+      return _provider?.dispose();
+    }
+    return null;
+  }
 
   @override
   Future<t_vendor_namespace.Item> getItem(frugal.FContext ctx) {

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -47,7 +47,7 @@ class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient with dispo
 
   @override
   Future<Null> onDispose() async {
-    if (_provider is disposable.Disposable && !(_provider?.isOrWillBeDisposed ?? true))  {
+    if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {
       return _provider.dispose();
     }
     return null;

--- a/test/expected/dart/include_vendor/pubspec.yaml
+++ b/test/expected/dart/include_vendor/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
       url: https://pub.workiva.org
     version: ^3.9.1
   logging: ^0.11.2
-  mockito: ^4.1.1
   some_vendored_place:
     hosted:
       name: some_vendored_place

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -91,8 +91,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
 
   @override
   Future<Null> onDispose() async {
-    if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {
-      return _provider?.dispose();
+    if (_provider is disposable.Disposable && !(_provider?.isOrWillBeDisposed ?? true))  {
+      return _provider.dispose();
     }
     return null;
   }

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -91,7 +91,7 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
 
   @override
   Future<Null> onDispose() async {
-    if (_provider is disposable.Disposable && !(_provider?.isOrWillBeDisposed ?? true))  {
+    if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {
       return _provider.dispose();
     }
     return null;

--- a/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
+++ b/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
@@ -9,7 +9,6 @@ import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';
-import 'package:mockito/mockito.dart' show Mock;
 import 'package:logging/logging.dart' as logging;
 import 'package:thrift/thrift.dart' as thrift;
 import 'package:frugal/frugal.dart' as frugal;
@@ -27,10 +26,8 @@ class FVendoredBaseClient extends disposable.Disposable implements FVendoredBase
   static final logging.Logger _frugalLog = logging.Logger('VendoredBase');
   Map<String, frugal.FMethod> _methods;
 
-  FVendoredBaseClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware]) {
-    if (provider != null && provider is disposable.Disposable && provider is! Mock && !provider.isOrWillBeDisposed) {
-      manageDisposable(provider);
-    }
+  FVendoredBaseClient(frugal.FServiceProvider provider, [List<frugal.Middleware> middleware])
+      : this._provider = provider {
     _transport = provider.transport;
     _protocolFactory = provider.protocolFactory;
     var combined = middleware ?? [];
@@ -38,8 +35,17 @@ class FVendoredBaseClient extends disposable.Disposable implements FVendoredBase
     this._methods = {};
   }
 
+  frugal.FServiceProvider _provider;
   frugal.FTransport _transport;
   frugal.FProtocolFactory _protocolFactory;
+
+  @override
+  Future<Null> onDispose() async {
+    if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {
+      return _provider?.dispose();
+    }
+    return null;
+  }
 
 }
 

--- a/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
+++ b/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
@@ -41,8 +41,8 @@ class FVendoredBaseClient extends disposable.Disposable implements FVendoredBase
 
   @override
   Future<Null> onDispose() async {
-    if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {
-      return _provider?.dispose();
+    if (_provider is disposable.Disposable && !(_provider?.isOrWillBeDisposed ?? true))  {
+      return _provider.dispose();
     }
     return null;
   }

--- a/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
+++ b/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
@@ -41,7 +41,7 @@ class FVendoredBaseClient extends disposable.Disposable implements FVendoredBase
 
   @override
   Future<Null> onDispose() async {
-    if (_provider is disposable.Disposable && !(_provider?.isOrWillBeDisposed ?? true))  {
+    if (_provider is disposable.Disposable && !_provider.isOrWillBeDisposed)  {
       return _provider.dispose();
     }
     return null;


### PR DESCRIPTION
### Story:
#1249 added safeguards to prevent sending a `Mock` object to `manageDisposable`. This was nested references on the `Mock` objects were accessed in `manageDisposable`, which would throw an error since the first nested getter would return `null`. 

The solution, however, requires testing for a `Mock` object, which requires access to the mockito package in production code. This is undesirable, since that package is meant just for testing. 

This change moves the disposal to `onDispose` and calls `dispose()` directly on the disposable objects. We safeguard in the case where the object is already disposing, or is not a `Disposable`. In the case where the object is a `Mock`, the call to `dispose()` is a no-op, since it's at the top level of the parent object.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
* Run tests with/without generated frugal in DPC.

### My Test Results:
TODO

#### Reviewers:
@Workiva/product2