### PR TITLE
Thrift 0.13.0

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.9.3</version>
+            <version>0.13.0</version>
         </dependency>
         <dependency>
             <groupId>com.workiva</groupId>

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.9.3</version>
+            <version>0.13.0</version>
         </dependency>
         <dependency>
             <groupId>io.nats</groupId>
@@ -181,7 +181,7 @@
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <consoleOutput>true</consoleOutput>
-                    
+
                     <failOnViolation>false</failOnViolation>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <includeResources>false</includeResources>
@@ -195,7 +195,7 @@
                             <goal>check</goal>
                         </goals>
                         <configuration>
-                            
+
                             <failOnViolation>false</failOnViolation>
                         </configuration>
                     </execution>

--- a/lib/java/src/main/java/com/workiva/frugal/provider/FServiceClient.java
+++ b/lib/java/src/main/java/com/workiva/frugal/provider/FServiceClient.java
@@ -23,13 +23,12 @@ import com.workiva.frugal.protocol.FProtocolFactory;
 import com.workiva.frugal.provider.FServiceProvider;
 import org.apache.thrift.protocol.TMessage;
 import org.apache.thrift.protocol.TMessageType;
-import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.TApplicationException;
-import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+import org.apache.thrift.TSerializable;
 
 /**
  * FProtocolHelper is used by generated code to consolidate the logic generated.
@@ -44,7 +43,7 @@ public class FServiceClient {
 		this.protocolFactory_ = provider.getProtocolFactory();
 	}
 
-	protected void requestBase(FContext ctx, String method, TBase<?, ?> args, TBase<?, ?> res) throws TException {
+	protected void requestBase(FContext ctx, String method, TSerializable args, TSerializable res) throws TException {
 		byte[] payload = prepareMessage(ctx, method, args, TMessageType.CALL);
 		TTransport response = transport_.request(ctx, payload);
 		FProtocol iprot = protocolFactory_.getProtocol(response);
@@ -54,7 +53,7 @@ public class FServiceClient {
 			throw new TApplicationException(TApplicationExceptionType.WRONG_METHOD_NAME, method + " failed: wrong method name");
 		}
 		if (message.type == TMessageType.EXCEPTION) {
-			TApplicationException e = TApplicationException.read(iprot); // CHANGES IN THRIFT 0.10.0, TODO: readFrom
+			TApplicationException e = TApplicationException.readFrom(iprot);
 			iprot.readMessageEnd();
 			TException returnedException = e;
 			if (e.getType() == TApplicationExceptionType.RESPONSE_TOO_LARGE) {
@@ -69,12 +68,12 @@ public class FServiceClient {
 		iprot.readMessageEnd();
 	}
 
-	protected void onewayBase(FContext ctx, String method, TBase<?, ?> args) throws TException {
+	protected void onewayBase(FContext ctx, String method, TSerializable args) throws TException {
 		byte[] payload = prepareMessage(ctx, method, args, TMessageType.ONEWAY);
 		transport_.oneway(ctx, payload);
 	}
 
-	private byte[] prepareMessage(FContext ctx, String method, TBase<?, ?> args, byte type) throws TException {
+	private byte[] prepareMessage(FContext ctx, String method, TSerializable args, byte type) throws TException {
 		TMemoryOutputBuffer memoryBuffer = new TMemoryOutputBuffer(transport_.getRequestSizeLimit());
 		FProtocol oprot = protocolFactory_.getProtocol(memoryBuffer);
 		oprot.writeRequestHeader(ctx);

--- a/lib/java/src/main/java/com/workiva/frugal/provider/FServiceClient.java
+++ b/lib/java/src/main/java/com/workiva/frugal/provider/FServiceClient.java
@@ -25,10 +25,10 @@ import org.apache.thrift.protocol.TMessage;
 import org.apache.thrift.protocol.TMessageType;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.TApplicationException;
+import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
-import org.apache.thrift.TSerializable;
 
 /**
  * FProtocolHelper is used by generated code to consolidate the logic generated.
@@ -43,7 +43,7 @@ public class FServiceClient {
 		this.protocolFactory_ = provider.getProtocolFactory();
 	}
 
-	protected void requestBase(FContext ctx, String method, TSerializable args, TSerializable res) throws TException {
+	protected void requestBase(FContext ctx, String method, TBase<?, ?> args, TBase<?, ?> res) throws TException {
 		byte[] payload = prepareMessage(ctx, method, args, TMessageType.CALL);
 		TTransport response = transport_.request(ctx, payload);
 		FProtocol iprot = protocolFactory_.getProtocol(response);
@@ -68,12 +68,12 @@ public class FServiceClient {
 		iprot.readMessageEnd();
 	}
 
-	protected void onewayBase(FContext ctx, String method, TSerializable args) throws TException {
+	protected void onewayBase(FContext ctx, String method, TBase<?, ?> args) throws TException {
 		byte[] payload = prepareMessage(ctx, method, args, TMessageType.ONEWAY);
 		transport_.oneway(ctx, payload);
 	}
 
-	private byte[] prepareMessage(FContext ctx, String method, TSerializable args, byte type) throws TException {
+	private byte[] prepareMessage(FContext ctx, String method, TBase<?, ?> args, byte type) throws TException {
 		TMemoryOutputBuffer memoryBuffer = new TMemoryOutputBuffer(transport_.getRequestSizeLimit());
 		FProtocol oprot = protocolFactory_.getProtocol(memoryBuffer);
 		oprot.writeRequestHeader(ctx);

--- a/lib/java/src/test/java/com/workiva/frugal/provider/FServiceClientTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/provider/FServiceClientTest.java
@@ -5,7 +5,7 @@ import com.workiva.frugal.protocol.FProtocol;
 import com.workiva.frugal.protocol.FProtocolFactory;
 import com.workiva.frugal.transport.FTransport;
 import com.workiva.frugal.transport.TMemoryOutputBuffer;
-import org.apache.thrift.TBase;
+import org.apache.thrift.TSerializable;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TMessage;
 import org.apache.thrift.protocol.TMessageType;
@@ -38,8 +38,8 @@ public class FServiceClientTest {
         when(protocolFactory.getProtocol(response)).thenReturn(iprot);
         FServiceProvider provider = new FServiceProvider(transport, protocolFactory);
         FContext ctx = new FContext("request");
-        TBase<?, ?> args = mock(TBase.class); // ADDED IN THRIFT 0.10.0.  TODO: replace with org.apache.thrift.TSerializable
-        TBase<?, ?> res = mock(TBase.class);
+        TSerializable args = mock(TSerializable.class);
+        TSerializable res = mock(TSerializable.class);
 
         // Call
         FServiceClient client = new FServiceClient(provider);
@@ -72,7 +72,7 @@ public class FServiceClientTest {
         when(protocolFactory.getProtocol(any(TMemoryOutputBuffer.class))).thenReturn(oprot);
         FServiceProvider provider = new FServiceProvider(transport, protocolFactory);
         FContext ctx = new FContext("oneway");
-        TBase<?, ?> args = mock(TBase.class); // ADDED IN THRIFT 0.10.0.  TODO: replace with org.apache.thrift.TSerializable
+        TSerializable args = mock(TSerializable.class);
 
         // Call
         FServiceClient client = new FServiceClient(provider);

--- a/lib/java/src/test/java/com/workiva/frugal/provider/FServiceClientTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/provider/FServiceClientTest.java
@@ -5,7 +5,7 @@ import com.workiva.frugal.protocol.FProtocol;
 import com.workiva.frugal.protocol.FProtocolFactory;
 import com.workiva.frugal.transport.FTransport;
 import com.workiva.frugal.transport.TMemoryOutputBuffer;
-import org.apache.thrift.TSerializable;
+import org.apache.thrift.TBase;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TMessage;
 import org.apache.thrift.protocol.TMessageType;
@@ -38,8 +38,8 @@ public class FServiceClientTest {
         when(protocolFactory.getProtocol(response)).thenReturn(iprot);
         FServiceProvider provider = new FServiceProvider(transport, protocolFactory);
         FContext ctx = new FContext("request");
-        TSerializable args = mock(TSerializable.class);
-        TSerializable res = mock(TSerializable.class);
+        TBase<?, ?> args = mock(TBase.class);
+        TBase<?, ?> res = mock(TBase.class);
 
         // Call
         FServiceClient client = new FServiceClient(provider);
@@ -72,7 +72,7 @@ public class FServiceClientTest {
         when(protocolFactory.getProtocol(any(TMemoryOutputBuffer.class))).thenReturn(oprot);
         FServiceProvider provider = new FServiceProvider(transport, protocolFactory);
         FContext ctx = new FContext("oneway");
-        TSerializable args = mock(TSerializable.class);
+        TBase<?, ?> args = mock(TBase.class);
 
         // Call
         FServiceClient client = new FServiceClient(provider);

--- a/test/integration/java/frugal-integration-test/pom.xml
+++ b/test/integration/java/frugal-integration-test/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.9.3</version>
+            <version>0.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
### Story:
Pulling in thrift 0.13.0 to patch CVE's.  Successor to #1337

CVE-2019-0210
CVE-2019-0205
CVE-2018-1320

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [x] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
Update was broken into 2 PRs, if moving to 0.13.0 is to much, consider generating code with frugal v3.10.0 first, then attempting the upgrade.

### How To Test:
Run the java examples with old and new service client configurations.

### My Test Results:

| Server Thrift Version | Client Thrift Version | Status |
|--------|-------|-------|
| v0.9.3 | v0.9.3 | ??? |
| v0.9.3 | v0.13.0 | ??? |
| v0.13.0 | v0.9.3 | ??? |
| v0.13.0 | v0.13.0 | ??? |

#### Reviewers:
@Workiva/service-platform 