### PR TITLE
java: Improve NATS timeout exception

### DIFF
--- a/lib/java/src/test/java/com/workiva/frugal/transport/FNatsTransportTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/transport/FNatsTransportTest.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 
 import static com.workiva.frugal.transport.FAsyncTransportTest.mockFrame;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
@@ -179,6 +181,24 @@ public class FNatsTransportTest {
             fail();
         } catch (TTransportException e) {
             assertEquals(TTransportExceptionType.DISCONNECTED, e.getType());
+        }
+    }
+
+    @Test
+    public void testRequestTimedOut() throws TTransportException {
+        when(conn.getStatus()).thenReturn(Status.CONNECTED);
+        Dispatcher mockDispatcher = mock(Dispatcher.class);
+        when(conn.createDispatcher(any(MessageHandler.class))).thenReturn(mockDispatcher);
+        transport.open();
+
+        try {
+            FContext fContext = new FContext();
+            fContext.setTimeout(0);
+            transport.request(fContext, "helloworld".getBytes());
+            fail();
+        } catch (TTransportException e) {
+            assertEquals(TTransportExceptionType.TIMED_OUT, e.getType());
+            assertThat(e.getMessage(), containsString("foo"));
         }
     }
 }


### PR DESCRIPTION
### Story:
See commit message for details.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [x] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
I considered adding `protected TException getRequestTimeoutException` to `FAsyncTransport` rather than creating a separate wrapping exception.  This approach avoided new API and wasn't significantly more complicated.

### How To Test:
Already manually included in a client and tested using an internal service in order to produce the sample stack traces.

### My Test Results:

#### Reviewers:
@Workiva/product2