### PR TITLE
INFENG-11584: java: Support custom ExecutorService on a per-FServlet basis

### DIFF
--- a/lib/java/src/main/java/com/workiva/frugal/server/FDefaultNatsServerEventHandler.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FDefaultNatsServerEventHandler.java
@@ -1,45 +1,10 @@
 package com.workiva.frugal.server;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.time.Clock;
-import java.util.Map;
-
 /**
  * A default event handler for an FNatsServer.
  */
-public class FDefaultNatsServerEventHandler implements FServerEventHandler {
-    private static final Logger LOGGER = LoggerFactory.getLogger(FDefaultNatsServerEventHandler.class);
-    public static final String REQUEST_RECEIVED_MILLIS_KEY = "request_received_millis";
-
-    private long highWatermark;
-    // protected for testing
-    protected Clock clock;
-
+public class FDefaultNatsServerEventHandler extends FDefaultServerEventHandler {
     public FDefaultNatsServerEventHandler(long highWatermark) {
-        this.highWatermark = highWatermark;
-        this.clock = Clock.systemUTC();
+        super(highWatermark);
     }
-
-    @Override
-    public void onRequestReceived(Map<Object, Object> ephemeralProperties) {
-        long now = clock.millis();
-        ephemeralProperties.put(REQUEST_RECEIVED_MILLIS_KEY, now);
-    }
-
-    @Override
-    public void onRequestStarted(Map<Object, Object> ephemeralProperties) {
-        if (ephemeralProperties.get(REQUEST_RECEIVED_MILLIS_KEY) != null) {
-            long started = (long) ephemeralProperties.get(REQUEST_RECEIVED_MILLIS_KEY);
-            long duration = clock.millis() - started;
-            if (duration > highWatermark) {
-                LOGGER.warn(String.format(
-                        "request spent %d ms in the transport buffer, your consumer might be backed up", duration));
-            }
-        }
-    }
-
-    @Override
-    public void onRequestEnded(Map<Object, Object> ephemeralProperties) {}
 }

--- a/lib/java/src/main/java/com/workiva/frugal/server/FDefaultServerEventHandler.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FDefaultServerEventHandler.java
@@ -1,0 +1,45 @@
+package com.workiva.frugal.server;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.util.Map;
+
+/**
+ * A default event handler for an FServer.
+ */
+public class FDefaultServerEventHandler implements FServerEventHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FDefaultServerEventHandler.class);
+    public static final String REQUEST_RECEIVED_MILLIS_KEY = "request_received_millis";
+
+    private long highWatermark;
+    // protected for testing
+    protected Clock clock;
+
+    public FDefaultServerEventHandler(long highWatermark) {
+        this.highWatermark = highWatermark;
+        this.clock = Clock.systemUTC();
+    }
+
+    @Override
+    public void onRequestReceived(Map<Object, Object> ephemeralProperties) {
+        long now = clock.millis();
+        ephemeralProperties.put(REQUEST_RECEIVED_MILLIS_KEY, now);
+    }
+
+    @Override
+    public void onRequestStarted(Map<Object, Object> ephemeralProperties) {
+        if (ephemeralProperties.get(REQUEST_RECEIVED_MILLIS_KEY) != null) {
+            long started = (long) ephemeralProperties.get(REQUEST_RECEIVED_MILLIS_KEY);
+            long duration = clock.millis() - started;
+            if (duration > highWatermark) {
+                LOGGER.warn(String.format(
+                        "request spent %d ms in the transport buffer, your consumer might be backed up", duration));
+            }
+        }
+    }
+
+    @Override
+    public void onRequestEnded(Map<Object, Object> ephemeralProperties) {}
+}

--- a/lib/java/src/main/java/com/workiva/frugal/server/FServlet.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FServlet.java
@@ -84,10 +84,18 @@ public class FServlet extends HttpServlet {
             FProtocolFactory inProtocolFactory,
             FProtocolFactory outProtocolFactory,
             int maxRequestSize) {
-        this.processor = processor;
-        this.inProtocolFactory = inProtocolFactory;
-        this.outProtocolFactory = outProtocolFactory;
-        this.maxRequestSize = maxRequestSize;
+        this(builder()
+                .processor(processor)
+                .inProtocolFactory(inProtocolFactory)
+                .outProtocolFactory(outProtocolFactory)
+                .maxRequestSize(maxRequestSize));
+    }
+
+    private FServlet(Builder b) {
+        this.processor = b.processor;
+        this.inProtocolFactory = b.inProtocolFactory;
+        this.outProtocolFactory = b.outProtocolFactory;
+        this.maxRequestSize = b.maxRequestSize;
     }
 
     @Override
@@ -159,5 +167,40 @@ public class FServlet extends HttpServlet {
             responseLimit = 0;
         }
         return responseLimit;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private FProcessor processor;
+        private FProtocolFactory inProtocolFactory;
+        private FProtocolFactory outProtocolFactory;
+        private int maxRequestSize;
+
+        public FServlet build() {
+            return new FServlet(this);
+        }
+
+        public Builder processor(FProcessor processor) {
+            this.processor = processor;
+            return this;
+        }
+
+        public Builder inProtocolFactory(FProtocolFactory inProtocolFactory) {
+            this.inProtocolFactory = inProtocolFactory;
+            return this;
+        }
+
+        public Builder outProtocolFactory(FProtocolFactory outProtocolFactory) {
+            this.outProtocolFactory = outProtocolFactory;
+            return this;
+        }
+
+        public Builder maxRequestSize(int maxRequestSize) {
+            this.maxRequestSize = maxRequestSize;
+            return this;
+        }
     }
 }


### PR DESCRIPTION
# [INFENG-11584](https://jira.atl.workiva.net/browse/INFENG-11584)
![Issue Status](http://bender.workiva.org:9000/Bender/status/INFENG-11584)

### Story:
See commit messages for details.  In particular, the third commit:
> Submitting to an ExecutorService is an easy way to limit concurrency
> differently on a per-endpoint basis rather than relying on the global
> shared HTTP thread pool.  Additionally, this also allows the same
> concurrent limits to be applied if the service handler is exposed by
> multiple servers (for example, NATS and HTTP).  Finally, this also makes
> it easy to specify meaningful service thread names rather than using
> generic HTTP pooled thread names.  This could be extended in the future
>  to use the asynchronous servlet mechanism so the HTTP thread can be
> reused while the Frugal thread is still processing.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [x] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
Commits are intended to be designed independently.

### How To Test:
I've manually tested on an internal service using HTTP that logs requests with thread names:
1. by default, it continues to use an HTTP thread
2. when using `FServlet.Builder.executorService`, it delegates to the executor

#### Reviewers:
@Workiva/product2
FYI @shaunbrockhoff-wk 