### PR TITLE
Fix scope operation type error

### DIFF
--- a/compiler/parser/types.go
+++ b/compiler/parser/types.go
@@ -370,7 +370,7 @@ func addInclude(includesSet map[string]*Include, includes []*Include, t *Type, f
 		includeName := t.Name[0:strings.Index(t.Name, ".")]
 		include := frugal.Include(includeName)
 		if include == nil {
-			return nil, nil, fmt.Errorf("Type %s references invalid include %s", t.Name, include.Name)
+			return nil, nil, fmt.Errorf("Type %s references invalid include %s", t.Name, includeName)
 		}
 		if _, ok := includesSet[includeName]; !ok {
 			includesSet[includeName] = include

--- a/compiler/parser/types.go
+++ b/compiler/parser/types.go
@@ -1052,6 +1052,9 @@ func (f *Frugal) validate() error {
 	if err := f.validateServices(f.ParsedIncludes); err != nil {
 		return err
 	}
+	if err := f.validateScopes(f.ParsedIncludes); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1280,6 +1283,24 @@ func (f *Frugal) validateServiceTypes(service *Service, includes map[string]*Fru
 				return fmt.Errorf("Invalid exception type %s for %s.%s",
 					field.Type.Name, service.Name, method.Name)
 			}
+		}
+	}
+	return nil
+}
+func (f *Frugal) validateScopes(includes map[string]*Frugal) error {
+	for _, scope := range f.Scopes {
+		if err := f.validateScopeTypes(scope, includes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *Frugal) validateScopeTypes(scope *Scope, includes map[string]*Frugal) error {
+	for _, op := range scope.Operations {
+		if !f.isValidType(op.Type) {
+			return fmt.Errorf("Invalid operation type %s for %s.%s",
+				op.Type.Name, scope.Name, op.Name)
 		}
 	}
 	return nil

--- a/test/audit_test.go
+++ b/test/audit_test.go
@@ -122,7 +122,7 @@ func TestScopeBreakingChanges(t *testing.T) {
 		"scope Foo: prefix changed: 'foo.bar.{}.{}.qux' -> 'foo.bar.{}.{}.qux.que'",
 		"scope Foo: prefix changed: 'foo.bar.{}.{}.qux' -> 'foo.bar.{}.{}'",
 		"scope Foo: operation removed: Bar",
-		"scope Foo: operation Foo: types not equal: 'Thing' -> 'int'",
+		"scope Foo: operation Foo: types not equal: 'Thing' -> 'i32'",
 	}
 	for i := 0; i < 7; i++ {
 		badFile := fmt.Sprintf("idl/breaking_changes/scope%d.frugal", i+1)

--- a/test/common_test.go
+++ b/test/common_test.go
@@ -34,6 +34,7 @@ const (
 	duplicateStructFieldIds = "idl/duplicate_field_ids.frugal"
 	frugalGenFile           = "idl/variety.frugal"
 	badNamespace            = "idl/bad_namespace.frugal"
+	badOpType               = "idl/bad_op_type.frugal"
 	includeVendor           = "idl/include_vendor.frugal"
 	includeVendorNoPath     = "idl/include_vendor_no_path.frugal"
 	vendorNamespace         = "idl/vendor_namespace.frugal"

--- a/test/idl/bad_op_type.frugal
+++ b/test/idl/bad_op_type.frugal
@@ -1,0 +1,3 @@
+scope test prefix test {
+  test: invalid.type
+}

--- a/test/idl/breaking_changes/scope7.frugal
+++ b/test/idl/breaking_changes/scope7.frugal
@@ -24,7 +24,7 @@ exception InvalidOperation {
 scope Foo prefix foo.bar.{baz}.{biz}.qux {
 
     /**@ This is an operation docstring. */
-    Foo: int // This is an operation.
+    Foo: i32 // This is an operation.
     Bar: Stuff
 }
 

--- a/test/invalid_test.go
+++ b/test/invalid_test.go
@@ -115,3 +115,16 @@ func TestWildcardNamespaceWithVendorAnnotation(t *testing.T) {
 		t.Fatal("Expected error")
 	}
 }
+
+// Ensures an error is returned when a scope operation has an invalid type.
+func TestInvalidScopeOperationType(t *testing.T) {
+	options := compiler.Options{
+		File:  badOpType,
+		Gen:   "go",
+		Out:   outputDir,
+		Delim: delim,
+	}
+	if err := compiler.Compile(options); err == nil {
+		t.Fatal("Expected error")
+	}
+}


### PR DESCRIPTION
### Story:
If a scope operation references an invalid include, the generator currently crashes.  (As an aside, the `recover` makes it rather difficult to diagnose.  It seems like the tool should just handle all cases rather than giving a vague error message when it crashes...)

Commits are intended to be reviewed independently

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:

### How To Test:

### My Test Results:

#### Reviewers:
@Workiva/product2
cc: @justinlindh-wf 