### PR TITLE
java: Add TTransportExceptionType.DISCONNECTED

### DIFF
--- a/lib/dart/lib/src/frugal/f_error.dart
+++ b/lib/dart/lib/src/frugal/f_error.dart
@@ -78,4 +78,7 @@ class FrugalTTransportErrorType extends TTransportErrorType {
 
   /// Indicates the response was too large for the transport.
   static const int RESPONSE_TOO_LARGE = 101;
+
+  /// Indicates the request failed because the transport was disconnected.
+  static const int DISCONNECTED = 102;
 }

--- a/lib/go/errors.go
+++ b/lib/go/errors.go
@@ -34,6 +34,10 @@ const (
 	// TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE is a TTransportException
 	// error type indicating the response exceeded the size limit.
 	TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE = 101
+
+	// TRANSPORT_EXCEPTION_DISCONNECTED is a TTransportException error type
+	// indicating the transport was disconnected
+	TRANSPORT_EXCEPTION_DISCONNECTED = 102
 )
 
 // TApplicationException types used in frugal instantiated

--- a/lib/gopherjs/frugal/errors.go
+++ b/lib/gopherjs/frugal/errors.go
@@ -34,6 +34,10 @@ const (
 	// TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE is a TTransportException
 	// error type indicating the response exceeded the size limit.
 	TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE = 101
+
+	// TRANSPORT_EXCEPTION_DISCONNECTED is a TTransportException error type
+	// indicating the transport was disconnected.
+	TRANSPORT_EXCEPTION_DISCONNECTED = 102
 )
 
 // TApplicationException types used in frugal instantiated

--- a/lib/java/src/main/java/com/workiva/frugal/exception/TTransportExceptionType.java
+++ b/lib/java/src/main/java/com/workiva/frugal/exception/TTransportExceptionType.java
@@ -40,4 +40,8 @@ public class TTransportExceptionType {
      */
     public static final int RESPONSE_TOO_LARGE = 101;
 
+    /**
+     * TTransportException code that indicates the transport was disconnected.
+     */
+    public static final int DISCONNECTED = 102;
 }

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FNatsPublisherTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FNatsPublisherTransport.java
@@ -17,8 +17,6 @@ import com.workiva.frugal.exception.TTransportExceptionType;
 import io.nats.client.Connection;
 import io.nats.client.Connection.Status;
 import org.apache.thrift.transport.TTransportException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static com.workiva.frugal.transport.FNatsTransport.FRUGAL_PREFIX;
 import static com.workiva.frugal.transport.FNatsTransport.NATS_MAX_MESSAGE_SIZE;
@@ -29,8 +27,6 @@ import static com.workiva.frugal.transport.FNatsTransport.getClosedConditionExce
  * Messages are limited to 1MB in size.
  */
 public class FNatsPublisherTransport implements FPublisherTransport {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FNatsPublisherTransport.class);
-
     private final Connection conn;
 
     /**

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FNatsPublisherTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FNatsPublisherTransport.java
@@ -65,12 +65,12 @@ public class FNatsPublisherTransport implements FPublisherTransport {
     }
 
     @Override
-    public synchronized boolean isOpen() {
+    public boolean isOpen() {
         return conn.getStatus() == Status.CONNECTED;
     }
 
     @Override
-    public synchronized void open() throws TTransportException {
+    public void open() throws TTransportException {
         // We only need to check that the NATS client is connected
         if (conn.getStatus() != Status.CONNECTED) {
             throw new TTransportException(TTransportExceptionType.NOT_OPEN,
@@ -79,7 +79,7 @@ public class FNatsPublisherTransport implements FPublisherTransport {
     }
 
     @Override
-    public synchronized void close() {
+    public void close() {
         /* Do nothing */
     }
 

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FNatsPublisherTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FNatsPublisherTransport.java
@@ -66,15 +66,19 @@ public class FNatsPublisherTransport implements FPublisherTransport {
 
     @Override
     public boolean isOpen() {
-        return conn.getStatus() == Status.CONNECTED;
+        return isOpen(conn.getStatus());
+    }
+
+    private boolean isOpen(Status status) {
+        return status == Status.CONNECTED;
     }
 
     @Override
     public void open() throws TTransportException {
         // We only need to check that the NATS client is connected
-        if (conn.getStatus() != Status.CONNECTED) {
-            throw new TTransportException(TTransportExceptionType.NOT_OPEN,
-                    "NATS not connected, has status " + conn.getStatus());
+        Status status = conn.getStatus();
+        if (!isOpen(status)) {
+            throw getClosedConditionException(status, "open:");
         }
     }
 
@@ -90,8 +94,9 @@ public class FNatsPublisherTransport implements FPublisherTransport {
 
     @Override
     public void publish(String topic, byte[] payload) throws TTransportException {
-        if (!isOpen()) {
-            throw getClosedConditionException(conn.getStatus(), "publish:");
+        Status status = conn.getStatus();
+        if (!isOpen(status)) {
+            throw getClosedConditionException(status, "publish:");
         }
 
         if ("".equals(topic)) {

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FNatsTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FNatsTransport.java
@@ -169,7 +169,10 @@ public class FNatsTransport extends FAsyncTransport {
      */
     protected static TTransportException getClosedConditionException(Status connStatus, String prefix) {
         if (connStatus != Status.CONNECTED) {
-            return new TTransportException(TTransportExceptionType.NOT_OPEN,
+            int ttype = connStatus == Status.DISCONNECTED || connStatus == Status.RECONNECTING
+                    ? TTransportExceptionType.DISCONNECTED
+                    : TTransportExceptionType.NOT_OPEN;
+            return new TTransportException(ttype,
                     String.format("%s NATS client not connected (has status %s)", prefix, connStatus.name()));
         }
         return new TTransportException(TTransportExceptionType.NOT_OPEN,

--- a/lib/java/src/test/java/com/workiva/frugal/transport/FNatsPublisherTransportTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/transport/FNatsPublisherTransportTest.java
@@ -72,8 +72,8 @@ public class FNatsPublisherTransportTest {
     }
 
     @Test
-    public void testPublishNotConnected() throws TTransportException {
-        when(conn.getStatus()).thenReturn(Status.DISCONNECTED);
+    public void testPublishClosed() throws TTransportException {
+        when(conn.getStatus()).thenReturn(Status.CLOSED);
         byte[] payload = new byte[]{1, 2, 3, 4};
 
         try {

--- a/lib/python/frugal/exceptions.py
+++ b/lib/python/frugal/exceptions.py
@@ -23,6 +23,7 @@ class TTransportExceptionType(object):
 
     REQUEST_TOO_LARGE = 100
     RESPONSE_TOO_LARGE = 101
+    DISCONNECTED = 102
 
 
 class TApplicationExceptionType(object):


### PR DESCRIPTION
### Story:
Commits are intended to be reviewed independently. See commit messages for details.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
I had previously discussed adding a `RECONNECTING` option, but I think `DISCONNECTED` makes more sense since "reconnecting" is really a sub-state of "disconnected".

I don't have the expertise to implement similar changes for the other languages, so I have simply reserved an exception type number.

### My Test Results:
I manually tested as part of a service that does frequent publishes.  I stopped NATS and was able to verify the new type was used.

#### Reviewers:
@Workiva/product2