### PR TITLE
java: Expose request for extensible processing

### DIFF
--- a/lib/java/src/test/java/com/workiva/frugal/server/FNatsServerTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/server/FNatsServerTest.java
@@ -216,10 +216,6 @@ public class FNatsServerTest {
         FNatsServer.Request request = (FNatsServer.Request) captor.getValue();
         assertArrayEquals(data, request.frameBytes);
         assertEquals(reply, request.reply);
-        assertEquals(mockProtocolFactory, request.inputProtoFactory);
-        assertEquals(mockProtocolFactory, request.outputProtoFactory);
-        assertEquals(mockProcessor, request.processor);
-        assertEquals(mockConn, request.conn);
     }
 
     @Test
@@ -246,9 +242,9 @@ public class FNatsServerTest {
         long highWatermark = 5000;
         MockFProcessor processor = new MockFProcessor(data, "blah".getBytes());
         mockProtocolFactory = new FProtocolFactory(new TJSONProtocol.Factory());
-        FNatsServer.Request request = new FNatsServer.Request(data, reply,
-                mockProtocolFactory, mockProtocolFactory, processor, mockConn,
-                new FDefaultNatsServerEventHandler(5000), new HashMap<>());
+        server = new FNatsServer.Builder(mockConn, processor, mockProtocolFactory, new String[]{subject})
+                .withQueueGroup(queue).build();
+        FNatsServer.Request request = server.new Request(data, reply, new HashMap<>());
 
         request.run();
 
@@ -264,9 +260,9 @@ public class FNatsServerTest {
         long highWatermark = 5000;
         MockFProcessor processor = new MockFProcessor(new RuntimeException());
         mockProtocolFactory = new FProtocolFactory(new TJSONProtocol.Factory());
-        FNatsServer.Request request = new FNatsServer.Request(data, reply,
-                mockProtocolFactory, mockProtocolFactory, processor, mockConn,
-                new FDefaultNatsServerEventHandler(5000), new HashMap<>());
+        server = new FNatsServer.Builder(mockConn, processor, mockProtocolFactory, new String[]{subject})
+                .withQueueGroup(queue).build();
+        FNatsServer.Request request = server.new Request(data, reply, new HashMap<>());
 
         request.run();
 
@@ -282,9 +278,9 @@ public class FNatsServerTest {
         long highWatermark = 5000;
         MockFProcessor processor = new MockFProcessor(data, null);
         mockProtocolFactory = new FProtocolFactory(new TJSONProtocol.Factory());
-        FNatsServer.Request request = new FNatsServer.Request(data, reply,
-                mockProtocolFactory, mockProtocolFactory, processor, mockConn,
-                new FDefaultNatsServerEventHandler(5000), new HashMap<>());
+        server = new FNatsServer.Builder(mockConn, processor, mockProtocolFactory, new String[]{subject})
+                .withQueueGroup(queue).build();
+        FNatsServer.Request request = server.new Request(data, reply, new HashMap<>());
 
         request.run();
 


### PR DESCRIPTION
### Story:
Clients and servers are inherently decoupled with NATS messaging, which presents a unique opportunity for cooperative request handling by multiple server instances. However, to allow strategies that leverage this characteristic, like [RFD 0278](https://sandbox.wdesk.com/a/QWNjb3VudB82NzE5NTMwMjcyOTQ4MjI0/doc/0302cab5f422408196f0b5bef095770d/r/-1/v/1/sec/0302cab5f422408196f0b5bef095770d_1), the POJO used to represent the request in `FNatsServer` needs to be exposed.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [x] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
This PR _only_ makes the necessary code changes to expose the minimum `FNatsServer.Request` POJO. All current behavior should be preserved. The implementation of the aforementioned RFD would have to be done by consumers.

I considered keeping the POJO a `static class`, but it required a larger refactor in order to expose a way to populate the processing instance variables (`FProtocolFactory`,`FProcessor`, etc). It was ultimately much simpler to forgo copying references of these variables into the POJO, and simply use the original references on the `FNatsServer` class in the `processRequest()` method.

### How To Test:
I've copied this file `FNatsServer` into our PR that implements the design in [RFD 0278](https://sandbox.wdesk.com/a/QWNjb3VudB82NzE5NTMwMjcyOTQ4MjI0/doc/0302cab5f422408196f0b5bef095770d/r/-1/v/1/sec/0302cab5f422408196f0b5bef095770d_1) and deployed it to our development environment. Links are in the RFD.

### My Test Results:
- [x] The original request handling behavior is unchanged.
- [x] The new ability to interact with the exposed Request POJO also works as intended.

#### Reviewers:
@Workiva/product2
@natewoods-wf
@chadknight-wf
@richklein-wf

### Review Note
It is easier to review the 2 commits separately. The 2nd commit is only a formatting change, which obfuscates the actual changes a bit.