### PR TITLE
CPLAT-11680: Expose frugal client scope factories

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -309,19 +309,18 @@ func (g *Generator) exportClasses(dir string) error {
 		}
 
 		servTitle := strings.Title(service.Name)
-		exports += fmt.Sprintf("export '%s/%s%s%s.%s' show F%s;\n",
-			servSrcDir, generator.FilePrefix, toFileName(service.Name), serviceSuffix, lang, servTitle)
-		exports += fmt.Sprintf("export '%s/%s%s%s.%s' show F%sClient;\n",
-			servSrcDir, generator.FilePrefix, toFileName(service.Name), serviceSuffix, lang, servTitle)
+		exports += fmt.Sprintf("export '%s/%s%s%s.%s' show F%s, F%sClient, f%sClientFactory;\n",
+			servSrcDir, generator.FilePrefix, toFileName(service.Name), serviceSuffix, lang, servTitle, servTitle, servTitle)
 	}
 	for _, scope := range g.Frugal.Scopes {
 		scopeSrcDir := "src"
 		if _, ok := g.Options[libraryPrefixOption]; ok {
 			scopeSrcDir = filename
 		}
+
 		scopeTitle := strings.Title(scope.Name)
-		exports += fmt.Sprintf("export '%s/%s%s%s.%s' show %sPublisher, %sSubscriber;\n",
-			scopeSrcDir, generator.FilePrefix, toFileName(scope.Name), scopeSuffix, lang, scopeTitle, scopeTitle)
+		exports += fmt.Sprintf("export '%s/%s%s%s.%s' show %sPublisher, %sSubscriber, %sPublisherFactory, %sSubscriberFactory;\n",
+			scopeSrcDir, generator.FilePrefix, toFileName(scope.Name), scopeSuffix, lang, scopeTitle, scopeTitle, lowercaseFirstCharacter(scopeTitle), lowercaseFirstCharacter(scopeTitle))
 	}
 	stat, err := mainFile.Stat()
 	if err != nil {

--- a/examples/dart/gen-dart/v1_music/lib/v1_music.dart
+++ b/examples/dart/gen-dart/v1_music/lib/v1_music.dart
@@ -8,6 +8,5 @@ export 'src/f_album.dart' show Album;
 export 'src/f_purchasing_error.dart' show PurchasingError;
 export 'src/f_perf_rights_org.dart' show PerfRightsOrg;
 
-export 'src/f_store_service.dart' show FStore;
-export 'src/f_store_service.dart' show FStoreClient;
-export 'src/f_album_winners_scope.dart' show AlbumWinnersPublisher, AlbumWinnersSubscriber;
+export 'src/f_store_service.dart' show FStore, FStoreClient, fStoreClientFactory;
+export 'src/f_album_winners_scope.dart' show AlbumWinnersPublisher, AlbumWinnersSubscriber, albumWinnersPublisherFactory, albumWinnersSubscriberFactory;

--- a/test/expected/dart/actual_base/actual_base_dart.dart
+++ b/test/expected/dart/actual_base/actual_base_dart.dart
@@ -9,5 +9,4 @@ export 'src/f_nested_thing.dart' show nested_thing;
 export 'src/f_api_exception.dart' show api_exception;
 export 'src/f_base_health_condition.dart' show base_health_condition;
 
-export 'src/f_base_foo_service.dart' show FBaseFoo;
-export 'src/f_base_foo_service.dart' show FBaseFooClient;
+export 'src/f_base_foo_service.dart' show FBaseFoo, FBaseFooClient, fBaseFooClientFactory;

--- a/test/expected/dart/include_vendor/include_vendor.dart
+++ b/test/expected/dart/include_vendor/include_vendor.dart
@@ -5,6 +5,5 @@ library include_vendor;
 
 export 'src/f_vendored_references.dart' show VendoredReferences;
 
-export 'src/f_my_service_service.dart' show FMyService;
-export 'src/f_my_service_service.dart' show FMyServiceClient;
-export 'src/f_my_scope_scope.dart' show MyScopePublisher, MyScopeSubscriber;
+export 'src/f_my_service_service.dart' show FMyService, FMyServiceClient, fMyServiceClientFactory;
+export 'src/f_my_scope_scope.dart' show MyScopePublisher, MyScopeSubscriber, myScopePublisherFactory, myScopeSubscriberFactory;

--- a/test/expected/dart/variety/variety.dart
+++ b/test/expected/dart/variety/variety.dart
@@ -15,8 +15,6 @@ export 'src/f_awesome_exception.dart' show AwesomeException;
 export 'src/f_health_condition.dart' show HealthCondition;
 export 'src/f_its_an_enum.dart' show ItsAnEnum;
 
-export 'src/f_foo_service.dart' show FFoo;
-export 'src/f_foo_service.dart' show FFooClient;
-export 'src/f_foo_transitive_deps_service.dart' show FFooTransitiveDeps;
-export 'src/f_foo_transitive_deps_service.dart' show FFooTransitiveDepsClient;
-export 'src/f_events_scope.dart' show EventsPublisher, EventsSubscriber;
+export 'src/f_foo_service.dart' show FFoo, FFooClient, fFooClientFactory;
+export 'src/f_foo_transitive_deps_service.dart' show FFooTransitiveDeps, FFooTransitiveDepsClient, fFooTransitiveDepsClientFactory;
+export 'src/f_events_scope.dart' show EventsPublisher, EventsSubscriber, eventsPublisherFactory, eventsSubscriberFactory;

--- a/test/expected/dart/vendor_namespace/vendor_namespace.dart
+++ b/test/expected/dart/vendor_namespace/vendor_namespace.dart
@@ -7,5 +7,4 @@ export 'src/f_vendor_namespace_constants.dart' show VendorNamespaceConstants;
 export 'src/f_item.dart' show Item;
 export 'src/f_my_enum.dart' show MyEnum;
 
-export 'src/f_vendored_base_service.dart' show FVendoredBase;
-export 'src/f_vendored_base_service.dart' show FVendoredBaseClient;
+export 'src/f_vendored_base_service.dart' show FVendoredBase, FVendoredBaseClient, fVendoredBaseClientFactory;


### PR DESCRIPTION
### Story:
Dart generated frugal factories for clients and scopes were not publicly exported from the generated entrypoint. 

This updates the frugal compiler to expose those factories from the generated entrypoint.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
N/A

### How To Test:
CI Passes (tests updated)

### My Test Results:
N/A

#### Reviewers:
@Workiva/product2