### PR TITLE
SPLAT-65: GO: encapsulate Flush (thrift 0.13.0 preparation)

### DIFF
--- a/compiler/generator/golang/generator.go
+++ b/compiler/generator/golang/generator.go
@@ -1326,8 +1326,8 @@ func (g *Generator) GeneratePublisher(file *os.File, scope *parser.Scope) error 
 	}
 
 	publisher += fmt.Sprintf("type %sPublisher interface {\n", scopeCamel)
-	// publisher += "\tOpen() error\n"
-	// publisher += "\tClose() error\n"
+	publisher += "\tOpen() error\n"
+	publisher += "\tClose() error\n"
 	for _, op := range scope.Operations {
 		publisher += fmt.Sprintf("\tPublish%s(ctx frugal.FContext, %sreq %s) error\n", op.Name, args, g.getGoTypeFromThriftType(op.Type))
 	}
@@ -1351,6 +1351,9 @@ func (g *Generator) GeneratePublisher(file *os.File, scope *parser.Scope) error 
 	}
 	publisher += "\treturn publisher\n"
 	publisher += "}\n\n"
+
+	publisher += fmt.Sprintf("func (p %sPublisher) Open() error { return p.client.Open() }\n", scopeLower)
+	publisher += fmt.Sprintf("func (p %sPublisher) Close() error { return p.client.Close() }\n\n", scopeLower)
 
 	prefix := ""
 	for _, op := range scope.Operations {

--- a/examples/go/gen-go/v1/music/f_albumwinners_scope.go
+++ b/examples/go/gen-go/v1/music/f_albumwinners_scope.go
@@ -14,8 +14,6 @@ import (
 // semantics. Subscribers to this scope will be notified if they win a contest.
 // Scopes must have a prefix.
 type AlbumWinnersPublisher interface {
-	Open() error
-	Close() error
 	PublishContestStart(ctx frugal.FContext, req []*Album) error
 	PublishTimeLeft(ctx frugal.FContext, req Minutes) error
 	PublishWinner(ctx frugal.FContext, req *Album) error
@@ -28,7 +26,7 @@ type albumWinnersPublisher struct {
 
 func NewAlbumWinnersPublisher(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) AlbumWinnersPublisher {
 	publisher := &albumWinnersPublisher{
-		client:  frugal.NewFPublisherClient(provider),
+		client:  frugal.NewFScopeClient(provider),
 		methods: make(map[string]*frugal.Method),
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
@@ -48,8 +46,9 @@ func (p *albumWinnersPublisher) PublishContestStart(ctx frugal.FContext, req []*
 
 func (p *albumWinnersPublisher) publishContestStart(ctx frugal.FContext, req []*Album) error {
 	prefix := "v1.music."
+	op := "ContestStart"
 	topic := fmt.Sprintf("%sAlbumWinners.%s", prefix, op)
-	return p.client.Publish(ctx, "ContestStart", topic, albumWinnersContestStartMessage(req))
+	return p.client.Publish(ctx, op, topic, albumWinnersContestStartMessage(req))
 }
 
 type albumWinnersContestStartMessage []*Album
@@ -69,7 +68,7 @@ func (p albumWinnersContestStartMessage) Write(oprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p albumWinnersContestStartMessage) Read(iprot thrift.TProcotol) error {
+func (p albumWinnersContestStartMessage) Read(iprot thrift.TProtocol) error {
 	panic("Not Implemented!")
 }
 
@@ -83,8 +82,9 @@ func (p *albumWinnersPublisher) PublishTimeLeft(ctx frugal.FContext, req Minutes
 
 func (p *albumWinnersPublisher) publishTimeLeft(ctx frugal.FContext, req Minutes) error {
 	prefix := "v1.music."
+	op := "TimeLeft"
 	topic := fmt.Sprintf("%sAlbumWinners.%s", prefix, op)
-	return p.client.Publish(ctx, "TimeLeft", topic, albumWinnersTimeLeftMessage(req))
+	return p.client.Publish(ctx, op, topic, albumWinnersTimeLeftMessage(req))
 }
 
 type albumWinnersTimeLeftMessage Minutes
@@ -96,7 +96,7 @@ func (p albumWinnersTimeLeftMessage) Write(oprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p albumWinnersTimeLeftMessage) Read(iprot thrift.TProcotol) error {
+func (p albumWinnersTimeLeftMessage) Read(iprot thrift.TProtocol) error {
 	panic("Not Implemented!")
 }
 
@@ -110,8 +110,9 @@ func (p *albumWinnersPublisher) PublishWinner(ctx frugal.FContext, req *Album) e
 
 func (p *albumWinnersPublisher) publishWinner(ctx frugal.FContext, req *Album) error {
 	prefix := "v1.music."
+	op := "Winner"
 	topic := fmt.Sprintf("%sAlbumWinners.%s", prefix, op)
-	return p.client.Publish(ctx, "Winner", topic, req)
+	return p.client.Publish(ctx, op, topic, req)
 }
 
 // Scopes are a Frugal extension to the IDL for declaring PubSub

--- a/examples/go/gen-go/v1/music/f_albumwinners_scope.go
+++ b/examples/go/gen-go/v1/music/f_albumwinners_scope.go
@@ -14,6 +14,8 @@ import (
 // semantics. Subscribers to this scope will be notified if they win a contest.
 // Scopes must have a prefix.
 type AlbumWinnersPublisher interface {
+	Open() error
+	Close() error
 	PublishContestStart(ctx frugal.FContext, req []*Album) error
 	PublishTimeLeft(ctx frugal.FContext, req Minutes) error
 	PublishWinner(ctx frugal.FContext, req *Album) error
@@ -35,6 +37,9 @@ func NewAlbumWinnersPublisher(provider *frugal.FScopeProvider, middleware ...fru
 	publisher.methods["publishWinner"] = frugal.NewMethod(publisher, publisher.publishWinner, "publishWinner", middleware)
 	return publisher
 }
+
+func (p albumWinnersPublisher) Open() error  { return p.client.Open() }
+func (p albumWinnersPublisher) Close() error { return p.client.Close() }
 
 func (p *albumWinnersPublisher) PublishContestStart(ctx frugal.FContext, req []*Album) error {
 	ret := p.methods["publishContestStart"].Invoke([]interface{}{ctx, req})

--- a/examples/go/gen-go/v1/music/f_store_service.go
+++ b/examples/go/gen-go/v1/music/f_store_service.go
@@ -129,87 +129,35 @@ type storeFBuyAlbum struct {
 
 func (p *storeFBuyAlbum) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := StoreBuyAlbumArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "buyAlbum", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "buyAlbum", err.Error())
+	}
 	result := StoreBuyAlbumResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.ASIN, args.Acct})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("buyAlbum", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "buyAlbum", typedError.Error())
 			return nil
 		}
-		switch v := err2.(type) {
+		switch v := err.(type) {
 		case *PurchasingError:
 			result.Error = v
 		default:
-			p.GetWriteMutex().Lock()
-			err2 := storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "buyAlbum", "Internal error processing buyAlbum: "+err2.Error())
-			p.GetWriteMutex().Unlock()
-			return err2
+			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "buyAlbum", "Internal error processing buyAlbum: "+err.Error())
 		}
 	} else {
 		var retval *Album = ret[0].(*Album)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "buyAlbum", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("buyAlbum", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "buyAlbum", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "buyAlbum", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "buyAlbum", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "buyAlbum", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "buyAlbum", result)
 }
 
 type storeFEnterAlbumGiveaway struct {
@@ -219,92 +167,30 @@ type storeFEnterAlbumGiveaway struct {
 func (p *storeFEnterAlbumGiveaway) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	logrus.Warn("Deprecated function 'Store.EnterAlbumGiveaway' was called by a client")
 	args := StoreEnterAlbumGiveawayArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "enterAlbumGiveaway", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "enterAlbumGiveaway", err.Error())
+	}
 	result := StoreEnterAlbumGiveawayResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.Email, args.Name})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("enterAlbumGiveaway", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "enterAlbumGiveaway", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "enterAlbumGiveaway", "Internal error processing enterAlbumGiveaway: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "enterAlbumGiveaway", "Internal error processing enterAlbumGiveaway: "+err.Error())
 	} else {
 		var retval bool = ret[0].(bool)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "enterAlbumGiveaway", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("enterAlbumGiveaway", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "enterAlbumGiveaway", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "enterAlbumGiveaway", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "enterAlbumGiveaway", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			storeWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "enterAlbumGiveaway", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
-}
-
-func storeWriteApplicationError(ctx frugal.FContext, oprot *frugal.FProtocol, type_ int32, method, message string) error {
-	x := thrift.NewTApplicationException(type_, message)
-	oprot.WriteResponseHeader(ctx)
-	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
-	x.Write(oprot)
-	oprot.WriteMessageEnd()
-	oprot.Flush()
-	return x
+	return p.SendReply(ctx, oprot, "enterAlbumGiveaway", result)
 }
 
 type StoreBuyAlbumArgs struct {

--- a/examples/go/gen-go/v1/music/f_store_service.go
+++ b/examples/go/gen-go/v1/music/f_store_service.go
@@ -132,7 +132,7 @@ func (p *storeFBuyAlbum) Process(ctx frugal.FContext, iprot, oprot *frugal.FProt
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "buyAlbum", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "buyAlbum", err.Error())
 	}
 	result := StoreBuyAlbumResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ASIN, args.Acct})
@@ -151,13 +151,13 @@ func (p *storeFBuyAlbum) Process(ctx frugal.FContext, iprot, oprot *frugal.FProt
 		case *PurchasingError:
 			result.Error = v
 		default:
-			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "buyAlbum", "Internal error processing buyAlbum: "+err.Error())
+			return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "buyAlbum", "Internal error processing buyAlbum: "+err.Error())
 		}
 	} else {
 		var retval *Album = ret[0].(*Album)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "buyAlbum", result)
+	return p.SendReply(ctx, oprot, "buyAlbum", &result)
 }
 
 type storeFEnterAlbumGiveaway struct {
@@ -170,7 +170,7 @@ func (p *storeFEnterAlbumGiveaway) Process(ctx frugal.FContext, iprot, oprot *fr
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "enterAlbumGiveaway", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "enterAlbumGiveaway", err.Error())
 	}
 	result := StoreEnterAlbumGiveawayResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.Email, args.Name})
@@ -185,12 +185,12 @@ func (p *storeFEnterAlbumGiveaway) Process(ctx frugal.FContext, iprot, oprot *fr
 			p.SendError(ctx, oprot, typedError.TypeId(), "enterAlbumGiveaway", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "enterAlbumGiveaway", "Internal error processing enterAlbumGiveaway: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "enterAlbumGiveaway", "Internal error processing enterAlbumGiveaway: "+err.Error())
 	} else {
 		var retval bool = ret[0].(bool)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "enterAlbumGiveaway", result)
+	return p.SendReply(ctx, oprot, "enterAlbumGiveaway", &result)
 }
 
 type StoreBuyAlbumArgs struct {

--- a/lib/go/client.go
+++ b/lib/go/client.go
@@ -1,0 +1,100 @@
+package frugal
+
+import "git.apache.org/thrift.git/lib/go/thrift"
+
+var _ FClient = (*FStandardClient)(nil)
+
+// FClient ...
+type FClient interface {
+	Call(ctx FContext, method string, args, result thrift.TStruct) error
+	Oneway(ctx FContext, method string, args thrift.TStruct) error
+}
+
+// FStandardClient implements FClient, and uses the standard message format for Frugal.
+type FStandardClient struct {
+	transport       FTransport
+	protocolFactory *FProtocolFactory
+}
+
+// NewFStandardClient implements FClient, and uses the standard message format for Frugal.
+func NewFStandardClient(provider *FServiceProvider) *FStandardClient {
+	return &FStandardClient{
+		transport:       provider.GetTransport(),
+		protocolFactory: provider.GetProtocolFactory(),
+	}
+}
+
+// Call invokes a service.
+func (client *FStandardClient) Call(ctx FContext, method string, args, result thrift.TStruct) error {
+	payload, err := client.prepareMessage(ctx, method, args, thrift.CALL)
+	if err != nil {
+		return err
+	}
+	resultTransport, err := client.transport.Request(ctx, payload)
+	if err != nil {
+		return err
+	}
+	iprot := client.protocolFactory.GetProtocol(resultTransport)
+	if err = iprot.ReadResponseHeader(ctx); err != nil {
+		return err
+	}
+	oMethod, mTypeID, _, err := iprot.ReadMessageBegin()
+	if err != nil {
+		return err
+	}
+	if oMethod != method {
+		return thrift.NewTApplicationException(APPLICATION_EXCEPTION_WRONG_METHOD_NAME, method+" failed: wrong method name")
+	}
+	if mTypeID == thrift.EXCEPTION {
+		error0 := thrift.NewTApplicationException(APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
+		var error1 thrift.TApplicationException
+		error1, err = error0.Read(iprot)
+		if err != nil {
+			return err
+		}
+		if err = iprot.ReadMessageEnd(); err != nil {
+			return err
+		}
+		if error1.TypeId() == APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
+			return thrift.NewTTransportException(TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
+		}
+		return error1
+	}
+	if mTypeID != thrift.REPLY {
+		return thrift.NewTApplicationException(APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, method+" failed: invalid message type")
+	}
+	if err = result.Read(iprot); err != nil {
+		return err
+	}
+	return iprot.ReadMessageEnd()
+}
+
+// Oneway ...
+func (client *FStandardClient) Oneway(ctx FContext, method string, args thrift.TStruct) error {
+	payload, err := client.prepareMessage(ctx, method, args, thrift.ONEWAY)
+	if err != nil {
+		return err
+	}
+	return client.transport.Oneway(ctx, payload)
+}
+
+func (client FStandardClient) prepareMessage(ctx FContext, method string, args thrift.TStruct, kind thrift.TMessageType) ([]byte, error) {
+	buffer := NewTMemoryOutputBuffer(client.transport.GetRequestSizeLimit())
+	oprot := client.protocolFactory.GetProtocol(buffer)
+	if err := oprot.WriteRequestHeader(ctx); err != nil {
+		return nil, err
+	}
+	if err := oprot.WriteMessageBegin(method, kind, 0); err != nil {
+		return nil, err
+	}
+	if err := args.Write(oprot); err != nil {
+		return nil, err
+	}
+	if err := oprot.WriteMessageEnd(); err != nil {
+		return nil, err
+	}
+	if err := oprot.Flush(); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}

--- a/lib/go/client.go
+++ b/lib/go/client.go
@@ -6,6 +6,8 @@ var _ FClient = (*FStandardClient)(nil)
 
 // FClient ...
 type FClient interface {
+	Open() error  // holdover from publisher refactor, remove in frugal v4
+	Close() error // holdover from publisher refactor, remvoe in frugal v4
 	Call(ctx FContext, method string, args, result thrift.TStruct) error
 	Oneway(ctx FContext, method string, args thrift.TStruct) error
 	Publish(ctx FContext, op, topic string, message thrift.TStruct) error
@@ -40,7 +42,17 @@ func NewFScopeClient(provider *FScopeProvider) *FStandardClient {
 	return client
 }
 
-// Call invokes a service.
+// Open ...
+func (client *FStandardClient) Open() error {
+	return client.publisher.Open()
+}
+
+// Close ...
+func (client *FStandardClient) Close() error {
+	return client.publisher.Close()
+}
+
+// Call invokes a service and waits for a response.
 func (client *FStandardClient) Call(ctx FContext, method string, args, result thrift.TStruct) error {
 	payload, err := client.prepareMessage(ctx, method, args, thrift.CALL)
 	if err != nil {
@@ -50,8 +62,51 @@ func (client *FStandardClient) Call(ctx FContext, method string, args, result th
 	if err != nil {
 		return err
 	}
+	return client.processReply(ctx, method, result, resultTransport)
+}
+
+// Oneway sends a message to a service, without waiting for a response.
+func (client *FStandardClient) Oneway(ctx FContext, method string, args thrift.TStruct) error {
+	payload, err := client.prepareMessage(ctx, method, args, thrift.ONEWAY)
+	if err != nil {
+		return err
+	}
+	return client.transport.Oneway(ctx, payload)
+}
+
+// Publish sends a message to a topic.
+func (client *FStandardClient) Publish(ctx FContext, op, topic string, message thrift.TStruct) error {
+	payload, err := client.prepareMessage(ctx, op, message, thrift.CALL)
+	if err != nil {
+		return err
+	}
+	return client.publisher.Publish(topic, payload)
+}
+
+func (client FStandardClient) prepareMessage(ctx FContext, method string, args thrift.TStruct, kind thrift.TMessageType) ([]byte, error) {
+	buffer := NewTMemoryOutputBuffer(client.limit)
+	oprot := client.protocolFactory.GetProtocol(buffer)
+	if err := oprot.WriteRequestHeader(ctx); err != nil {
+		return nil, err
+	}
+	if err := oprot.WriteMessageBegin(method, kind, 0); err != nil {
+		return nil, err
+	}
+	if err := args.Write(oprot); err != nil {
+		return nil, err
+	}
+	if err := oprot.WriteMessageEnd(); err != nil {
+		return nil, err
+	}
+	if err := oprot.Flush(); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}
+
+func (client FStandardClient) processReply(ctx FContext, method string, result thrift.TStruct, resultTransport thrift.TTransport) error {
 	iprot := client.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
+	if err := iprot.ReadResponseHeader(ctx); err != nil {
 		return err
 	}
 	oMethod, mTypeID, _, err := iprot.ReadMessageBegin()
@@ -83,43 +138,4 @@ func (client *FStandardClient) Call(ctx FContext, method string, args, result th
 		return err
 	}
 	return iprot.ReadMessageEnd()
-}
-
-// Oneway ...
-func (client *FStandardClient) Oneway(ctx FContext, method string, args thrift.TStruct) error {
-	payload, err := client.prepareMessage(ctx, method, args, thrift.ONEWAY)
-	if err != nil {
-		return err
-	}
-	return client.transport.Oneway(ctx, payload)
-}
-
-// Publish ...
-func (client *FStandardClient) Publish(ctx FContext, op, topic string, message thrift.TStruct) error {
-	payload, err := client.prepareMessage(ctx, op, message, thrift.CALL)
-	if err != nil {
-		return err
-	}
-	return client.publisher.Publish(topic, payload)
-}
-
-func (client FStandardClient) prepareMessage(ctx FContext, method string, args thrift.TStruct, kind thrift.TMessageType) ([]byte, error) {
-	buffer := NewTMemoryOutputBuffer(client.limit)
-	oprot := client.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return nil, err
-	}
-	if err := oprot.WriteMessageBegin(method, kind, 0); err != nil {
-		return nil, err
-	}
-	if err := args.Write(oprot); err != nil {
-		return nil, err
-	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return nil, err
-	}
-	if err := oprot.Flush(); err != nil {
-		return nil, err
-	}
-	return buffer.Bytes(), nil
 }

--- a/lib/go/client_test.go
+++ b/lib/go/client_test.go
@@ -1,0 +1,160 @@
+package frugal
+
+import (
+	"testing"
+
+	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+var (
+	_ FPublisherTransport = (*mockFPublisherTransport)(nil)
+	_ thrift.TStruct      = (*mockTStruct)(nil)
+)
+
+type mockFPublisherTransport struct {
+	mock.Mock
+}
+
+func (m *mockFPublisherTransport) Open() error               { return m.Called().Error(0) }
+func (m *mockFPublisherTransport) Close() error              { return m.Called().Error(0) }
+func (m *mockFPublisherTransport) IsOpen() bool              { return m.Called().Bool(0) }
+func (m *mockFPublisherTransport) GetPublishSizeLimit() uint { return m.Called().Get(0).(uint) }
+func (m *mockFPublisherTransport) Publish(topic string, body []byte) error {
+	return m.Called(topic, body).Error(0)
+}
+
+type mockTStruct struct {
+	mock.Mock
+}
+
+func (m *mockTStruct) Read(iprot thrift.TProtocol) error  { return m.Called(iprot).Error(0) }
+func (m *mockTStruct) Write(oprot thrift.TProtocol) error { return m.Called(oprot).Error(0) }
+
+func TestFStandardClient(t *testing.T) {
+	transport := new(mockFTransport)
+	mockTProtocolFactory := new(mockTProtocolFactory)
+	protoFactory := NewFProtocolFactory(mockTProtocolFactory)
+	provider := NewFServiceProvider(transport, protoFactory)
+	transport.On("GetRequestSizeLimit").Return(uint(100))
+
+	out := NewFStandardClient(provider)
+	assert.Equal(t, out.transport, transport)
+	assert.Equal(t, out.protocolFactory, protoFactory)
+	assert.Equal(t, out.limit, uint(100))
+}
+
+func TestFScopeClient(t *testing.T) {
+	mockPublisherTransportFactory := new(mockFPublisherTransportFactory)
+	mockTProtocolFactory := new(mockTProtocolFactory)
+	protoFactory := NewFProtocolFactory(mockTProtocolFactory)
+	provider := NewFScopeProvider(mockPublisherTransportFactory, nil, protoFactory)
+	publisherTransport := new(fNatsPublisherTransport)
+	mockPublisherTransportFactory.On("GetTransport").Return(publisherTransport)
+
+	out := NewFScopeClient(provider)
+	assert.Equal(t, out.publisher, publisherTransport)
+	assert.Equal(t, out.protocolFactory, protoFactory)
+	assert.Equal(t, out.limit, uint(natsMaxMessageSize))
+}
+
+func TestFClientOpen(t *testing.T) {
+	publisher := new(mockFPublisherTransport)
+	client := &FStandardClient{publisher: publisher}
+	publisher.On("Open").Return(nil)
+	assert.NoError(t, client.Open())
+	publisher.AssertExpectations(t)
+}
+
+func TestFClientClose(t *testing.T) {
+	publisher := new(mockFPublisherTransport)
+	client := &FStandardClient{publisher: publisher}
+	publisher.On("Close").Return(nil)
+	assert.NoError(t, client.Close())
+	publisher.AssertExpectations(t)
+}
+
+func TestFClientPublish(t *testing.T) {
+	obj := new(mockTStruct)
+	publisher := new(mockFPublisherTransport)
+	mockTProtocolFactory := new(mockTProtocolFactory)
+	protoFactory := NewFProtocolFactory(mockTProtocolFactory)
+	client := &FStandardClient{
+		publisher:       publisher,
+		protocolFactory: protoFactory,
+	}
+	mockTransport := new(mockFTransport)
+	proto := thrift.NewTJSONProtocol(mockTransport)
+	ctx := NewFContext("uuid")
+
+	mockTProtocolFactory.On("GetProtocol", mock.Anything).Return(proto)
+	mockTransport.On("Write", mock.Anything).Return(55, nil)
+	obj.On("Write", mock.Anything).Return(nil)
+	mockTransport.On("Flush").Return(nil)
+	publisher.On("Publish", "topic", []byte{0, 0, 0, 0}).Return(nil)
+
+	assert.NoError(t, client.Publish(ctx, "op", "topic", obj))
+
+	publisher.AssertExpectations(t)
+	mockTProtocolFactory.AssertExpectations(t)
+	mockTransport.AssertExpectations(t)
+	obj.AssertExpectations(t)
+}
+
+func TestFClientOneway(t *testing.T) {
+	ctx := NewFContext("uuid")
+	obj := new(mockTStruct)
+	mockTProtocolFactory := new(mockTProtocolFactory)
+	protoFactory := NewFProtocolFactory(mockTProtocolFactory)
+	transport := new(mockFTransport)
+	client := &FStandardClient{
+		transport:       transport,
+		protocolFactory: protoFactory,
+	}
+	mockTransport := new(mockFTransport)
+	proto := thrift.NewTJSONProtocol(mockTransport)
+
+	mockTProtocolFactory.On("GetProtocol", mock.Anything).Return(proto)
+	mockTransport.On("Write", mock.Anything).Return(55, nil)
+	obj.On("Write", mock.Anything).Return(nil)
+	mockTransport.On("Flush").Return(nil)
+	transport.On("Oneway").Return(nil)
+
+	assert.NoError(t, client.Oneway(ctx, "method", obj))
+
+	obj.AssertExpectations(t)
+	mockTProtocolFactory.AssertExpectations(t)
+	mockTransport.AssertExpectations(t)
+	transport.AssertExpectations(t)
+}
+
+func TestFClientCall(t *testing.T) {
+	t.Skip("fails")
+	ctx := NewFContext("uuid")
+	args := new(mockTStruct)
+	result := new(mockTStruct)
+	mockTProtocolFactory := new(mockTProtocolFactory)
+	protoFactory := NewFProtocolFactory(mockTProtocolFactory)
+	transport := new(mockFTransport)
+	client := &FStandardClient{
+		transport:       transport,
+		protocolFactory: protoFactory,
+	}
+	mockTransport := new(mockFTransport)
+	proto := thrift.NewTJSONProtocol(mockTransport)
+
+	mockTProtocolFactory.On("GetProtocol", mock.Anything).Return(proto)
+	mockTransport.On("Write", mock.Anything).Return(55, nil)
+	args.On("Write", mock.Anything).Return(nil)
+	mockTransport.On("Flush").Return(nil)
+	transport.On("Request").Return(nil)
+
+	assert.NoError(t, client.Call(ctx, "method", args, result))
+
+	args.AssertExpectations(t)
+	result.AssertExpectations(t)
+	mockTProtocolFactory.AssertExpectations(t)
+	mockTransport.AssertExpectations(t)
+	transport.AssertExpectations(t)
+}

--- a/lib/go/go.mod
+++ b/lib/go/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/Sirupsen/logrus v0.11.5
 	github.com/go-stomp/stomp v2.0.6+incompatible
 	github.com/mattrobenolt/gocql v0.0.0-20130828033103-56c5a46b65ee
+	github.com/nats-io/gnatsd v1.4.1
 	github.com/nats-io/go-nats v0.0.0-20161120202126-6b6bf392d34d
 	github.com/nats-io/nats-server/v2 v2.1.7
 	github.com/stretchr/testify v1.6.1

--- a/lib/go/processor.go
+++ b/lib/go/processor.go
@@ -179,6 +179,8 @@ func NewFBaseProcessorFunction(writeMu *sync.Mutex, handler *Method) *FBaseProce
 
 // GetWriteMutex returns the Mutex which should be used to synchronize access
 // to the output FProtocol.
+//
+// Deprecated: use SendError or SendReply instead!
 func (f *FBaseProcessorFunction) GetWriteMutex() *sync.Mutex {
 	return f.writeMu
 }
@@ -192,4 +194,52 @@ func (f *FBaseProcessorFunction) AddMiddleware(middleware ServiceMiddleware) {
 // InvokeMethod invokes the handler method.
 func (f *FBaseProcessorFunction) InvokeMethod(args []interface{}) Results {
 	return f.handler.Invoke(args)
+}
+
+// SendError writes the error to the desired transport
+func (f *FBaseProcessorFunction) SendError(ctx FContext, oprot *FProtocol, kind int32, method, message string) error {
+	f.writeMu.Lock()
+	err := f.sendError(ctx, oprot, kind, method, message)
+	f.writeMu.Unlock()
+	return err
+}
+
+func (f *FBaseProcessorFunction) sendError(ctx FContext, oprot *FProtocol, kind int32, method, message string) error {
+	err := thrift.NewTApplicationException(kind, message)
+	oprot.WriteResponseHeader(ctx)
+	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
+	err.Write(oprot)
+	oprot.WriteMessageEnd()
+	oprot.Flush()
+	return err
+}
+
+// SendReply ...
+func (f *FBaseProcessorFunction) SendReply(ctx FContext, oprot *FProtocol, method string, result thrift.TStruct) error {
+	f.writeMu.Lock()
+	defer f.writeMu.Unlock()
+	if err := oprot.WriteResponseHeader(ctx); err != nil {
+		return f.trapError(ctx, oprot, method, err)
+	}
+	if err := oprot.WriteMessageBegin(method, thrift.REPLY, 0); err != nil {
+		return f.trapError(ctx, oprot, method, err)
+	}
+	if err := result.Write(oprot); err != nil {
+		return f.trapError(ctx, oprot, method, err)
+	}
+	if err := oprot.WriteMessageEnd(); err != nil {
+		return f.trapError(ctx, oprot, method, err)
+	}
+	if err := oprot.Flush(); err != nil {
+		return f.trapError(ctx, oprot, method, err)
+	}
+	return nil
+}
+
+func (f *FBaseProcessorFunction) trapError(ctx FContext, oprot *FProtocol, method string, err error) error {
+	if IsErrTooLarge(err) {
+		f.sendError(ctx, oprot, APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, method, err.Error())
+		return nil
+	}
+	return err
 }

--- a/lib/go/processor_test.go
+++ b/lib/go/processor_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
@@ -261,4 +262,24 @@ func TestFBaseProcessorAnnotations(t *testing.T) {
 	annoMap = processor.Annotations()
 	assert.Equal("baz", annoMap["foo"]["bar"])
 	assert.Equal("boom", annoMap["foo"]["boosh"])
+}
+
+func TestFBaseProcessorFunctionSendError(t *testing.T) {
+	ctx := NewFContext("guid")
+	fn := &FBaseProcessorFunction{writeMu: &sync.Mutex{}}
+	buffer := NewTMemoryOutputBuffer(100)
+	proto := &FProtocol{TProtocol: thrift.NewTJSONProtocol(buffer)}
+	assert.EqualError(t, fn.SendError(ctx, proto, 0, "method", "message"), "message")
+	assert.Equal(t, string(buffer.Bytes()[9:]), `[1,"method",3,0,{"1":{"str":"message"},"2":{"i32":0}}]`)
+}
+
+func TestFBaseProcessorFunctionSendReply(t *testing.T) {
+	ctx := NewFContext("guid")
+	fn := &FBaseProcessorFunction{writeMu: &sync.Mutex{}}
+	buffer := NewTMemoryOutputBuffer(100)
+	proto := &FProtocol{TProtocol: thrift.NewTJSONProtocol(buffer)}
+	obj := new(mockTStruct)
+	obj.On("Write", mock.Anything).Return(nil)
+	assert.NoError(t, fn.SendReply(ctx, proto, "method", obj))
+	assert.Equal(t, string(buffer.Bytes()[9:]), `[1,"method",2,0]`)
 }

--- a/lib/gopherjs/frugal/client.go
+++ b/lib/gopherjs/frugal/client.go
@@ -1,0 +1,141 @@
+package frugal
+
+import "github.com/Workiva/frugal/lib/gopherjs/thrift"
+
+var _ FClient = (*FStandardClient)(nil)
+
+// FClient ...
+type FClient interface {
+	Open() error  // holdover from publisher refactor, remove in frugal v4
+	Close() error // holdover from publisher refactor, remvoe in frugal v4
+	Call(ctx FContext, method string, args, result thrift.TStruct) error
+	Oneway(ctx FContext, method string, args thrift.TStruct) error
+	Publish(ctx FContext, op, topic string, message thrift.TStruct) error
+}
+
+// FStandardClient implements FClient, and uses the standard message format for Frugal.
+type FStandardClient struct {
+	transport       FTransport
+	publisher       FPublisherTransport
+	protocolFactory *FProtocolFactory
+	limit           uint
+}
+
+// NewFStandardClient implements FClient, and uses the standard message format for Frugal.
+func NewFStandardClient(provider *FServiceProvider) *FStandardClient {
+	client := &FStandardClient{
+		transport:       provider.GetTransport(),
+		protocolFactory: provider.GetProtocolFactory(),
+	}
+	client.limit = client.transport.GetRequestSizeLimit()
+	return client
+}
+
+// NewFScopeClient ...
+func NewFScopeClient(provider *FScopeProvider) *FStandardClient {
+	transport, protocolFactory := provider.NewPublisher()
+	client := &FStandardClient{
+		publisher:       transport,
+		protocolFactory: protocolFactory,
+	}
+	client.limit = client.publisher.GetPublishSizeLimit()
+	return client
+}
+
+// Open ...
+func (client *FStandardClient) Open() error {
+	return client.publisher.Open()
+}
+
+// Close ...
+func (client *FStandardClient) Close() error {
+	return client.publisher.Close()
+}
+
+// Call invokes a service and waits for a response.
+func (client *FStandardClient) Call(ctx FContext, method string, args, result thrift.TStruct) error {
+	payload, err := client.prepareMessage(ctx, method, args, thrift.CALL)
+	if err != nil {
+		return err
+	}
+	resultTransport, err := client.transport.Request(ctx, payload)
+	if err != nil {
+		return err
+	}
+	return client.processReply(ctx, method, result, resultTransport)
+}
+
+// Oneway sends a message to a service, without waiting for a response.
+func (client *FStandardClient) Oneway(ctx FContext, method string, args thrift.TStruct) error {
+	payload, err := client.prepareMessage(ctx, method, args, thrift.ONEWAY)
+	if err != nil {
+		return err
+	}
+	return client.transport.Oneway(ctx, payload)
+}
+
+// Publish sends a message to a topic.
+func (client *FStandardClient) Publish(ctx FContext, op, topic string, message thrift.TStruct) error {
+	payload, err := client.prepareMessage(ctx, op, message, thrift.CALL)
+	if err != nil {
+		return err
+	}
+	return client.publisher.Publish(topic, payload)
+}
+
+func (client FStandardClient) prepareMessage(ctx FContext, method string, args thrift.TStruct, kind thrift.TMessageType) ([]byte, error) {
+	buffer := NewTMemoryOutputBuffer(client.limit)
+	oprot := client.protocolFactory.GetProtocol(buffer)
+	if err := oprot.WriteRequestHeader(ctx); err != nil {
+		return nil, err
+	}
+	if err := oprot.WriteMessageBegin(method, kind, 0); err != nil {
+		return nil, err
+	}
+	if err := args.Write(oprot); err != nil {
+		return nil, err
+	}
+	if err := oprot.WriteMessageEnd(); err != nil {
+		return nil, err
+	}
+	if err := oprot.Flush(); err != nil {
+		return nil, err
+	}
+	return buffer.Bytes(), nil
+}
+
+func (client FStandardClient) processReply(ctx FContext, method string, result thrift.TStruct, resultTransport thrift.TTransport) error {
+	iprot := client.protocolFactory.GetProtocol(resultTransport)
+	if err := iprot.ReadResponseHeader(ctx); err != nil {
+		return err
+	}
+	oMethod, mTypeID, _, err := iprot.ReadMessageBegin()
+	if err != nil {
+		return err
+	}
+	if oMethod != method {
+		return thrift.NewTApplicationException(APPLICATION_EXCEPTION_WRONG_METHOD_NAME, method+" failed: wrong method name")
+	}
+	if mTypeID == thrift.EXCEPTION {
+		error0 := thrift.NewTApplicationException(APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
+		var error1 thrift.TApplicationException
+		error1, err = error0.Read(iprot)
+		if err != nil {
+			return err
+		}
+		if err = iprot.ReadMessageEnd(); err != nil {
+			return err
+		}
+		if error1.TypeId() == APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
+			return thrift.NewTTransportException(TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
+		}
+		return error1
+	}
+	if mTypeID != thrift.REPLY {
+		return thrift.NewTApplicationException(APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, method+" failed: invalid message type")
+	}
+	if err = result.Read(iprot); err != nil {
+		return err
+	}
+	return iprot.ReadMessageEnd()
+}

--- a/lib/gopherjs/frugal/client_test.go
+++ b/lib/gopherjs/frugal/client_test.go
@@ -1,0 +1,168 @@
+package frugal
+
+import (
+	"testing"
+
+	"github.com/Workiva/frugal/lib/gopherjs/thrift"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+var (
+	_ FPublisherTransport = (*mockFPublisherTransport)(nil)
+	_ thrift.TStruct      = (*mockTStruct)(nil)
+)
+
+type mockFPublisherTransport struct {
+	mock.Mock
+}
+
+func (m *mockFPublisherTransport) Open() error               { return m.Called().Error(0) }
+func (m *mockFPublisherTransport) Close() error              { return m.Called().Error(0) }
+func (m *mockFPublisherTransport) IsOpen() bool              { return m.Called().Bool(0) }
+func (m *mockFPublisherTransport) GetPublishSizeLimit() uint { return m.Called().Get(0).(uint) }
+func (m *mockFPublisherTransport) Publish(topic string, body []byte) error {
+	return m.Called(topic, body).Error(0)
+}
+
+type mockTStruct struct {
+	mock.Mock
+}
+
+func (m *mockTStruct) Read(iprot thrift.TProtocol) error  { return m.Called(iprot).Error(0) }
+func (m *mockTStruct) Write(oprot thrift.TProtocol) error { return m.Called(oprot).Error(0) }
+
+func TestFStandardClient(t *testing.T) {
+	transport := new(mockFTransport)
+	mockTProtocolFactory := new(mockTProtocolFactory)
+	protoFactory := NewFProtocolFactory(mockTProtocolFactory)
+	provider := NewFServiceProvider(transport, protoFactory)
+	transport.On("GetRequestSizeLimit").Return(uint(100))
+
+	out := NewFStandardClient(provider)
+	assert.Equal(t, out.transport, transport)
+	assert.Equal(t, out.protocolFactory, protoFactory)
+	assert.Equal(t, out.limit, uint(100))
+}
+
+func TestFScopeClient(t *testing.T) {
+	mockPublisherTransportFactory := new(mockFPublisherTransportFactory)
+	mockTProtocolFactory := new(mockTProtocolFactory)
+	protoFactory := NewFProtocolFactory(mockTProtocolFactory)
+	provider := NewFScopeProvider(mockPublisherTransportFactory, nil, protoFactory)
+	publisherTransport := new(fNatsPublisherTransport)
+	mockPublisherTransportFactory.On("GetTransport").Return(publisherTransport)
+
+	out := NewFScopeClient(provider)
+	assert.Equal(t, out.publisher, publisherTransport)
+	assert.Equal(t, out.protocolFactory, protoFactory)
+	assert.Equal(t, out.limit, uint(natsMaxMessageSize))
+}
+
+func TestFClientOpen(t *testing.T) {
+	publisher := new(mockFPublisherTransport)
+	client := &FStandardClient{publisher: publisher}
+	publisher.On("Open").Return(nil)
+	assert.NoError(t, client.Open())
+	publisher.AssertExpectations(t)
+}
+
+func TestFClientClose(t *testing.T) {
+	publisher := new(mockFPublisherTransport)
+	client := &FStandardClient{publisher: publisher}
+	publisher.On("Close").Return(nil)
+	assert.NoError(t, client.Close())
+	publisher.AssertExpectations(t)
+}
+
+func TestFClientPublish(t *testing.T) {
+	obj := new(mockTStruct)
+	publisher := new(mockFPublisherTransport)
+	mockTProtocolFactory := new(mockTProtocolFactory)
+	protoFactory := NewFProtocolFactory(mockTProtocolFactory)
+	client := &FStandardClient{
+		publisher:       publisher,
+		protocolFactory: protoFactory,
+	}
+	mockTransport := new(mockFTransport)
+	proto := thrift.NewTJSONProtocol(mockTransport)
+	ctx := NewFContext("uuid")
+
+	mockTProtocolFactory.On("GetProtocol", mock.Anything).Return(proto)
+	mockTransport.On("Write", mock.Anything).Return(55, nil)
+	obj.On("Write", mock.Anything).Return(nil)
+	mockTransport.On("Flush").Return(nil)
+	publisher.On("Publish", "topic", []byte{0, 0, 0, 0}).Return(nil)
+
+	assert.NoError(t, client.Publish(ctx, "op", "topic", obj))
+
+	publisher.AssertExpectations(t)
+	mockTProtocolFactory.AssertExpectations(t)
+	mockTransport.AssertExpectations(t)
+	obj.AssertExpectations(t)
+}
+
+func TestFClientOneway(t *testing.T) {
+	ctx := NewFContext("uuid")
+	obj := new(mockTStruct)
+	mockTProtocolFactory := new(mockTProtocolFactory)
+	protoFactory := NewFProtocolFactory(mockTProtocolFactory)
+	transport := new(mockFTransport)
+	client := &FStandardClient{
+		transport:       transport,
+		protocolFactory: protoFactory,
+	}
+	mockTransport := new(mockFTransport)
+	proto := thrift.NewTJSONProtocol(mockTransport)
+
+	mockTProtocolFactory.On("GetProtocol", mock.Anything).Return(proto)
+	mockTransport.On("Write", mock.Anything).Return(55, nil)
+	obj.On("Write", mock.Anything).Return(nil)
+	mockTransport.On("Flush").Return(nil)
+	transport.On("Oneway").Return(nil)
+
+	assert.NoError(t, client.Oneway(ctx, "method", obj))
+
+	obj.AssertExpectations(t)
+	mockTProtocolFactory.AssertExpectations(t)
+	mockTransport.AssertExpectations(t)
+	transport.AssertExpectations(t)
+}
+
+func TestFClientCall(t *testing.T) {
+	ctx := NewFContext("uuid")
+	args := new(mockTStruct)
+	result := new(mockTStruct)
+	mockTProtocolFactory := new(mockTProtocolFactory)
+	protoFactory := NewFProtocolFactory(mockTProtocolFactory)
+	transport := new(mockFTransport)
+	client := &FStandardClient{
+		transport:       transport,
+		protocolFactory: protoFactory,
+	}
+	mockTransport := new(mockFTransport)
+	proto := thrift.NewTJSONProtocol(mockTransport)
+	resultTransport := new(mockFTransport)
+
+	mockTProtocolFactory.On("GetProtocol", mock.Anything).Return(proto)
+	mockTransport.On("Write", mock.Anything).Return(55, nil)
+	args.On("Write", mock.Anything).Return(nil)
+	mockTransport.On("Flush").Return(nil)
+	transport.On("Request").Return(resultTransport, nil)
+	calls := 0
+	output := append([]byte{0, 0, 0, 0, 0}, []byte(`[1, "method", 2, 0]`)...)
+	mockTransport.On("Read", mock.Anything).Run(func(args mock.Arguments) {
+		args.Get(0).([]byte)[0] = output[calls]
+		calls++
+	}).Return(1, nil)
+	mockTransport.On("Read", mock.Anything).Run(func(args mock.Arguments) { copy(args.Get(0).([]byte), []byte("[]")) }).Return(2, nil).Once()
+	result.On("Read", mock.Anything).Return(nil)
+
+	assert.NoError(t, client.Call(ctx, "method", args, result))
+
+	args.AssertExpectations(t)
+	result.AssertExpectations(t)
+	mockTProtocolFactory.AssertExpectations(t)
+	transport.AssertExpectations(t)
+	resultTransport.AssertExpectations(t)
+}

--- a/lib/gopherjs/frugal/context.go
+++ b/lib/gopherjs/frugal/context.go
@@ -91,13 +91,40 @@ type FContext interface {
 	Timeout() time.Duration
 }
 
+// FContextWithEphemeralProperties is an extension of the FContext interface
+// with support for ephemeral properties. Ephemeral properties are a map of
+// key-value pairs that won't be serialized with the rest of the FContext.
+// TODO 4.0 add this to the FContext interface
+type FContextWithEphemeralProperties interface {
+	FContext
+
+	// Clone performs a deep copy of an FContextWithEphemeralProperties while
+	// handling opids correctly.
+	Clone() FContextWithEphemeralProperties
+
+	// EphemeralProperty gets the property associated with the given key.
+	EphemeralProperty(key interface{}) (interface{}, bool)
+
+	// EphemeralProperties returns a copy of the ephemeral properties map.
+	EphemeralProperties() map[interface{}]interface{}
+
+	// AddEphemeralProperty adds a keyp-value pair to the ephemeral properties.
+	AddEphemeralProperty(key, value interface{}) FContext
+}
+
 // Clone performs a deep copy of an FContext while handling opids correctly.
-// TODO 3.0 consider adding this to the FContext interface.
+// TODO 4.0 consider adding this to the FContext interface.
 func Clone(ctx FContext) FContext {
-	clone := &FContextImpl{
-		requestHeaders:  ctx.RequestHeaders(),
-		responseHeaders: ctx.ResponseHeaders(),
+	if fctxWEP, ok := ctx.(FContextWithEphemeralProperties); ok {
+		return fctxWEP.Clone()
 	}
+
+	clone := &FContextImpl{
+		requestHeaders:      ctx.RequestHeaders(),
+		responseHeaders:     ctx.ResponseHeaders(),
+		ephemeralProperties: make(map[interface{}]interface{}),
+	}
+
 	clone.requestHeaders[opIDHeader] = getNextOpID()
 	return clone
 }
@@ -106,9 +133,10 @@ var nextOpID uint64
 
 // FContextImpl is an implementation of FContext.
 type FContextImpl struct {
-	requestHeaders  map[string]string
-	responseHeaders map[string]string
-	mu              sync.RWMutex
+	requestHeaders      map[string]string
+	responseHeaders     map[string]string
+	ephemeralProperties map[interface{}]interface{}
+	mu                  sync.RWMutex
 }
 
 // NewFContext returns a Context for the given correlation id. If an empty
@@ -125,7 +153,8 @@ func NewFContext(correlationID string) FContext {
 			opIDHeader:    getNextOpID(),
 			timeoutHeader: strconv.FormatInt(int64(defaultTimeout/time.Millisecond), 10),
 		},
-		responseHeaders: make(map[string]string),
+		responseHeaders:     make(map[string]string),
+		ephemeralProperties: make(map[interface{}]interface{}),
 	}
 
 	return ctx
@@ -215,6 +244,45 @@ func (c *FContextImpl) Timeout() time.Duration {
 		return defaultTimeout
 	}
 	return time.Millisecond * time.Duration(timeoutMillis)
+}
+
+// Clone performs a deep copy of an FContextWithEphemeralProperties while
+// handling opids correctly.
+func (c *FContextImpl) Clone() FContextWithEphemeralProperties {
+	cloned := &FContextImpl{
+		requestHeaders:      c.RequestHeaders(),
+		responseHeaders:     c.ResponseHeaders(),
+		ephemeralProperties: c.EphemeralProperties(),
+	}
+	cloned.requestHeaders[opIDHeader] = getNextOpID()
+	return cloned
+}
+
+// EphemeralProperty gets the property associated with the given key.
+func (c *FContextImpl) EphemeralProperty(key interface{}) (interface{}, bool) {
+	c.mu.Lock()
+	value, ok := c.ephemeralProperties[key]
+	c.mu.Unlock()
+	return value, ok
+}
+
+// EphemeralProperties returns a copy of the ephemeral properties map.
+func (c *FContextImpl) EphemeralProperties() map[interface{}]interface{} {
+	c.mu.RLock()
+	properties := make(map[interface{}]interface{}, len(c.ephemeralProperties))
+	for key, value := range c.ephemeralProperties {
+		properties[key] = value
+	}
+	c.mu.RUnlock()
+	return properties
+}
+
+// AddEphemeralProperty adds a keyp-value pair to the ephemeral properties.
+func (c *FContextImpl) AddEphemeralProperty(key, value interface{}) FContext {
+	c.mu.Lock()
+	c.ephemeralProperties[key] = value
+	c.mu.Unlock()
+	return c
 }
 
 // setRequestOpID sets the request operation id for context.

--- a/lib/gopherjs/frugal/errors.go
+++ b/lib/gopherjs/frugal/errors.go
@@ -36,7 +36,7 @@ const (
 	TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE = 101
 
 	// TRANSPORT_EXCEPTION_DISCONNECTED is a TTransportException error type
-	// indicating the transport was disconnected.
+	// indicating the transport was disconnected
 	TRANSPORT_EXCEPTION_DISCONNECTED = 102
 )
 

--- a/lib/gopherjs/frugal/nats_scope_transport.go
+++ b/lib/gopherjs/frugal/nats_scope_transport.go
@@ -88,8 +88,7 @@ func (n *fNatsPublisherTransport) Close() error {
 }
 
 // GetPublishSizeLimit returns the maximum allowable size of a payload
-// to be published. A non-positive number is returned to indicate an
-// unbounded allowable size.
+// to be published. 0 is returned to indicate an unbounded allowable size.
 func (n *fNatsPublisherTransport) GetPublishSizeLimit() uint {
 	return uint(natsMaxMessageSize)
 }

--- a/lib/gopherjs/frugal/nats_scope_transport_test.go
+++ b/lib/gopherjs/frugal/nats_scope_transport_test.go
@@ -46,13 +46,13 @@ func runServer(opts *server.Options) *server.Server {
 
 	end := time.Now().Add(10 * time.Second)
 	for time.Now().Before(end) {
-		addr := s.GetListenEndpoint()
-		if addr == "" {
+		addr := s.Addr()
+		if addr == nil {
 			time.Sleep(10 * time.Millisecond)
 			// Retry. We might take a little while to open a connection.
 			continue
 		}
-		conn, err := net.Dial("tcp", addr)
+		conn, err := net.Dial("tcp", addr.String())
 		if err != nil {
 			// Retry after 50ms
 			time.Sleep(50 * time.Millisecond)

--- a/lib/gopherjs/frugal/nats_server.go
+++ b/lib/gopherjs/frugal/nats_server.go
@@ -26,25 +26,59 @@ import (
 const (
 	defaultWorkQueueLen = 64
 	defaultWatermark    = 5 * time.Second
+
+	RequestReceivedTimeKey = "request_received_time"
 )
 
 type frameWrapper struct {
-	frameBytes []byte
-	timestamp  time.Time
-	reply      string
+	frameBytes          []byte
+	reply               string
+	ephemeralProperties map[interface{}]interface{}
 }
 
 // FNatsServerBuilder configures and builds NATS server instances.
 type FNatsServerBuilder struct {
-	conn          *nats.Conn
-	processor     FProcessor
-	protoFactory  *FProtocolFactory
-	subjects      []string
-	queue         string
-	workerCount   uint
-	queueLen      uint
-	highWatermark time.Duration
+	conn              *nats.Conn
+	processor         FProcessor
+	protoFactory      *FProtocolFactory
+	subjects          []string
+	queue             string
+	workerCount       uint
+	queueLen          uint
+	highWatermark     time.Duration
+	onRequestReceived func(map[interface{}]interface{})
+	onRequestStarted  func(map[interface{}]interface{})
+	onRequestFinished func(map[interface{}]interface{})
 }
+
+// var for testing purposes
+var timeNow = time.Now
+
+// DefaultFNatsServerOnRequestReceived is the default handler called when an
+// FNatsServer receives a message. It adds the time the request was received
+// to the passed in properties.
+func DefaultFNatsServerOnRequestReceived(properties map[interface{}]interface{}) {
+	properties[RequestReceivedTimeKey] = timeNow()
+}
+
+// NewDefaultFNatsServerOnRequestStarted constructs a default handler for when
+// an FNatsServer starts processing a message. It checks the current time
+// against a start time in the passed in properties, and logs a warning if the
+// difference is over a threshold.
+func NewDefaultFNatsServerOnRequestStarted(highWatermark time.Duration) func(map[interface{}]interface{}) {
+	return func(properties map[interface{}]interface{}) {
+		if start, ok := properties[RequestReceivedTimeKey]; ok {
+			dur := time.Since(start.(time.Time))
+			if dur > highWatermark {
+				logger().Warnf("frugal: request spent %+v in the transport buffer, your consumer might be backed up", dur)
+			}
+		}
+	}
+}
+
+// DefaultFNatsServerOnRequestFinished is the default handler called when an
+// FNatsServer finishes processing a message. If does nothing
+func DefaultFNatsServerOnRequestFinished(properties map[interface{}]interface{}) {}
 
 // NewFNatsServerBuilder creates a builder which configures and builds NATS
 // server instances.
@@ -59,6 +93,44 @@ func NewFNatsServerBuilder(conn *nats.Conn, processor FProcessor,
 		queueLen:      defaultWorkQueueLen,
 		highWatermark: defaultWatermark,
 	}
+}
+
+// WithRequestReceivedEventHandler sets a function to be called when the
+// FNatsServer receives a message, but before it is put onto a work queue. The
+// properties map will be set on the FContext before processing is started.
+//
+// If the same functionality can be accomplished through middleware, middleware
+// is preferred as it is more flexible and more portable between different
+// servers. This function should only handle events and behaviour specific to
+// an FNatsServer that aren't applicable to other frugal servers.
+func (f *FNatsServerBuilder) WithRequestReceivedEventHandler(handler func(map[interface{}]interface{})) *FNatsServerBuilder {
+	f.onRequestReceived = handler
+	return f
+}
+
+// WithRequestStartedEventHandler sets a function to be called before the
+// FNatsServer processes a message. The properties map will be set on the
+// FContext before processing begins.
+//
+// If the same functionality can be accomplished through middleware, middleware
+// is preferred as it is more flexible and more portable between different
+// servers. This function should only handle events and behaviour specific to
+// an FNatsServer that aren't applicable to other frugal servers.
+func (f *FNatsServerBuilder) WithRequestStartedEventHandler(handler func(map[interface{}]interface{})) *FNatsServerBuilder {
+	f.onRequestStarted = handler
+	return f
+}
+
+// WithRequestFinishedEventHandler sets a function to be called after the
+// FNatsServer processes a message.
+//
+// If the same functionality can be accomplished through middleware, middleware
+// is preferred as it is more flexible and more portable between different
+// servers. This function should only handle events and behaviour specific to
+// an FNatsServer that aren't applicable to other frugal servers.
+func (f *FNatsServerBuilder) WithRequestFinishedEventHandler(handler func(map[interface{}]interface{})) *FNatsServerBuilder {
+	f.onRequestFinished = handler
+	return f
 }
 
 // WithQueueGroup adds a NATS queue group to receive requests on.
@@ -89,31 +161,46 @@ func (f *FNatsServerBuilder) WithHighWatermark(highWatermark time.Duration) *FNa
 
 // Build a new configured NATS FServer.
 func (f *FNatsServerBuilder) Build() FServer {
+	if f.onRequestReceived == nil {
+		f.onRequestReceived = DefaultFNatsServerOnRequestReceived
+	}
+	if f.onRequestStarted == nil {
+		f.onRequestStarted = NewDefaultFNatsServerOnRequestStarted(f.highWatermark)
+	}
+	if f.onRequestFinished == nil {
+		f.onRequestFinished = DefaultFNatsServerOnRequestFinished
+	}
+
 	return &fNatsServer{
-		conn:          f.conn,
-		processor:     f.processor,
-		protoFactory:  f.protoFactory,
-		subjects:      f.subjects,
-		queue:         f.queue,
-		workerCount:   f.workerCount,
-		workC:         make(chan *frameWrapper, f.queueLen),
-		quit:          make(chan struct{}),
-		highWatermark: f.highWatermark,
+		conn:              f.conn,
+		processor:         f.processor,
+		protoFactory:      f.protoFactory,
+		subjects:          f.subjects,
+		queue:             f.queue,
+		workerCount:       f.workerCount,
+		workC:             make(chan *frameWrapper, f.queueLen),
+		quit:              make(chan struct{}),
+		onRequestReceived: f.onRequestReceived,
+		onRequestStarted:  f.onRequestStarted,
+		onRequestFinished: f.onRequestFinished,
 	}
 }
 
 // fNatsServer implements FServer by using NATS as the underlying transport.
 // Clients must connect with the transport created by NewNatsFTransport.
 type fNatsServer struct {
-	conn          *nats.Conn
-	processor     FProcessor
-	protoFactory  *FProtocolFactory
-	subjects      []string
-	queue         string
-	workerCount   uint
-	workC         chan *frameWrapper
-	quit          chan struct{}
-	highWatermark time.Duration
+	conn         *nats.Conn
+	processor    FProcessor
+	protoFactory *FProtocolFactory
+	subjects     []string
+	queue        string
+	workerCount  uint
+	workC        chan *frameWrapper
+	quit         chan struct{}
+
+	onRequestReceived func(map[interface{}]interface{})
+	onRequestStarted  func(map[interface{}]interface{})
+	onRequestFinished func(map[interface{}]interface{})
 }
 
 // Serve starts the server.
@@ -151,12 +238,15 @@ func (f *fNatsServer) Stop() error {
 // handler is invoked when a request is received. The request is placed on the
 // work channel which is processed by a worker goroutine.
 func (f *fNatsServer) handler(msg *nats.Msg) {
+	ephemeralProperties := make(map[interface{}]interface{})
+	f.onRequestReceived(ephemeralProperties)
+
 	if msg.Reply == "" {
 		logger().Warn("frugal: discarding invalid NATS request (no reply)")
 		return
 	}
 	select {
-	case f.workC <- &frameWrapper{frameBytes: msg.Data, timestamp: time.Now(), reply: msg.Reply}:
+	case f.workC <- &frameWrapper{frameBytes: msg.Data, reply: msg.Reply, ephemeralProperties: ephemeralProperties}:
 	case <-f.quit:
 		return
 	}
@@ -170,25 +260,24 @@ func (f *fNatsServer) worker() {
 		case <-f.quit:
 			return
 		case frame := <-f.workC:
-			dur := time.Since(frame.timestamp)
-			if dur > f.highWatermark {
-				logger().Warnf("frugal: request spent %+v in the transport buffer, your consumer might be backed up", dur)
-			}
-			if err := f.processFrame(frame.frameBytes, frame.reply); err != nil {
+			f.onRequestStarted(frame.ephemeralProperties)
+			if err := f.processFrame(frame); err != nil {
 				logger().Errorf("frugal: error processing request: %s", err.Error())
 			}
+			f.onRequestFinished(frame.ephemeralProperties)
 		}
 	}
 }
 
 // processFrame invokes the FProcessor and sends the response on the given
 // subject.
-func (f *fNatsServer) processFrame(frame []byte, reply string) error {
+func (f *fNatsServer) processFrame(frame *frameWrapper) error {
 	// Read and process frame.
-	input := &thrift.TMemoryBuffer{Buffer: bytes.NewBuffer(frame[4:])} // Discard frame size
+	input := &thrift.TMemoryBuffer{Buffer: bytes.NewBuffer(frame.frameBytes[4:])} // Discard frame size
 	// Only allow 1MB to be buffered.
 	output := NewTMemoryOutputBuffer(natsMaxMessageSize)
 	iprot := f.protoFactory.GetProtocol(input)
+	iprot.ephemeralProperties = frame.ephemeralProperties
 	oprot := f.protoFactory.GetProtocol(output)
 	if err := f.processor.Process(iprot, oprot); err != nil {
 		return err
@@ -199,5 +288,5 @@ func (f *fNatsServer) processFrame(frame []byte, reply string) error {
 	}
 
 	// Send response.
-	return f.conn.Publish(reply, output.Bytes())
+	return f.conn.Publish(frame.reply, output.Bytes())
 }

--- a/lib/gopherjs/frugal/nats_server_test.go
+++ b/lib/gopherjs/frugal/nats_server_test.go
@@ -23,6 +23,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDefaultFNatsServerOnRequestReceived(t *testing.T) {
+	testingTime := time.Unix(1556627378, 0)
+	oldTimeNow := timeNow
+	defer func() {
+		timeNow = oldTimeNow
+	}()
+	timeNow = func() time.Time {
+		return testingTime
+	}
+
+	properties := make(map[interface{}]interface{})
+	DefaultFNatsServerOnRequestReceived(properties)
+	assert.Equal(t, testingTime, properties[RequestReceivedTimeKey])
+}
+
 // Ensures FStatelessNatsServer receives requests and sends back responses on
 // the correct subject.
 func TestFStatelessNatsServer(t *testing.T) {

--- a/lib/gopherjs/frugal/nats_transport_test.go
+++ b/lib/gopherjs/frugal/nats_transport_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 type mockRegistry struct {
-	frameC chan ([]byte)
+	frameC chan []byte
 	err    error
 }
 
@@ -246,13 +246,16 @@ func newClientAndServer(t *testing.T, isTTransport bool) (*fNatsTransport, *fNat
 	server := NewFNatsServerBuilder(conn, mockProcessor, protocolFactory, []string{"foo"}).
 		WithQueueGroup("queue").
 		WithWorkerCount(1).
+		WithRequestReceivedEventHandler(func(map[interface{}]interface{}) {}).
+		WithRequestStartedEventHandler(func(map[interface{}]interface{}) {}).
 		Build()
 	mockTransport := new(mockFTransport)
 	proto := thrift.NewTJSONProtocol(mockTransport)
 	mockTProtocolFactory.On("GetProtocol", mock.AnythingOfType("*thrift.TMemoryBuffer")).Return(proto).Once()
 	mockTProtocolFactory.On("GetProtocol", mock.AnythingOfType("*frugal.TMemoryOutputBuffer")).Return(proto).Once()
-	fproto := &FProtocol{proto}
-	mockProcessor.On("Process", fproto, fproto).Return(nil)
+	inputFproto := &FProtocol{TProtocol: proto, ephemeralProperties: make(map[interface{}]interface{})}
+	outputPproto := &FProtocol{TProtocol: proto, ephemeralProperties: make(map[interface{}]interface{})}
+	mockProcessor.On("Process", inputFproto, outputPproto).Return(nil)
 
 	go func() {
 		assert.Nil(t, server.Serve())

--- a/lib/gopherjs/frugal/processor.go
+++ b/lib/gopherjs/frugal/processor.go
@@ -176,6 +176,8 @@ func NewFBaseProcessorFunction(writeMu *sync.Mutex, handler *Method) *FBaseProce
 
 // GetWriteMutex returns the Mutex which should be used to synchronize access
 // to the output FProtocol.
+//
+// Deprecated: use SendError or SendReply instead!
 func (f *FBaseProcessorFunction) GetWriteMutex() *sync.Mutex {
 	return f.writeMu
 }
@@ -189,4 +191,52 @@ func (f *FBaseProcessorFunction) AddMiddleware(middleware ServiceMiddleware) {
 // InvokeMethod invokes the handler method.
 func (f *FBaseProcessorFunction) InvokeMethod(args []interface{}) Results {
 	return f.handler.Invoke(args)
+}
+
+// SendError writes the error to the desired transport
+func (f *FBaseProcessorFunction) SendError(ctx FContext, oprot *FProtocol, kind int32, method, message string) error {
+	f.writeMu.Lock()
+	err := f.sendError(ctx, oprot, kind, method, message)
+	f.writeMu.Unlock()
+	return err
+}
+
+func (f *FBaseProcessorFunction) sendError(ctx FContext, oprot *FProtocol, kind int32, method, message string) error {
+	err := thrift.NewTApplicationException(kind, message)
+	oprot.WriteResponseHeader(ctx)
+	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
+	err.Write(oprot)
+	oprot.WriteMessageEnd()
+	oprot.Flush()
+	return err
+}
+
+// SendReply ...
+func (f *FBaseProcessorFunction) SendReply(ctx FContext, oprot *FProtocol, method string, result thrift.TStruct) error {
+	f.writeMu.Lock()
+	defer f.writeMu.Unlock()
+	if err := oprot.WriteResponseHeader(ctx); err != nil {
+		return f.trapError(ctx, oprot, method, err)
+	}
+	if err := oprot.WriteMessageBegin(method, thrift.REPLY, 0); err != nil {
+		return f.trapError(ctx, oprot, method, err)
+	}
+	if err := result.Write(oprot); err != nil {
+		return f.trapError(ctx, oprot, method, err)
+	}
+	if err := oprot.WriteMessageEnd(); err != nil {
+		return f.trapError(ctx, oprot, method, err)
+	}
+	if err := oprot.Flush(); err != nil {
+		return f.trapError(ctx, oprot, method, err)
+	}
+	return nil
+}
+
+func (f *FBaseProcessorFunction) trapError(ctx FContext, oprot *FProtocol, method string, err error) error {
+	if IsErrTooLarge(err) {
+		f.sendError(ctx, oprot, APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, method, err.Error())
+		return nil
+	}
+	return err
 }

--- a/lib/gopherjs/frugal/processor_test.go
+++ b/lib/gopherjs/frugal/processor_test.go
@@ -17,10 +17,11 @@ import (
 	"bytes"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 
-	"github.com/Workiva/frugal/lib/gopherjs/thrift"
 	"github.com/Sirupsen/logrus"
+	"github.com/Workiva/frugal/lib/gopherjs/thrift"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -59,7 +60,7 @@ func TestFBaseProcessorHappyPath(t *testing.T) {
 	reads <- pingFrame[5:34] // FContext headers
 	reads <- pingFrame[34:]  // request body
 	mockTransport.reads = reads
-	proto := &FProtocol{thrift.NewTJSONProtocol(mockTransport)}
+	proto := &FProtocol{TProtocol: thrift.NewTJSONProtocol(mockTransport)}
 	processor := NewFBaseProcessor()
 	processorFunction := &pingProcessor{t: t, expectedProto: proto}
 	processor.AddToProcessorMap("ping", processorFunction)
@@ -87,7 +88,7 @@ func TestFBaseProcessorError(t *testing.T) {
 	reads <- pingFrame[5:34] // FContext headers
 	reads <- pingFrame[34:]  // request body
 	mockTransport.reads = reads
-	proto := &FProtocol{thrift.NewTJSONProtocol(mockTransport)}
+	proto := &FProtocol{TProtocol: thrift.NewTJSONProtocol(mockTransport)}
 	processor := NewFBaseProcessor()
 	err := errors.New("error")
 	processorFunction := &pingProcessor{t: t, expectedProto: proto, err: err}
@@ -107,7 +108,7 @@ func TestFBaseProcessorReadError(t *testing.T) {
 	mockTransport := new(mockTTransport)
 	err := errors.New("error")
 	mockTransport.readError = err
-	proto := &FProtocol{thrift.NewTJSONProtocol(mockTransport)}
+	proto := &FProtocol{TProtocol: thrift.NewTJSONProtocol(mockTransport)}
 	processor := NewFBaseProcessor()
 
 	err = processor.Process(proto, proto)
@@ -150,7 +151,7 @@ func TestFBaseProcessorNoProcessorFunction(t *testing.T) {
 	}
 	mockTransport.On("Write", responseBody).Return(len(responseBody), nil).Once()
 	mockTransport.On("Flush").Return(nil)
-	proto := &FProtocol{thrift.NewTJSONProtocol(mockTransport)}
+	proto := &FProtocol{TProtocol: thrift.NewTJSONProtocol(mockTransport)}
 	processor := NewFBaseProcessor()
 
 	assert.NoError(t, processor.Process(proto, proto))
@@ -186,7 +187,7 @@ func TestFBaseProcessorNoProcessorFunctionWriteError(t *testing.T) {
 	// so cant check for equality.
 	//responseCtx := []byte{0, 0, 0, 0, 29, 0, 0, 0, 5, 95, 111, 112, 105, 100, 0, 0, 0, 1, 48, 0, 0, 0, 4, 95, 99, 105, 100, 0, 0, 0, 3, 49, 50, 51}
 	mockTransport.On("Write", mock.Anything).Return(0, errors.New("error")).Once()
-	proto := &FProtocol{thrift.NewTJSONProtocol(mockTransport)}
+	proto := &FProtocol{TProtocol: thrift.NewTJSONProtocol(mockTransport)}
 	processor := NewFBaseProcessor()
 
 	assert.Error(t, processor.Process(proto, proto))
@@ -232,7 +233,7 @@ func TestFBaseProcessorNoProcessorFunctionFlushError(t *testing.T) {
 	}
 	mockTransport.On("Write", responseBody).Return(len(responseBody), nil).Once()
 	mockTransport.On("Flush").Return(errors.New("error"))
-	proto := &FProtocol{thrift.NewTJSONProtocol(mockTransport)}
+	proto := &FProtocol{TProtocol: thrift.NewTJSONProtocol(mockTransport)}
 	processor := NewFBaseProcessor()
 
 	assert.Error(t, processor.Process(proto, proto))
@@ -261,4 +262,24 @@ func TestFBaseProcessorAnnotations(t *testing.T) {
 	annoMap = processor.Annotations()
 	assert.Equal("baz", annoMap["foo"]["bar"])
 	assert.Equal("boom", annoMap["foo"]["boosh"])
+}
+
+func TestFBaseProcessorFunctionSendError(t *testing.T) {
+	ctx := NewFContext("guid")
+	fn := &FBaseProcessorFunction{writeMu: &sync.Mutex{}}
+	buffer := NewTMemoryOutputBuffer(100)
+	proto := &FProtocol{TProtocol: thrift.NewTJSONProtocol(buffer)}
+	assert.EqualError(t, fn.SendError(ctx, proto, 0, "method", "message"), "message")
+	assert.Equal(t, string(buffer.Bytes()[9:]), `[1,"method",3,0,{"1":{"str":"message"},"2":{"i32":0}}]`)
+}
+
+func TestFBaseProcessorFunctionSendReply(t *testing.T) {
+	ctx := NewFContext("guid")
+	fn := &FBaseProcessorFunction{writeMu: &sync.Mutex{}}
+	buffer := NewTMemoryOutputBuffer(100)
+	proto := &FProtocol{TProtocol: thrift.NewTJSONProtocol(buffer)}
+	obj := new(mockTStruct)
+	obj.On("Write", mock.Anything).Return(nil)
+	assert.NoError(t, fn.SendReply(ctx, proto, "method", obj))
+	assert.Equal(t, string(buffer.Bytes()[9:]), `[1,"method",2,0]`)
 }

--- a/lib/gopherjs/frugal/protocol.go
+++ b/lib/gopherjs/frugal/protocol.go
@@ -86,7 +86,10 @@ func NewFProtocolFactory(protoFactory thrift.TProtocolFactory) *FProtocolFactory
 
 // GetProtocol returns a new FProtocol instance using the given TTransport.
 func (f *FProtocolFactory) GetProtocol(tr thrift.TTransport) *FProtocol {
-	return &FProtocol{f.protoFactory.GetProtocol(tr)}
+	return &FProtocol{
+		TProtocol:           f.protoFactory.GetProtocol(tr),
+		ephemeralProperties: make(map[interface{}]interface{}),
+	}
 }
 
 // FProtocol is Frugal's equivalent of Thrift's TProtocol. It defines the
@@ -98,6 +101,7 @@ func (f *FProtocolFactory) GetProtocol(tr thrift.TTransport) *FProtocol {
 // protocol documentation for more details.
 type FProtocol struct {
 	thrift.TProtocol
+	ephemeralProperties map[interface{}]interface{}
 }
 
 // WriteRequestHeader writes the request headers set on the given Context
@@ -115,8 +119,9 @@ func (f *FProtocol) ReadRequestHeader() (FContext, error) {
 	}
 
 	ctx := &FContextImpl{
-		requestHeaders:  make(map[string]string),
-		responseHeaders: make(map[string]string),
+		requestHeaders:      make(map[string]string),
+		responseHeaders:     make(map[string]string),
+		ephemeralProperties: make(map[interface{}]interface{}),
 	}
 
 	for name, value := range headers {
@@ -142,6 +147,7 @@ func (f *FProtocol) ReadRequestHeader() (FContext, error) {
 		ctx.AddResponseHeader(cidHeader, cid)
 	}
 
+	ctx.ephemeralProperties = f.ephemeralProperties
 	return ctx, nil
 }
 

--- a/lib/gopherjs/frugal/protocol_test.go
+++ b/lib/gopherjs/frugal/protocol_test.go
@@ -52,7 +52,7 @@ var (
 func TestReadRequestHeaderMissingOpID(t *testing.T) {
 	assert := assert.New(t)
 	transport := &thrift.TMemoryBuffer{Buffer: bytes.NewBuffer(basicFrame)}
-	proto := &FProtocol{tProtocolFactory.GetProtocol(transport)}
+	proto := &FProtocol{TProtocol: tProtocolFactory.GetProtocol(transport)}
 
 	expectedErr := thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, errors.New("frugal: request missing op id"))
 	_, err := proto.ReadRequestHeader()
@@ -64,8 +64,7 @@ func TestReadRequestHeaderMissingOpID(t *testing.T) {
 func TestReadRequestHeader(t *testing.T) {
 	assert := assert.New(t)
 	transport := &thrift.TMemoryBuffer{Buffer: bytes.NewBuffer(frugalFrame)}
-	proto := &FProtocol{tProtocolFactory.GetProtocol(transport)}
-
+	proto := &FProtocol{TProtocol: tProtocolFactory.GetProtocol(transport)}
 
 	ctx, err := proto.ReadRequestHeader()
 	assert.Nil(err)
@@ -86,7 +85,7 @@ func TestReadRequestHeader(t *testing.T) {
 func TestReadResponseHeader(t *testing.T) {
 	assert := assert.New(t)
 	transport := &thrift.TMemoryBuffer{Buffer: bytes.NewBuffer(basicFrame)}
-	proto := &FProtocol{tProtocolFactory.GetProtocol(transport)}
+	proto := &FProtocol{TProtocol: tProtocolFactory.GetProtocol(transport)}
 
 	ctx := NewFContext("")
 	proto.ReadResponseHeader(ctx)
@@ -101,7 +100,7 @@ func TestWriteHeaderErroredWrite(t *testing.T) {
 	mft := &mockFTransport{}
 	writeErr := errors.New("write failed")
 	mft.On("Write", basicFrame).Return(0, writeErr)
-	proto := &FProtocol{tProtocolFactory.GetProtocol(mft)}
+	proto := &FProtocol{TProtocol: tProtocolFactory.GetProtocol(mft)}
 	expectedErr := thrift.NewTTransportException(TRANSPORT_EXCEPTION_UNKNOWN,
 		fmt.Sprintf("frugal: error writing protocol headers in writeHeader: %s", writeErr))
 	assert.Equal(expectedErr, proto.writeHeader(basicHeaders))
@@ -114,7 +113,7 @@ func TestWriteHeaderBadWrite(t *testing.T) {
 	assert := assert.New(t)
 	mft := &mockFTransport{}
 	mft.On("Write", basicFrame).Return(0, nil)
-	proto := &FProtocol{tProtocolFactory.GetProtocol(mft)}
+	proto := &FProtocol{TProtocol: tProtocolFactory.GetProtocol(mft)}
 	expectedErr := thrift.NewTTransportException(thrift.UNKNOWN_PROTOCOL_EXCEPTION, "frugal: failed to write complete protocol headers")
 	assert.Equal(expectedErr, proto.writeHeader(basicHeaders))
 	mft.AssertExpectations(t)
@@ -125,7 +124,7 @@ func TestWriteHeader(t *testing.T) {
 	assert := assert.New(t)
 	mft := &mockFTransport{}
 	mft.On("Write", basicFrame).Return(len(basicFrame), nil)
-	proto := &FProtocol{tProtocolFactory.GetProtocol(mft)}
+	proto := &FProtocol{TProtocol: tProtocolFactory.GetProtocol(mft)}
 	assert.Nil(proto.writeHeader(basicHeaders))
 	mft.AssertExpectations(t)
 }
@@ -135,7 +134,7 @@ func TestWriteHeader(t *testing.T) {
 func TestWriteReadRequestHeader(t *testing.T) {
 	assert := assert.New(t)
 	transport := &thrift.TMemoryBuffer{Buffer: &bytes.Buffer{}}
-	proto := &FProtocol{tProtocolFactory.GetProtocol(transport)}
+	proto := &FProtocol{TProtocol: tProtocolFactory.GetProtocol(transport)}
 	ctx := NewFContext("123")
 	origOpID, err := getOpID(ctx)
 	assert.Nil(err)
@@ -171,7 +170,7 @@ func TestWriteReadRequestHeader(t *testing.T) {
 func TestWriteReadResponseHeader(t *testing.T) {
 	assert := assert.New(t)
 	transport := &thrift.TMemoryBuffer{Buffer: &bytes.Buffer{}}
-	proto := &FProtocol{tProtocolFactory.GetProtocol(transport)}
+	proto := &FProtocol{TProtocol: tProtocolFactory.GetProtocol(transport)}
 	ctx := NewFContext("123")
 	origOpID, err := getOpID(ctx)
 	assert.Nil(err)

--- a/lib/gopherjs/frugal/registry_test.go
+++ b/lib/gopherjs/frugal/registry_test.go
@@ -51,7 +51,7 @@ func TestClientRegistry(t *testing.T) {
 	assert.Nil(registry.Register(ctx, resultC))
 	// Encode a frame with this context
 	transport := &thrift.TMemoryBuffer{Buffer: new(bytes.Buffer)}
-	proto := &FProtocol{tProtocolFactory.GetProtocol(transport)}
+	proto := &FProtocol{TProtocol: tProtocolFactory.GetProtocol(transport)}
 	assert.Nil(proto.writeHeader(ctx.RequestHeaders()))
 	// Pass the frame to execute
 	frame := transport.Bytes()

--- a/lib/gopherjs/frugal/transport.go
+++ b/lib/gopherjs/frugal/transport.go
@@ -39,8 +39,7 @@ type FPublisherTransport interface {
 	IsOpen() bool
 
 	// GetPublishSizeLimit returns the maximum allowable size of a payload
-	// to be published. A non-positive number is returned to indicate an
-	// unbounded allowable size.
+	// to be published. 0 is returned to indicate an unbounded allowable size.
 	GetPublishSizeLimit() uint
 
 	// Publish sends the given payload with the transport. Implementations

--- a/test/expected/go/actual_base/f_basefoo_service.txt
+++ b/test/expected/go/actual_base/f_basefoo_service.txt
@@ -80,7 +80,7 @@ func (p *basefooFBasePing) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "basePing", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "basePing", err.Error())
 	}
 	result := BaseFooBasePingResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -95,9 +95,9 @@ func (p *basefooFBasePing) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 			p.SendError(ctx, oprot, typedError.TypeId(), "basePing", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "basePing", "Internal error processing basePing: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "basePing", "Internal error processing basePing: "+err.Error())
 	}
-	return p.SendReply(ctx, oprot, "basePing", result)
+	return p.SendReply(ctx, oprot, "basePing", &result)
 }
 
 type BaseFooBasePingArgs struct {

--- a/test/expected/go/actual_base/f_basefoo_service.txt
+++ b/test/expected/go/actual_base/f_basefoo_service.txt
@@ -23,22 +23,22 @@ type FBaseFoo interface {
 }
 
 type FBaseFooClient struct {
-	transport       frugal.FTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	c       frugal.FClient
+	methods map[string]*frugal.Method
 }
 
 func NewFBaseFooClient(provider *frugal.FServiceProvider, middleware ...frugal.ServiceMiddleware) *FBaseFooClient {
 	methods := make(map[string]*frugal.Method)
 	client := &FBaseFooClient{
-		transport:       provider.GetTransport(),
-		protocolFactory: provider.GetProtocolFactory(),
-		methods:         methods,
+		c:       frugal.NewFStandardClient(provider),
+		methods: methods,
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
 	methods["basePing"] = frugal.NewMethod(client, client.basePing, "basePing", middleware)
 	return client
 }
+
+func (f *FBaseFooClient) Client_() frugal.FClient { return f.c }
 
 func (f *FBaseFooClient) BasePing(ctx frugal.FContext) (err error) {
 	ret := f.methods["basePing"].Invoke([]interface{}{ctx})
@@ -52,67 +52,10 @@ func (f *FBaseFooClient) BasePing(ctx frugal.FContext) (err error) {
 }
 
 func (f *FBaseFooClient) basePing(ctx frugal.FContext) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("basePing", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := BaseFooBasePingArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "basePing" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "basePing failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "basePing failed: invalid message type")
-		return
-	}
 	result := BaseFooBasePingResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "basePing", &args, &result)
+	if err != nil {
 		return
 	}
 	return
@@ -134,89 +77,27 @@ type basefooFBasePing struct {
 
 func (p *basefooFBasePing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := BaseFooBasePingArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "basePing", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "basePing", err.Error())
+	}
 	result := BaseFooBasePingResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("basePing", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "basePing", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "basePing", "Internal error processing basePing: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "basePing", "Internal error processing basePing: "+err.Error())
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "basePing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("basePing", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "basePing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "basePing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "basePing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "basePing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
-}
-
-func basefooWriteApplicationError(ctx frugal.FContext, oprot *frugal.FProtocol, type_ int32, method, message string) error {
-	x := thrift.NewTApplicationException(type_, message)
-	oprot.WriteResponseHeader(ctx)
-	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
-	x.Write(oprot)
-	oprot.WriteMessageEnd()
-	oprot.Flush()
-	return x
+	return p.SendReply(ctx, oprot, "basePing", result)
 }
 
 type BaseFooBasePingArgs struct {

--- a/test/expected/go/deprecated_logging/f_foo_service.go
+++ b/test/expected/go/deprecated_logging/f_foo_service.go
@@ -435,7 +435,7 @@ func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
 	}
 	result := FooPingResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -450,9 +450,9 @@ func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 			p.SendError(ctx, oprot, typedError.TypeId(), "ping", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
 	}
-	return p.SendReply(ctx, oprot, "ping", result)
+	return p.SendReply(ctx, oprot, "ping", &result)
 }
 
 type fooFBlah struct {
@@ -464,7 +464,7 @@ func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
 	}
 	result := FooBlahResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.Num, args.Str, args.Event})
@@ -485,13 +485,13 @@ func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 		case *golang.APIException:
 			result.API = v
 		default:
-			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
+			return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
 		}
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "blah", result)
+	return p.SendReply(ctx, oprot, "blah", &result)
 }
 
 type fooFOneWay struct {
@@ -503,7 +503,7 @@ func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
 	}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ID, args.Req})
 	if len(ret) != 1 {
@@ -517,7 +517,7 @@ func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol
 			p.SendError(ctx, oprot, typedError.TypeId(), "oneWay", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
 	}
 	return err
 }
@@ -531,7 +531,7 @@ func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProto
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
 	}
 	result := FooBinMethodResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.Bin, args.Str})
@@ -550,13 +550,13 @@ func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProto
 		case *golang.APIException:
 			result.API = v
 		default:
-			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
+			return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
 		}
 	} else {
 		var retval []byte = ret[0].([]byte)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "bin_method", result)
+	return p.SendReply(ctx, oprot, "bin_method", &result)
 }
 
 type fooFParamModifiers struct {
@@ -568,7 +568,7 @@ func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.F
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
 	}
 	result := FooParamModifiersResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.OptNum, args.DefaultNum, args.ReqNum})
@@ -583,12 +583,12 @@ func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.F
 			p.SendError(ctx, oprot, typedError.TypeId(), "param_modifiers", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "param_modifiers", result)
+	return p.SendReply(ctx, oprot, "param_modifiers", &result)
 }
 
 type fooFUnderlyingTypesTest struct {
@@ -600,7 +600,7 @@ func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *fru
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
 	}
 	result := FooUnderlyingTypesTestResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ListType, args.SetType})
@@ -615,12 +615,12 @@ func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *fru
 			p.SendError(ctx, oprot, typedError.TypeId(), "underlying_types_test", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
 	} else {
 		var retval []ID = ret[0].([]ID)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "underlying_types_test", result)
+	return p.SendReply(ctx, oprot, "underlying_types_test", &result)
 }
 
 type fooFGetThing struct {
@@ -632,7 +632,7 @@ func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
 	}
 	result := FooGetThingResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -647,12 +647,12 @@ func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "getThing", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
 	} else {
 		var retval *validStructs.Thing = ret[0].(*validStructs.Thing)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "getThing", result)
+	return p.SendReply(ctx, oprot, "getThing", &result)
 }
 
 type fooFGetMyInt struct {
@@ -664,7 +664,7 @@ func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
 	}
 	result := FooGetMyIntResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -679,12 +679,12 @@ func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "getMyInt", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
 	} else {
 		var retval ValidTypes.MyInt = ret[0].(ValidTypes.MyInt)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "getMyInt", result)
+	return p.SendReply(ctx, oprot, "getMyInt", &result)
 }
 
 type fooFUseSubdirStruct struct {
@@ -696,7 +696,7 @@ func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
 	}
 	result := FooUseSubdirStructResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.A})
@@ -711,12 +711,12 @@ func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.
 			p.SendError(ctx, oprot, typedError.TypeId(), "use_subdir_struct", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
 	} else {
 		var retval *subdir_include.A = ret[0].(*subdir_include.A)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "use_subdir_struct", result)
+	return p.SendReply(ctx, oprot, "use_subdir_struct", &result)
 }
 
 type fooFSayHelloWith struct {
@@ -728,7 +728,7 @@ func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
 	}
 	result := FooSayHelloWithResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.NewMessage_})
@@ -743,12 +743,12 @@ func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 			p.SendError(ctx, oprot, typedError.TypeId(), "sayHelloWith", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "sayHelloWith", result)
+	return p.SendReply(ctx, oprot, "sayHelloWith", &result)
 }
 
 type fooFWhatDoYouSay struct {
@@ -760,7 +760,7 @@ func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
 	}
 	result := FooWhatDoYouSayResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageArgs_})
@@ -775,12 +775,12 @@ func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 			p.SendError(ctx, oprot, typedError.TypeId(), "whatDoYouSay", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "whatDoYouSay", result)
+	return p.SendReply(ctx, oprot, "whatDoYouSay", &result)
 }
 
 type fooFSayAgain struct {
@@ -792,7 +792,7 @@ func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
 	}
 	result := FooSayAgainResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageResult_})
@@ -807,12 +807,12 @@ func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "sayAgain", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "sayAgain", result)
+	return p.SendReply(ctx, oprot, "sayAgain", &result)
 }
 
 type FooPingArgs struct {

--- a/test/expected/go/deprecated_logging/f_foo_service.go
+++ b/test/expected/go/deprecated_logging/f_foo_service.go
@@ -49,18 +49,14 @@ type FFoo interface {
 // a frugal Context for each service call.
 type FFooClient struct {
 	*golang.FBaseFooClient
-	transport       frugal.FTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	methods map[string]*frugal.Method
 }
 
 func NewFFooClient(provider *frugal.FServiceProvider, middleware ...frugal.ServiceMiddleware) *FFooClient {
 	methods := make(map[string]*frugal.Method)
 	client := &FFooClient{
-		FBaseFooClient:  golang.NewFBaseFooClient(provider, middleware...),
-		transport:       provider.GetTransport(),
-		protocolFactory: provider.GetProtocolFactory(),
-		methods:         methods,
+		FBaseFooClient: golang.NewFBaseFooClient(provider, middleware...),
+		methods:        methods,
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
 	methods["ping"] = frugal.NewMethod(client, client.ping, "ping", middleware)
@@ -92,67 +88,10 @@ func (f *FFooClient) Ping(ctx frugal.FContext) (err error) {
 }
 
 func (f *FFooClient) ping(ctx frugal.FContext) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("ping", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooPingArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "ping" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "ping failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "ping failed: invalid message type")
-		return
-	}
 	result := FooPingResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "ping", &args, &result)
+	if err != nil {
 		return
 	}
 	return
@@ -174,71 +113,14 @@ func (f *FFooClient) Blah(ctx frugal.FContext, num int32, str string, event *Eve
 }
 
 func (f *FFooClient) blah(ctx frugal.FContext, num int32, str string, event *Event) (r int64, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("blah", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooBlahArgs{
 		Num:   num,
 		Str:   str,
 		Event: event,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "blah" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "blah failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "blah failed: invalid message type")
-		return
-	}
 	result := FooBlahResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "blah", &args, &result)
+	if err != nil {
 		return
 	}
 	if result.Awe != nil {
@@ -266,29 +148,11 @@ func (f *FFooClient) OneWay(ctx frugal.FContext, id ID, req Request) (err error)
 }
 
 func (f *FFooClient) oneWay(ctx frugal.FContext, id ID, req Request) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("oneWay", thrift.ONEWAY, 0); err != nil {
-		return
-	}
 	args := FooOneWayArgs{
 		ID:  id,
 		Req: req,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	err = f.transport.Oneway(ctx, buffer.Bytes())
-	return
+	return f.Client_().Oneway(ctx, "oneWay", &args)
 }
 
 func (f *FFooClient) BinMethod(ctx frugal.FContext, bin []byte, str string) (r []byte, err error) {
@@ -306,70 +170,13 @@ func (f *FFooClient) BinMethod(ctx frugal.FContext, bin []byte, str string) (r [
 }
 
 func (f *FFooClient) bin_method(ctx frugal.FContext, bin []byte, str string) (r []byte, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("bin_method", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooBinMethodArgs{
 		Bin: bin,
 		Str: str,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "bin_method" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "bin_method failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "bin_method failed: invalid message type")
-		return
-	}
 	result := FooBinMethodResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "bin_method", &args, &result)
+	if err != nil {
 		return
 	}
 	if result.API != nil {
@@ -395,71 +202,14 @@ func (f *FFooClient) ParamModifiers(ctx frugal.FContext, opt_num int32, default_
 }
 
 func (f *FFooClient) param_modifiers(ctx frugal.FContext, opt_num int32, default_num int32, req_num int32) (r int64, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("param_modifiers", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooParamModifiersArgs{
 		OptNum:     opt_num,
 		DefaultNum: default_num,
 		ReqNum:     req_num,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "param_modifiers" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "param_modifiers failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "param_modifiers failed: invalid message type")
-		return
-	}
 	result := FooParamModifiersResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "param_modifiers", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -481,70 +231,13 @@ func (f *FFooClient) UnderlyingTypesTest(ctx frugal.FContext, list_type []ID, se
 }
 
 func (f *FFooClient) underlying_types_test(ctx frugal.FContext, list_type []ID, set_type map[ID]bool) (r []ID, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("underlying_types_test", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooUnderlyingTypesTestArgs{
 		ListType: list_type,
 		SetType:  set_type,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "underlying_types_test" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "underlying_types_test failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "underlying_types_test failed: invalid message type")
-		return
-	}
 	result := FooUnderlyingTypesTestResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "underlying_types_test", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -566,67 +259,10 @@ func (f *FFooClient) GetThing(ctx frugal.FContext) (r *validStructs.Thing, err e
 }
 
 func (f *FFooClient) getThing(ctx frugal.FContext) (r *validStructs.Thing, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("getThing", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooGetThingArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "getThing" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "getThing failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "getThing failed: invalid message type")
-		return
-	}
 	result := FooGetThingResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "getThing", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -648,67 +284,10 @@ func (f *FFooClient) GetMyInt(ctx frugal.FContext) (r ValidTypes.MyInt, err erro
 }
 
 func (f *FFooClient) getMyInt(ctx frugal.FContext) (r ValidTypes.MyInt, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("getMyInt", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooGetMyIntArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "getMyInt" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "getMyInt failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "getMyInt failed: invalid message type")
-		return
-	}
 	result := FooGetMyIntResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "getMyInt", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -730,69 +309,12 @@ func (f *FFooClient) UseSubdirStruct(ctx frugal.FContext, a *subdir_include.A) (
 }
 
 func (f *FFooClient) use_subdir_struct(ctx frugal.FContext, a *subdir_include.A) (r *subdir_include.A, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("use_subdir_struct", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooUseSubdirStructArgs{
 		A: a,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "use_subdir_struct" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "use_subdir_struct failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "use_subdir_struct failed: invalid message type")
-		return
-	}
 	result := FooUseSubdirStructResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "use_subdir_struct", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -814,69 +336,12 @@ func (f *FFooClient) SayHelloWith(ctx frugal.FContext, newmessage string) (r str
 }
 
 func (f *FFooClient) sayHelloWith(ctx frugal.FContext, newmessage string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("sayHelloWith", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooSayHelloWithArgs{
 		NewMessage_: newmessage,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "sayHelloWith" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "sayHelloWith failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "sayHelloWith failed: invalid message type")
-		return
-	}
 	result := FooSayHelloWithResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "sayHelloWith", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -898,69 +363,12 @@ func (f *FFooClient) WhatDoYouSay(ctx frugal.FContext, messageargs string) (r st
 }
 
 func (f *FFooClient) whatDoYouSay(ctx frugal.FContext, messageargs string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("whatDoYouSay", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooWhatDoYouSayArgs{
 		MessageArgs_: messageargs,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "whatDoYouSay" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "whatDoYouSay failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "whatDoYouSay failed: invalid message type")
-		return
-	}
 	result := FooWhatDoYouSayResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "whatDoYouSay", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -982,69 +390,12 @@ func (f *FFooClient) SayAgain(ctx frugal.FContext, messageresult string) (r stri
 }
 
 func (f *FFooClient) sayAgain(ctx frugal.FContext, messageresult string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("sayAgain", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooSayAgainArgs{
 		MessageResult_: messageresult,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "sayAgain" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "sayAgain failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "sayAgain failed: invalid message type")
-		return
-	}
 	result := FooSayAgainResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "sayAgain", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -1081,79 +432,27 @@ type fooFPing struct {
 
 func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooPingArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
+	}
 	result := FooPingResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("ping", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "ping", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("ping", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "ping", result)
 }
 
 type fooFBlah struct {
@@ -1162,89 +461,37 @@ type fooFBlah struct {
 
 func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooBlahArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
+	}
 	result := FooBlahResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.Num, args.Str, args.Event})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("blah", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "blah", typedError.Error())
 			return nil
 		}
-		switch v := err2.(type) {
+		switch v := err.(type) {
 		case *AwesomeException:
 			result.Awe = v
 		case *golang.APIException:
 			result.API = v
 		default:
-			p.GetWriteMutex().Lock()
-			err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err2.Error())
-			p.GetWriteMutex().Unlock()
-			return err2
+			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
 		}
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("blah", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "blah", result)
 }
 
 type fooFOneWay struct {
@@ -1253,33 +500,24 @@ type fooFOneWay struct {
 
 func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooOneWayArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
-	var err2 error
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
+	}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ID, args.Req})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("oneWay", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "oneWay", typedError.Error())
 			return nil
 		}
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
 	}
 	return err
 }
@@ -1290,87 +528,35 @@ type fooFBinMethod struct {
 
 func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooBinMethodArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
+	}
 	result := FooBinMethodResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.Bin, args.Str})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("bin_method", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "bin_method", typedError.Error())
 			return nil
 		}
-		switch v := err2.(type) {
+		switch v := err.(type) {
 		case *golang.APIException:
 			result.API = v
 		default:
-			p.GetWriteMutex().Lock()
-			err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err2.Error())
-			p.GetWriteMutex().Unlock()
-			return err2
+			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
 		}
 	} else {
 		var retval []byte = ret[0].([]byte)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("bin_method", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "bin_method", result)
 }
 
 type fooFParamModifiers struct {
@@ -1379,82 +565,30 @@ type fooFParamModifiers struct {
 
 func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooParamModifiersArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
+	}
 	result := FooParamModifiersResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.OptNum, args.DefaultNum, args.ReqNum})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("param_modifiers", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "param_modifiers", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("param_modifiers", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "param_modifiers", result)
 }
 
 type fooFUnderlyingTypesTest struct {
@@ -1463,82 +597,30 @@ type fooFUnderlyingTypesTest struct {
 
 func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooUnderlyingTypesTestArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
+	}
 	result := FooUnderlyingTypesTestResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.ListType, args.SetType})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("underlying_types_test", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "underlying_types_test", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
 	} else {
 		var retval []ID = ret[0].([]ID)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("underlying_types_test", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "underlying_types_test", result)
 }
 
 type fooFGetThing struct {
@@ -1547,82 +629,30 @@ type fooFGetThing struct {
 
 func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooGetThingArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
+	}
 	result := FooGetThingResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("getThing", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "getThing", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
 	} else {
 		var retval *validStructs.Thing = ret[0].(*validStructs.Thing)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("getThing", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "getThing", result)
 }
 
 type fooFGetMyInt struct {
@@ -1631,82 +661,30 @@ type fooFGetMyInt struct {
 
 func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooGetMyIntArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
+	}
 	result := FooGetMyIntResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("getMyInt", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "getMyInt", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
 	} else {
 		var retval ValidTypes.MyInt = ret[0].(ValidTypes.MyInt)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("getMyInt", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "getMyInt", result)
 }
 
 type fooFUseSubdirStruct struct {
@@ -1715,82 +693,30 @@ type fooFUseSubdirStruct struct {
 
 func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooUseSubdirStructArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
+	}
 	result := FooUseSubdirStructResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.A})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("use_subdir_struct", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "use_subdir_struct", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
 	} else {
 		var retval *subdir_include.A = ret[0].(*subdir_include.A)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("use_subdir_struct", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "use_subdir_struct", result)
 }
 
 type fooFSayHelloWith struct {
@@ -1799,82 +725,30 @@ type fooFSayHelloWith struct {
 
 func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooSayHelloWithArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
+	}
 	result := FooSayHelloWithResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.NewMessage_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("sayHelloWith", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "sayHelloWith", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("sayHelloWith", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "sayHelloWith", result)
 }
 
 type fooFWhatDoYouSay struct {
@@ -1883,82 +757,30 @@ type fooFWhatDoYouSay struct {
 
 func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooWhatDoYouSayArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
+	}
 	result := FooWhatDoYouSayResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageArgs_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("whatDoYouSay", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "whatDoYouSay", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("whatDoYouSay", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "whatDoYouSay", result)
 }
 
 type fooFSayAgain struct {
@@ -1967,92 +789,30 @@ type fooFSayAgain struct {
 
 func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooSayAgainArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
+	}
 	result := FooSayAgainResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageResult_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("sayAgain", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "sayAgain", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("sayAgain", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
-}
-
-func fooWriteApplicationError(ctx frugal.FContext, oprot *frugal.FProtocol, type_ int32, method, message string) error {
-	x := thrift.NewTApplicationException(type_, message)
-	oprot.WriteResponseHeader(ctx)
-	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
-	x.Write(oprot)
-	oprot.WriteMessageEnd()
-	oprot.Flush()
-	return x
+	return p.SendReply(ctx, oprot, "sayAgain", result)
 }
 
 type FooPingArgs struct {

--- a/test/expected/go/slim/f_events_scope.go
+++ b/test/expected/go/slim/f_events_scope.go
@@ -14,6 +14,8 @@ import (
 // the @ sign. Prefix specifies topic prefix tokens, which can be static or
 // variable.
 type EventsPublisher interface {
+	Open() error
+	Close() error
 	PublishEventCreated(ctx frugal.FContext, user string, req *Event) error
 	PublishSomeInt(ctx frugal.FContext, user string, req int64) error
 	PublishSomeStr(ctx frugal.FContext, user string, req string) error
@@ -37,6 +39,9 @@ func NewEventsPublisher(provider *frugal.FScopeProvider, middleware ...frugal.Se
 	publisher.methods["publishSomeList"] = frugal.NewMethod(publisher, publisher.publishSomeList, "publishSomeList", middleware)
 	return publisher
 }
+
+func (p eventsPublisher) Open() error  { return p.client.Open() }
+func (p eventsPublisher) Close() error { return p.client.Close() }
 
 // This is a docstring.
 func (p *eventsPublisher) PublishEventCreated(ctx frugal.FContext, user string, req *Event) error {

--- a/test/expected/go/slim/f_events_scope.go
+++ b/test/expected/go/slim/f_events_scope.go
@@ -10,8 +10,6 @@ import (
 	"github.com/Workiva/frugal/lib/go"
 )
 
-const delimiter = "."
-
 // This docstring gets added to the generated code because it has
 // the @ sign. Prefix specifies topic prefix tokens, which can be static or
 // variable.
@@ -25,33 +23,21 @@ type EventsPublisher interface {
 }
 
 type eventsPublisher struct {
-	transport       frugal.FPublisherTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	client  frugal.FClient
+	methods map[string]*frugal.Method
 }
 
 func NewEventsPublisher(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) EventsPublisher {
-	transport, protocolFactory := provider.NewPublisher()
-	methods := make(map[string]*frugal.Method)
 	publisher := &eventsPublisher{
-		transport:       transport,
-		protocolFactory: protocolFactory,
-		methods:         methods,
+		client:  frugal.NewFPublisherClient(provider),
+		methods: make(map[string]*frugal.Method),
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
-	methods["publishEventCreated"] = frugal.NewMethod(publisher, publisher.publishEventCreated, "publishEventCreated", middleware)
-	methods["publishSomeInt"] = frugal.NewMethod(publisher, publisher.publishSomeInt, "publishSomeInt", middleware)
-	methods["publishSomeStr"] = frugal.NewMethod(publisher, publisher.publishSomeStr, "publishSomeStr", middleware)
-	methods["publishSomeList"] = frugal.NewMethod(publisher, publisher.publishSomeList, "publishSomeList", middleware)
+	publisher.methods["publishEventCreated"] = frugal.NewMethod(publisher, publisher.publishEventCreated, "publishEventCreated", middleware)
+	publisher.methods["publishSomeInt"] = frugal.NewMethod(publisher, publisher.publishSomeInt, "publishSomeInt", middleware)
+	publisher.methods["publishSomeStr"] = frugal.NewMethod(publisher, publisher.publishSomeStr, "publishSomeStr", middleware)
+	publisher.methods["publishSomeList"] = frugal.NewMethod(publisher, publisher.publishSomeList, "publishSomeList", middleware)
 	return publisher
-}
-
-func (p *eventsPublisher) Open() error {
-	return p.transport.Open()
-}
-
-func (p *eventsPublisher) Close() error {
-	return p.transport.Close()
 }
 
 // This is a docstring.
@@ -65,27 +51,9 @@ func (p *eventsPublisher) PublishEventCreated(ctx frugal.FContext, user string, 
 
 func (p *eventsPublisher) publishEventCreated(ctx frugal.FContext, user string, req *Event) error {
 	ctx.AddRequestHeader("_topic_user", user)
-	op := "EventCreated"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
-	buffer := frugal.NewTMemoryOutputBuffer(p.transport.GetPublishSizeLimit())
-	oprot := p.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return err
-	}
-	if err := oprot.WriteMessageBegin(op, thrift.CALL, 0); err != nil {
-		return err
-	}
-	if err := req.Write(oprot); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", req), err)
-	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return err
-	}
-	if err := oprot.Flush(); err != nil {
-		return err
-	}
-	return p.transport.Publish(topic, buffer.Bytes())
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
+	return p.client.Publish(ctx, "EventCreated", topic, req)
 }
 
 func (p *eventsPublisher) PublishSomeInt(ctx frugal.FContext, user string, req int64) error {
@@ -98,27 +66,22 @@ func (p *eventsPublisher) PublishSomeInt(ctx frugal.FContext, user string, req i
 
 func (p *eventsPublisher) publishSomeInt(ctx frugal.FContext, user string, req int64) error {
 	ctx.AddRequestHeader("_topic_user", user)
-	op := "SomeInt"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
-	buffer := frugal.NewTMemoryOutputBuffer(p.transport.GetPublishSizeLimit())
-	oprot := p.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return err
-	}
-	if err := oprot.WriteMessageBegin(op, thrift.CALL, 0); err != nil {
-		return err
-	}
-	if err := oprot.WriteI64(int64(req)); err != nil {
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
+	return p.client.Publish(ctx, "SomeInt", topic, eventsSomeIntMessage(req))
+}
+
+type eventsSomeIntMessage int64
+
+func (p eventsSomeIntMessage) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteI64(int64(p)); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
 	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return err
-	}
-	if err := oprot.Flush(); err != nil {
-		return err
-	}
-	return p.transport.Publish(topic, buffer.Bytes())
+	return nil
+}
+
+func (p eventsSomeIntMessage) Read(iprot thrift.TProcotol) error {
+	panic("Not Implemented!")
 }
 
 func (p *eventsPublisher) PublishSomeStr(ctx frugal.FContext, user string, req string) error {
@@ -131,27 +94,22 @@ func (p *eventsPublisher) PublishSomeStr(ctx frugal.FContext, user string, req s
 
 func (p *eventsPublisher) publishSomeStr(ctx frugal.FContext, user string, req string) error {
 	ctx.AddRequestHeader("_topic_user", user)
-	op := "SomeStr"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
-	buffer := frugal.NewTMemoryOutputBuffer(p.transport.GetPublishSizeLimit())
-	oprot := p.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return err
-	}
-	if err := oprot.WriteMessageBegin(op, thrift.CALL, 0); err != nil {
-		return err
-	}
-	if err := oprot.WriteString(string(req)); err != nil {
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
+	return p.client.Publish(ctx, "SomeStr", topic, eventsSomeStrMessage(req))
+}
+
+type eventsSomeStrMessage string
+
+func (p eventsSomeStrMessage) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteString(string(p)); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
 	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return err
-	}
-	if err := oprot.Flush(); err != nil {
-		return err
-	}
-	return p.transport.Publish(topic, buffer.Bytes())
+	return nil
+}
+
+func (p eventsSomeStrMessage) Read(iprot thrift.TProcotol) error {
+	panic("Not Implemented!")
 }
 
 func (p *eventsPublisher) PublishSomeList(ctx frugal.FContext, user string, req []map[ID]*Event) error {
@@ -164,21 +122,18 @@ func (p *eventsPublisher) PublishSomeList(ctx frugal.FContext, user string, req 
 
 func (p *eventsPublisher) publishSomeList(ctx frugal.FContext, user string, req []map[ID]*Event) error {
 	ctx.AddRequestHeader("_topic_user", user)
-	op := "SomeList"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
-	buffer := frugal.NewTMemoryOutputBuffer(p.transport.GetPublishSizeLimit())
-	oprot := p.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return err
-	}
-	if err := oprot.WriteMessageBegin(op, thrift.CALL, 0); err != nil {
-		return err
-	}
-	if err := oprot.WriteListBegin(thrift.MAP, len(req)); err != nil {
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
+	return p.client.Publish(ctx, "SomeList", topic, eventsSomeListMessage(req))
+}
+
+type eventsSomeListMessage []map[ID]*Event
+
+func (p eventsSomeListMessage) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteListBegin(thrift.MAP, len(p)); err != nil {
 		return thrift.PrependError("error writing list begin: ", err)
 	}
-	for _, v := range req {
+	for _, v := range p {
 		if err := oprot.WriteMapBegin(thrift.I64, thrift.STRUCT, len(v)); err != nil {
 			return thrift.PrependError("error writing map begin: ", err)
 		}
@@ -197,13 +152,11 @@ func (p *eventsPublisher) publishSomeList(ctx frugal.FContext, user string, req 
 	if err := oprot.WriteListEnd(); err != nil {
 		return thrift.PrependError("error writing list end: ", err)
 	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return err
-	}
-	if err := oprot.Flush(); err != nil {
-		return err
-	}
-	return p.transport.Publish(topic, buffer.Bytes())
+	return nil
+}
+
+func (p eventsSomeListMessage) Read(iprot thrift.TProcotol) error {
+	panic("Not Implemented!")
 }
 
 // This docstring gets added to the generated code because it has
@@ -253,7 +206,7 @@ func (l *eventsSubscriber) SubscribeEventCreated(user string, handler func(fruga
 func (l *eventsSubscriber) SubscribeEventCreatedErrorable(user string, handler func(frugal.FContext, *Event) error) (*frugal.FSubscription, error) {
 	op := "EventCreated"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
 	transport, protocolFactory := l.provider.NewSubscriber()
 	cb := l.recvEventCreated(op, protocolFactory, handler)
 	if err := transport.Subscribe(topic, cb); err != nil {
@@ -303,7 +256,7 @@ func (l *eventsSubscriber) SubscribeSomeInt(user string, handler func(frugal.FCo
 func (l *eventsSubscriber) SubscribeSomeIntErrorable(user string, handler func(frugal.FContext, int64) error) (*frugal.FSubscription, error) {
 	op := "SomeInt"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
 	transport, protocolFactory := l.provider.NewSubscriber()
 	cb := l.recvSomeInt(op, protocolFactory, handler)
 	if err := transport.Subscribe(topic, cb); err != nil {
@@ -355,7 +308,7 @@ func (l *eventsSubscriber) SubscribeSomeStr(user string, handler func(frugal.FCo
 func (l *eventsSubscriber) SubscribeSomeStrErrorable(user string, handler func(frugal.FContext, string) error) (*frugal.FSubscription, error) {
 	op := "SomeStr"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
 	transport, protocolFactory := l.provider.NewSubscriber()
 	cb := l.recvSomeStr(op, protocolFactory, handler)
 	if err := transport.Subscribe(topic, cb); err != nil {
@@ -407,7 +360,7 @@ func (l *eventsSubscriber) SubscribeSomeList(user string, handler func(frugal.FC
 func (l *eventsSubscriber) SubscribeSomeListErrorable(user string, handler func(frugal.FContext, []map[ID]*Event) error) (*frugal.FSubscription, error) {
 	op := "SomeList"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
 	transport, protocolFactory := l.provider.NewSubscriber()
 	cb := l.recvSomeList(op, protocolFactory, handler)
 	if err := transport.Subscribe(topic, cb); err != nil {

--- a/test/expected/go/slim/f_events_scope.go
+++ b/test/expected/go/slim/f_events_scope.go
@@ -14,8 +14,6 @@ import (
 // the @ sign. Prefix specifies topic prefix tokens, which can be static or
 // variable.
 type EventsPublisher interface {
-	Open() error
-	Close() error
 	PublishEventCreated(ctx frugal.FContext, user string, req *Event) error
 	PublishSomeInt(ctx frugal.FContext, user string, req int64) error
 	PublishSomeStr(ctx frugal.FContext, user string, req string) error
@@ -29,7 +27,7 @@ type eventsPublisher struct {
 
 func NewEventsPublisher(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) EventsPublisher {
 	publisher := &eventsPublisher{
-		client:  frugal.NewFPublisherClient(provider),
+		client:  frugal.NewFScopeClient(provider),
 		methods: make(map[string]*frugal.Method),
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
@@ -52,8 +50,9 @@ func (p *eventsPublisher) PublishEventCreated(ctx frugal.FContext, user string, 
 func (p *eventsPublisher) publishEventCreated(ctx frugal.FContext, user string, req *Event) error {
 	ctx.AddRequestHeader("_topic_user", user)
 	prefix := fmt.Sprintf("foo.%s.", user)
+	op := "EventCreated"
 	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
-	return p.client.Publish(ctx, "EventCreated", topic, req)
+	return p.client.Publish(ctx, op, topic, req)
 }
 
 func (p *eventsPublisher) PublishSomeInt(ctx frugal.FContext, user string, req int64) error {
@@ -67,8 +66,9 @@ func (p *eventsPublisher) PublishSomeInt(ctx frugal.FContext, user string, req i
 func (p *eventsPublisher) publishSomeInt(ctx frugal.FContext, user string, req int64) error {
 	ctx.AddRequestHeader("_topic_user", user)
 	prefix := fmt.Sprintf("foo.%s.", user)
+	op := "SomeInt"
 	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
-	return p.client.Publish(ctx, "SomeInt", topic, eventsSomeIntMessage(req))
+	return p.client.Publish(ctx, op, topic, eventsSomeIntMessage(req))
 }
 
 type eventsSomeIntMessage int64
@@ -80,7 +80,7 @@ func (p eventsSomeIntMessage) Write(oprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p eventsSomeIntMessage) Read(iprot thrift.TProcotol) error {
+func (p eventsSomeIntMessage) Read(iprot thrift.TProtocol) error {
 	panic("Not Implemented!")
 }
 
@@ -95,8 +95,9 @@ func (p *eventsPublisher) PublishSomeStr(ctx frugal.FContext, user string, req s
 func (p *eventsPublisher) publishSomeStr(ctx frugal.FContext, user string, req string) error {
 	ctx.AddRequestHeader("_topic_user", user)
 	prefix := fmt.Sprintf("foo.%s.", user)
+	op := "SomeStr"
 	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
-	return p.client.Publish(ctx, "SomeStr", topic, eventsSomeStrMessage(req))
+	return p.client.Publish(ctx, op, topic, eventsSomeStrMessage(req))
 }
 
 type eventsSomeStrMessage string
@@ -108,7 +109,7 @@ func (p eventsSomeStrMessage) Write(oprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p eventsSomeStrMessage) Read(iprot thrift.TProcotol) error {
+func (p eventsSomeStrMessage) Read(iprot thrift.TProtocol) error {
 	panic("Not Implemented!")
 }
 
@@ -123,8 +124,9 @@ func (p *eventsPublisher) PublishSomeList(ctx frugal.FContext, user string, req 
 func (p *eventsPublisher) publishSomeList(ctx frugal.FContext, user string, req []map[ID]*Event) error {
 	ctx.AddRequestHeader("_topic_user", user)
 	prefix := fmt.Sprintf("foo.%s.", user)
+	op := "SomeList"
 	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
-	return p.client.Publish(ctx, "SomeList", topic, eventsSomeListMessage(req))
+	return p.client.Publish(ctx, op, topic, eventsSomeListMessage(req))
 }
 
 type eventsSomeListMessage []map[ID]*Event
@@ -155,7 +157,7 @@ func (p eventsSomeListMessage) Write(oprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p eventsSomeListMessage) Read(iprot thrift.TProcotol) error {
+func (p eventsSomeListMessage) Read(iprot thrift.TProtocol) error {
 	panic("Not Implemented!")
 }
 

--- a/test/expected/go/slim/f_foo_service.go
+++ b/test/expected/go/slim/f_foo_service.go
@@ -427,7 +427,7 @@ func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
 	}
 	result := FooPingResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -442,9 +442,9 @@ func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 			p.SendError(ctx, oprot, typedError.TypeId(), "ping", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
 	}
-	return p.SendReply(ctx, oprot, "ping", result)
+	return p.SendReply(ctx, oprot, "ping", &result)
 }
 
 type fooFBlah struct {
@@ -456,7 +456,7 @@ func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
 	}
 	result := FooBlahResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.Num, args.Str, args.Event})
@@ -477,13 +477,13 @@ func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 		case *golang.APIException:
 			result.API = v
 		default:
-			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
+			return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
 		}
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "blah", result)
+	return p.SendReply(ctx, oprot, "blah", &result)
 }
 
 type fooFOneWay struct {
@@ -495,7 +495,7 @@ func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
 	}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ID, args.Req})
 	if len(ret) != 1 {
@@ -509,7 +509,7 @@ func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol
 			p.SendError(ctx, oprot, typedError.TypeId(), "oneWay", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
 	}
 	return err
 }
@@ -523,7 +523,7 @@ func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProto
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
 	}
 	result := FooBinMethodResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.Bin, args.Str})
@@ -542,13 +542,13 @@ func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProto
 		case *golang.APIException:
 			result.API = v
 		default:
-			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
+			return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
 		}
 	} else {
 		var retval []byte = ret[0].([]byte)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "bin_method", result)
+	return p.SendReply(ctx, oprot, "bin_method", &result)
 }
 
 type fooFParamModifiers struct {
@@ -560,7 +560,7 @@ func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.F
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
 	}
 	result := FooParamModifiersResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.OptNum, args.DefaultNum, args.ReqNum})
@@ -575,12 +575,12 @@ func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.F
 			p.SendError(ctx, oprot, typedError.TypeId(), "param_modifiers", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "param_modifiers", result)
+	return p.SendReply(ctx, oprot, "param_modifiers", &result)
 }
 
 type fooFUnderlyingTypesTest struct {
@@ -592,7 +592,7 @@ func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *fru
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
 	}
 	result := FooUnderlyingTypesTestResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ListType, args.SetType})
@@ -607,12 +607,12 @@ func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *fru
 			p.SendError(ctx, oprot, typedError.TypeId(), "underlying_types_test", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
 	} else {
 		var retval []ID = ret[0].([]ID)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "underlying_types_test", result)
+	return p.SendReply(ctx, oprot, "underlying_types_test", &result)
 }
 
 type fooFGetThing struct {
@@ -624,7 +624,7 @@ func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
 	}
 	result := FooGetThingResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -639,12 +639,12 @@ func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "getThing", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
 	} else {
 		var retval *validStructs.Thing = ret[0].(*validStructs.Thing)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "getThing", result)
+	return p.SendReply(ctx, oprot, "getThing", &result)
 }
 
 type fooFGetMyInt struct {
@@ -656,7 +656,7 @@ func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
 	}
 	result := FooGetMyIntResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -671,12 +671,12 @@ func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "getMyInt", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
 	} else {
 		var retval ValidTypes.MyInt = ret[0].(ValidTypes.MyInt)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "getMyInt", result)
+	return p.SendReply(ctx, oprot, "getMyInt", &result)
 }
 
 type fooFUseSubdirStruct struct {
@@ -688,7 +688,7 @@ func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
 	}
 	result := FooUseSubdirStructResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.A})
@@ -703,12 +703,12 @@ func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.
 			p.SendError(ctx, oprot, typedError.TypeId(), "use_subdir_struct", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
 	} else {
 		var retval *subdir_include.A = ret[0].(*subdir_include.A)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "use_subdir_struct", result)
+	return p.SendReply(ctx, oprot, "use_subdir_struct", &result)
 }
 
 type fooFSayHelloWith struct {
@@ -720,7 +720,7 @@ func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
 	}
 	result := FooSayHelloWithResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.NewMessage_})
@@ -735,12 +735,12 @@ func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 			p.SendError(ctx, oprot, typedError.TypeId(), "sayHelloWith", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "sayHelloWith", result)
+	return p.SendReply(ctx, oprot, "sayHelloWith", &result)
 }
 
 type fooFWhatDoYouSay struct {
@@ -752,7 +752,7 @@ func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
 	}
 	result := FooWhatDoYouSayResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageArgs_})
@@ -767,12 +767,12 @@ func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 			p.SendError(ctx, oprot, typedError.TypeId(), "whatDoYouSay", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "whatDoYouSay", result)
+	return p.SendReply(ctx, oprot, "whatDoYouSay", &result)
 }
 
 type fooFSayAgain struct {
@@ -784,7 +784,7 @@ func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
 	}
 	result := FooSayAgainResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageResult_})
@@ -799,12 +799,12 @@ func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "sayAgain", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "sayAgain", result)
+	return p.SendReply(ctx, oprot, "sayAgain", &result)
 }
 
 type FooPingArgs struct {

--- a/test/expected/go/slim/f_foo_service.go
+++ b/test/expected/go/slim/f_foo_service.go
@@ -41,18 +41,14 @@ type FFoo interface {
 // a frugal Context for each service call.
 type FFooClient struct {
 	*golang.FBaseFooClient
-	transport       frugal.FTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	methods map[string]*frugal.Method
 }
 
 func NewFFooClient(provider *frugal.FServiceProvider, middleware ...frugal.ServiceMiddleware) *FFooClient {
 	methods := make(map[string]*frugal.Method)
 	client := &FFooClient{
-		FBaseFooClient:  golang.NewFBaseFooClient(provider, middleware...),
-		transport:       provider.GetTransport(),
-		protocolFactory: provider.GetProtocolFactory(),
-		methods:         methods,
+		FBaseFooClient: golang.NewFBaseFooClient(provider, middleware...),
+		methods:        methods,
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
 	methods["ping"] = frugal.NewMethod(client, client.ping, "ping", middleware)
@@ -84,67 +80,10 @@ func (f *FFooClient) Ping(ctx frugal.FContext) (err error) {
 }
 
 func (f *FFooClient) ping(ctx frugal.FContext) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("ping", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooPingArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "ping" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "ping failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "ping failed: invalid message type")
-		return
-	}
 	result := FooPingResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "ping", &args, &result)
+	if err != nil {
 		return
 	}
 	return
@@ -166,71 +105,14 @@ func (f *FFooClient) Blah(ctx frugal.FContext, num int32, str string, event *Eve
 }
 
 func (f *FFooClient) blah(ctx frugal.FContext, num int32, str string, event *Event) (r int64, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("blah", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooBlahArgs{
 		Num:   num,
 		Str:   str,
 		Event: event,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "blah" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "blah failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "blah failed: invalid message type")
-		return
-	}
 	result := FooBlahResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "blah", &args, &result)
+	if err != nil {
 		return
 	}
 	if result.Awe != nil {
@@ -258,29 +140,11 @@ func (f *FFooClient) OneWay(ctx frugal.FContext, id ID, req Request) (err error)
 }
 
 func (f *FFooClient) oneWay(ctx frugal.FContext, id ID, req Request) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("oneWay", thrift.ONEWAY, 0); err != nil {
-		return
-	}
 	args := FooOneWayArgs{
 		ID:  id,
 		Req: req,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	err = f.transport.Oneway(ctx, buffer.Bytes())
-	return
+	return f.Client_().Oneway(ctx, "oneWay", &args)
 }
 
 func (f *FFooClient) BinMethod(ctx frugal.FContext, bin []byte, str string) (r []byte, err error) {
@@ -298,70 +162,13 @@ func (f *FFooClient) BinMethod(ctx frugal.FContext, bin []byte, str string) (r [
 }
 
 func (f *FFooClient) bin_method(ctx frugal.FContext, bin []byte, str string) (r []byte, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("bin_method", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooBinMethodArgs{
 		Bin: bin,
 		Str: str,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "bin_method" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "bin_method failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "bin_method failed: invalid message type")
-		return
-	}
 	result := FooBinMethodResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "bin_method", &args, &result)
+	if err != nil {
 		return
 	}
 	if result.API != nil {
@@ -387,71 +194,14 @@ func (f *FFooClient) ParamModifiers(ctx frugal.FContext, opt_num int32, default_
 }
 
 func (f *FFooClient) param_modifiers(ctx frugal.FContext, opt_num int32, default_num int32, req_num int32) (r int64, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("param_modifiers", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooParamModifiersArgs{
 		OptNum:     opt_num,
 		DefaultNum: default_num,
 		ReqNum:     req_num,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "param_modifiers" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "param_modifiers failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "param_modifiers failed: invalid message type")
-		return
-	}
 	result := FooParamModifiersResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "param_modifiers", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -473,70 +223,13 @@ func (f *FFooClient) UnderlyingTypesTest(ctx frugal.FContext, list_type []ID, se
 }
 
 func (f *FFooClient) underlying_types_test(ctx frugal.FContext, list_type []ID, set_type map[ID]bool) (r []ID, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("underlying_types_test", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooUnderlyingTypesTestArgs{
 		ListType: list_type,
 		SetType:  set_type,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "underlying_types_test" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "underlying_types_test failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "underlying_types_test failed: invalid message type")
-		return
-	}
 	result := FooUnderlyingTypesTestResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "underlying_types_test", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -558,67 +251,10 @@ func (f *FFooClient) GetThing(ctx frugal.FContext) (r *validStructs.Thing, err e
 }
 
 func (f *FFooClient) getThing(ctx frugal.FContext) (r *validStructs.Thing, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("getThing", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooGetThingArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "getThing" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "getThing failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "getThing failed: invalid message type")
-		return
-	}
 	result := FooGetThingResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "getThing", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -640,67 +276,10 @@ func (f *FFooClient) GetMyInt(ctx frugal.FContext) (r ValidTypes.MyInt, err erro
 }
 
 func (f *FFooClient) getMyInt(ctx frugal.FContext) (r ValidTypes.MyInt, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("getMyInt", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooGetMyIntArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "getMyInt" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "getMyInt failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "getMyInt failed: invalid message type")
-		return
-	}
 	result := FooGetMyIntResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "getMyInt", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -722,69 +301,12 @@ func (f *FFooClient) UseSubdirStruct(ctx frugal.FContext, a *subdir_include.A) (
 }
 
 func (f *FFooClient) use_subdir_struct(ctx frugal.FContext, a *subdir_include.A) (r *subdir_include.A, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("use_subdir_struct", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooUseSubdirStructArgs{
 		A: a,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "use_subdir_struct" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "use_subdir_struct failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "use_subdir_struct failed: invalid message type")
-		return
-	}
 	result := FooUseSubdirStructResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "use_subdir_struct", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -806,69 +328,12 @@ func (f *FFooClient) SayHelloWith(ctx frugal.FContext, newmessage string) (r str
 }
 
 func (f *FFooClient) sayHelloWith(ctx frugal.FContext, newmessage string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("sayHelloWith", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooSayHelloWithArgs{
 		NewMessage_: newmessage,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "sayHelloWith" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "sayHelloWith failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "sayHelloWith failed: invalid message type")
-		return
-	}
 	result := FooSayHelloWithResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "sayHelloWith", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -890,69 +355,12 @@ func (f *FFooClient) WhatDoYouSay(ctx frugal.FContext, messageargs string) (r st
 }
 
 func (f *FFooClient) whatDoYouSay(ctx frugal.FContext, messageargs string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("whatDoYouSay", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooWhatDoYouSayArgs{
 		MessageArgs_: messageargs,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "whatDoYouSay" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "whatDoYouSay failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "whatDoYouSay failed: invalid message type")
-		return
-	}
 	result := FooWhatDoYouSayResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "whatDoYouSay", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -974,69 +382,12 @@ func (f *FFooClient) SayAgain(ctx frugal.FContext, messageresult string) (r stri
 }
 
 func (f *FFooClient) sayAgain(ctx frugal.FContext, messageresult string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("sayAgain", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooSayAgainArgs{
 		MessageResult_: messageresult,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "sayAgain" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "sayAgain failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "sayAgain failed: invalid message type")
-		return
-	}
 	result := FooSayAgainResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "sayAgain", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -1073,79 +424,27 @@ type fooFPing struct {
 
 func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooPingArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
+	}
 	result := FooPingResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("ping", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "ping", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("ping", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "ping", result)
 }
 
 type fooFBlah struct {
@@ -1154,89 +453,37 @@ type fooFBlah struct {
 
 func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooBlahArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
+	}
 	result := FooBlahResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.Num, args.Str, args.Event})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("blah", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "blah", typedError.Error())
 			return nil
 		}
-		switch v := err2.(type) {
+		switch v := err.(type) {
 		case *AwesomeException:
 			result.Awe = v
 		case *golang.APIException:
 			result.API = v
 		default:
-			p.GetWriteMutex().Lock()
-			err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err2.Error())
-			p.GetWriteMutex().Unlock()
-			return err2
+			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
 		}
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("blah", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "blah", result)
 }
 
 type fooFOneWay struct {
@@ -1245,33 +492,24 @@ type fooFOneWay struct {
 
 func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooOneWayArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
-	var err2 error
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
+	}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ID, args.Req})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("oneWay", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "oneWay", typedError.Error())
 			return nil
 		}
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
 	}
 	return err
 }
@@ -1282,87 +520,35 @@ type fooFBinMethod struct {
 
 func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooBinMethodArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
+	}
 	result := FooBinMethodResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.Bin, args.Str})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("bin_method", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "bin_method", typedError.Error())
 			return nil
 		}
-		switch v := err2.(type) {
+		switch v := err.(type) {
 		case *golang.APIException:
 			result.API = v
 		default:
-			p.GetWriteMutex().Lock()
-			err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err2.Error())
-			p.GetWriteMutex().Unlock()
-			return err2
+			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
 		}
 	} else {
 		var retval []byte = ret[0].([]byte)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("bin_method", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "bin_method", result)
 }
 
 type fooFParamModifiers struct {
@@ -1371,82 +557,30 @@ type fooFParamModifiers struct {
 
 func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooParamModifiersArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
+	}
 	result := FooParamModifiersResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.OptNum, args.DefaultNum, args.ReqNum})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("param_modifiers", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "param_modifiers", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("param_modifiers", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "param_modifiers", result)
 }
 
 type fooFUnderlyingTypesTest struct {
@@ -1455,82 +589,30 @@ type fooFUnderlyingTypesTest struct {
 
 func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooUnderlyingTypesTestArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
+	}
 	result := FooUnderlyingTypesTestResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.ListType, args.SetType})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("underlying_types_test", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "underlying_types_test", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
 	} else {
 		var retval []ID = ret[0].([]ID)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("underlying_types_test", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "underlying_types_test", result)
 }
 
 type fooFGetThing struct {
@@ -1539,82 +621,30 @@ type fooFGetThing struct {
 
 func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooGetThingArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
+	}
 	result := FooGetThingResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("getThing", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "getThing", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
 	} else {
 		var retval *validStructs.Thing = ret[0].(*validStructs.Thing)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("getThing", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "getThing", result)
 }
 
 type fooFGetMyInt struct {
@@ -1623,82 +653,30 @@ type fooFGetMyInt struct {
 
 func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooGetMyIntArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
+	}
 	result := FooGetMyIntResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("getMyInt", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "getMyInt", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
 	} else {
 		var retval ValidTypes.MyInt = ret[0].(ValidTypes.MyInt)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("getMyInt", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "getMyInt", result)
 }
 
 type fooFUseSubdirStruct struct {
@@ -1707,82 +685,30 @@ type fooFUseSubdirStruct struct {
 
 func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooUseSubdirStructArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
+	}
 	result := FooUseSubdirStructResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.A})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("use_subdir_struct", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "use_subdir_struct", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
 	} else {
 		var retval *subdir_include.A = ret[0].(*subdir_include.A)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("use_subdir_struct", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "use_subdir_struct", result)
 }
 
 type fooFSayHelloWith struct {
@@ -1791,82 +717,30 @@ type fooFSayHelloWith struct {
 
 func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooSayHelloWithArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
+	}
 	result := FooSayHelloWithResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.NewMessage_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("sayHelloWith", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "sayHelloWith", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("sayHelloWith", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "sayHelloWith", result)
 }
 
 type fooFWhatDoYouSay struct {
@@ -1875,82 +749,30 @@ type fooFWhatDoYouSay struct {
 
 func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooWhatDoYouSayArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
+	}
 	result := FooWhatDoYouSayResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageArgs_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("whatDoYouSay", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "whatDoYouSay", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("whatDoYouSay", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "whatDoYouSay", result)
 }
 
 type fooFSayAgain struct {
@@ -1959,92 +781,30 @@ type fooFSayAgain struct {
 
 func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooSayAgainArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
+	}
 	result := FooSayAgainResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageResult_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("sayAgain", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "sayAgain", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("sayAgain", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
-}
-
-func fooWriteApplicationError(ctx frugal.FContext, oprot *frugal.FProtocol, type_ int32, method, message string) error {
-	x := thrift.NewTApplicationException(type_, message)
-	oprot.WriteResponseHeader(ctx)
-	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
-	x.Write(oprot)
-	oprot.WriteMessageEnd()
-	oprot.Flush()
-	return x
+	return p.SendReply(ctx, oprot, "sayAgain", result)
 }
 
 type FooPingArgs struct {

--- a/test/expected/go/variety/f_events_scope.txt
+++ b/test/expected/go/variety/f_events_scope.txt
@@ -14,6 +14,8 @@ import (
 // the @ sign. Prefix specifies topic prefix tokens, which can be static or
 // variable.
 type EventsPublisher interface {
+	Open() error
+	Close() error
 	PublishEventCreated(ctx frugal.FContext, user string, req *Event) error
 	PublishSomeInt(ctx frugal.FContext, user string, req int64) error
 	PublishSomeStr(ctx frugal.FContext, user string, req string) error
@@ -37,6 +39,9 @@ func NewEventsPublisher(provider *frugal.FScopeProvider, middleware ...frugal.Se
 	publisher.methods["publishSomeList"] = frugal.NewMethod(publisher, publisher.publishSomeList, "publishSomeList", middleware)
 	return publisher
 }
+
+func (p eventsPublisher) Open() error  { return p.client.Open() }
+func (p eventsPublisher) Close() error { return p.client.Close() }
 
 // This is a docstring.
 func (p *eventsPublisher) PublishEventCreated(ctx frugal.FContext, user string, req *Event) error {

--- a/test/expected/go/variety/f_events_scope.txt
+++ b/test/expected/go/variety/f_events_scope.txt
@@ -10,8 +10,6 @@ import (
 	"github.com/Workiva/frugal/lib/go"
 )
 
-const delimiter = "."
-
 // This docstring gets added to the generated code because it has
 // the @ sign. Prefix specifies topic prefix tokens, which can be static or
 // variable.
@@ -25,33 +23,21 @@ type EventsPublisher interface {
 }
 
 type eventsPublisher struct {
-	transport       frugal.FPublisherTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	client  frugal.FClient
+	methods map[string]*frugal.Method
 }
 
 func NewEventsPublisher(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) EventsPublisher {
-	transport, protocolFactory := provider.NewPublisher()
-	methods := make(map[string]*frugal.Method)
 	publisher := &eventsPublisher{
-		transport:       transport,
-		protocolFactory: protocolFactory,
-		methods:         methods,
+		client:  frugal.NewFPublisherClient(provider),
+		methods: make(map[string]*frugal.Method),
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
-	methods["publishEventCreated"] = frugal.NewMethod(publisher, publisher.publishEventCreated, "publishEventCreated", middleware)
-	methods["publishSomeInt"] = frugal.NewMethod(publisher, publisher.publishSomeInt, "publishSomeInt", middleware)
-	methods["publishSomeStr"] = frugal.NewMethod(publisher, publisher.publishSomeStr, "publishSomeStr", middleware)
-	methods["publishSomeList"] = frugal.NewMethod(publisher, publisher.publishSomeList, "publishSomeList", middleware)
+	publisher.methods["publishEventCreated"] = frugal.NewMethod(publisher, publisher.publishEventCreated, "publishEventCreated", middleware)
+	publisher.methods["publishSomeInt"] = frugal.NewMethod(publisher, publisher.publishSomeInt, "publishSomeInt", middleware)
+	publisher.methods["publishSomeStr"] = frugal.NewMethod(publisher, publisher.publishSomeStr, "publishSomeStr", middleware)
+	publisher.methods["publishSomeList"] = frugal.NewMethod(publisher, publisher.publishSomeList, "publishSomeList", middleware)
 	return publisher
-}
-
-func (p *eventsPublisher) Open() error {
-	return p.transport.Open()
-}
-
-func (p *eventsPublisher) Close() error {
-	return p.transport.Close()
 }
 
 // This is a docstring.
@@ -65,27 +51,9 @@ func (p *eventsPublisher) PublishEventCreated(ctx frugal.FContext, user string, 
 
 func (p *eventsPublisher) publishEventCreated(ctx frugal.FContext, user string, req *Event) error {
 	ctx.AddRequestHeader("_topic_user", user)
-	op := "EventCreated"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
-	buffer := frugal.NewTMemoryOutputBuffer(p.transport.GetPublishSizeLimit())
-	oprot := p.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return err
-	}
-	if err := oprot.WriteMessageBegin(op, thrift.CALL, 0); err != nil {
-		return err
-	}
-	if err := req.Write(oprot); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", req), err)
-	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return err
-	}
-	if err := oprot.Flush(); err != nil {
-		return err
-	}
-	return p.transport.Publish(topic, buffer.Bytes())
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
+	return p.client.Publish(ctx, "EventCreated", topic, req)
 }
 
 func (p *eventsPublisher) PublishSomeInt(ctx frugal.FContext, user string, req int64) error {
@@ -98,27 +66,22 @@ func (p *eventsPublisher) PublishSomeInt(ctx frugal.FContext, user string, req i
 
 func (p *eventsPublisher) publishSomeInt(ctx frugal.FContext, user string, req int64) error {
 	ctx.AddRequestHeader("_topic_user", user)
-	op := "SomeInt"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
-	buffer := frugal.NewTMemoryOutputBuffer(p.transport.GetPublishSizeLimit())
-	oprot := p.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return err
-	}
-	if err := oprot.WriteMessageBegin(op, thrift.CALL, 0); err != nil {
-		return err
-	}
-	if err := oprot.WriteI64(int64(req)); err != nil {
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
+	return p.client.Publish(ctx, "SomeInt", topic, eventsSomeIntMessage(req))
+}
+
+type eventsSomeIntMessage int64
+
+func (p eventsSomeIntMessage) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteI64(int64(p)); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
 	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return err
-	}
-	if err := oprot.Flush(); err != nil {
-		return err
-	}
-	return p.transport.Publish(topic, buffer.Bytes())
+	return nil
+}
+
+func (p eventsSomeIntMessage) Read(iprot thrift.TProcotol) error {
+	panic("Not Implemented!")
 }
 
 func (p *eventsPublisher) PublishSomeStr(ctx frugal.FContext, user string, req string) error {
@@ -131,27 +94,22 @@ func (p *eventsPublisher) PublishSomeStr(ctx frugal.FContext, user string, req s
 
 func (p *eventsPublisher) publishSomeStr(ctx frugal.FContext, user string, req string) error {
 	ctx.AddRequestHeader("_topic_user", user)
-	op := "SomeStr"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
-	buffer := frugal.NewTMemoryOutputBuffer(p.transport.GetPublishSizeLimit())
-	oprot := p.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return err
-	}
-	if err := oprot.WriteMessageBegin(op, thrift.CALL, 0); err != nil {
-		return err
-	}
-	if err := oprot.WriteString(string(req)); err != nil {
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
+	return p.client.Publish(ctx, "SomeStr", topic, eventsSomeStrMessage(req))
+}
+
+type eventsSomeStrMessage string
+
+func (p eventsSomeStrMessage) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteString(string(p)); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
 	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return err
-	}
-	if err := oprot.Flush(); err != nil {
-		return err
-	}
-	return p.transport.Publish(topic, buffer.Bytes())
+	return nil
+}
+
+func (p eventsSomeStrMessage) Read(iprot thrift.TProcotol) error {
+	panic("Not Implemented!")
 }
 
 func (p *eventsPublisher) PublishSomeList(ctx frugal.FContext, user string, req []map[ID]*Event) error {
@@ -164,21 +122,18 @@ func (p *eventsPublisher) PublishSomeList(ctx frugal.FContext, user string, req 
 
 func (p *eventsPublisher) publishSomeList(ctx frugal.FContext, user string, req []map[ID]*Event) error {
 	ctx.AddRequestHeader("_topic_user", user)
-	op := "SomeList"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
-	buffer := frugal.NewTMemoryOutputBuffer(p.transport.GetPublishSizeLimit())
-	oprot := p.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return err
-	}
-	if err := oprot.WriteMessageBegin(op, thrift.CALL, 0); err != nil {
-		return err
-	}
-	if err := oprot.WriteListBegin(thrift.MAP, len(req)); err != nil {
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
+	return p.client.Publish(ctx, "SomeList", topic, eventsSomeListMessage(req))
+}
+
+type eventsSomeListMessage []map[ID]*Event
+
+func (p eventsSomeListMessage) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteListBegin(thrift.MAP, len(p)); err != nil {
 		return thrift.PrependError("error writing list begin: ", err)
 	}
-	for _, v := range req {
+	for _, v := range p {
 		if err := oprot.WriteMapBegin(thrift.I64, thrift.STRUCT, len(v)); err != nil {
 			return thrift.PrependError("error writing map begin: ", err)
 		}
@@ -197,13 +152,11 @@ func (p *eventsPublisher) publishSomeList(ctx frugal.FContext, user string, req 
 	if err := oprot.WriteListEnd(); err != nil {
 		return thrift.PrependError("error writing list end: ", err)
 	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return err
-	}
-	if err := oprot.Flush(); err != nil {
-		return err
-	}
-	return p.transport.Publish(topic, buffer.Bytes())
+	return nil
+}
+
+func (p eventsSomeListMessage) Read(iprot thrift.TProcotol) error {
+	panic("Not Implemented!")
 }
 
 // This docstring gets added to the generated code because it has
@@ -253,7 +206,7 @@ func (l *eventsSubscriber) SubscribeEventCreated(user string, handler func(fruga
 func (l *eventsSubscriber) SubscribeEventCreatedErrorable(user string, handler func(frugal.FContext, *Event) error) (*frugal.FSubscription, error) {
 	op := "EventCreated"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
 	transport, protocolFactory := l.provider.NewSubscriber()
 	cb := l.recvEventCreated(op, protocolFactory, handler)
 	if err := transport.Subscribe(topic, cb); err != nil {
@@ -303,7 +256,7 @@ func (l *eventsSubscriber) SubscribeSomeInt(user string, handler func(frugal.FCo
 func (l *eventsSubscriber) SubscribeSomeIntErrorable(user string, handler func(frugal.FContext, int64) error) (*frugal.FSubscription, error) {
 	op := "SomeInt"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
 	transport, protocolFactory := l.provider.NewSubscriber()
 	cb := l.recvSomeInt(op, protocolFactory, handler)
 	if err := transport.Subscribe(topic, cb); err != nil {
@@ -355,7 +308,7 @@ func (l *eventsSubscriber) SubscribeSomeStr(user string, handler func(frugal.FCo
 func (l *eventsSubscriber) SubscribeSomeStrErrorable(user string, handler func(frugal.FContext, string) error) (*frugal.FSubscription, error) {
 	op := "SomeStr"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
 	transport, protocolFactory := l.provider.NewSubscriber()
 	cb := l.recvSomeStr(op, protocolFactory, handler)
 	if err := transport.Subscribe(topic, cb); err != nil {
@@ -407,7 +360,7 @@ func (l *eventsSubscriber) SubscribeSomeList(user string, handler func(frugal.FC
 func (l *eventsSubscriber) SubscribeSomeListErrorable(user string, handler func(frugal.FContext, []map[ID]*Event) error) (*frugal.FSubscription, error) {
 	op := "SomeList"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
 	transport, protocolFactory := l.provider.NewSubscriber()
 	cb := l.recvSomeList(op, protocolFactory, handler)
 	if err := transport.Subscribe(topic, cb); err != nil {

--- a/test/expected/go/variety/f_events_scope.txt
+++ b/test/expected/go/variety/f_events_scope.txt
@@ -14,8 +14,6 @@ import (
 // the @ sign. Prefix specifies topic prefix tokens, which can be static or
 // variable.
 type EventsPublisher interface {
-	Open() error
-	Close() error
 	PublishEventCreated(ctx frugal.FContext, user string, req *Event) error
 	PublishSomeInt(ctx frugal.FContext, user string, req int64) error
 	PublishSomeStr(ctx frugal.FContext, user string, req string) error
@@ -29,7 +27,7 @@ type eventsPublisher struct {
 
 func NewEventsPublisher(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) EventsPublisher {
 	publisher := &eventsPublisher{
-		client:  frugal.NewFPublisherClient(provider),
+		client:  frugal.NewFScopeClient(provider),
 		methods: make(map[string]*frugal.Method),
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
@@ -52,8 +50,9 @@ func (p *eventsPublisher) PublishEventCreated(ctx frugal.FContext, user string, 
 func (p *eventsPublisher) publishEventCreated(ctx frugal.FContext, user string, req *Event) error {
 	ctx.AddRequestHeader("_topic_user", user)
 	prefix := fmt.Sprintf("foo.%s.", user)
+	op := "EventCreated"
 	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
-	return p.client.Publish(ctx, "EventCreated", topic, req)
+	return p.client.Publish(ctx, op, topic, req)
 }
 
 func (p *eventsPublisher) PublishSomeInt(ctx frugal.FContext, user string, req int64) error {
@@ -67,8 +66,9 @@ func (p *eventsPublisher) PublishSomeInt(ctx frugal.FContext, user string, req i
 func (p *eventsPublisher) publishSomeInt(ctx frugal.FContext, user string, req int64) error {
 	ctx.AddRequestHeader("_topic_user", user)
 	prefix := fmt.Sprintf("foo.%s.", user)
+	op := "SomeInt"
 	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
-	return p.client.Publish(ctx, "SomeInt", topic, eventsSomeIntMessage(req))
+	return p.client.Publish(ctx, op, topic, eventsSomeIntMessage(req))
 }
 
 type eventsSomeIntMessage int64
@@ -80,7 +80,7 @@ func (p eventsSomeIntMessage) Write(oprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p eventsSomeIntMessage) Read(iprot thrift.TProcotol) error {
+func (p eventsSomeIntMessage) Read(iprot thrift.TProtocol) error {
 	panic("Not Implemented!")
 }
 
@@ -95,8 +95,9 @@ func (p *eventsPublisher) PublishSomeStr(ctx frugal.FContext, user string, req s
 func (p *eventsPublisher) publishSomeStr(ctx frugal.FContext, user string, req string) error {
 	ctx.AddRequestHeader("_topic_user", user)
 	prefix := fmt.Sprintf("foo.%s.", user)
+	op := "SomeStr"
 	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
-	return p.client.Publish(ctx, "SomeStr", topic, eventsSomeStrMessage(req))
+	return p.client.Publish(ctx, op, topic, eventsSomeStrMessage(req))
 }
 
 type eventsSomeStrMessage string
@@ -108,7 +109,7 @@ func (p eventsSomeStrMessage) Write(oprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p eventsSomeStrMessage) Read(iprot thrift.TProcotol) error {
+func (p eventsSomeStrMessage) Read(iprot thrift.TProtocol) error {
 	panic("Not Implemented!")
 }
 
@@ -123,8 +124,9 @@ func (p *eventsPublisher) PublishSomeList(ctx frugal.FContext, user string, req 
 func (p *eventsPublisher) publishSomeList(ctx frugal.FContext, user string, req []map[ID]*Event) error {
 	ctx.AddRequestHeader("_topic_user", user)
 	prefix := fmt.Sprintf("foo.%s.", user)
+	op := "SomeList"
 	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
-	return p.client.Publish(ctx, "SomeList", topic, eventsSomeListMessage(req))
+	return p.client.Publish(ctx, op, topic, eventsSomeListMessage(req))
 }
 
 type eventsSomeListMessage []map[ID]*Event
@@ -155,7 +157,7 @@ func (p eventsSomeListMessage) Write(oprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p eventsSomeListMessage) Read(iprot thrift.TProcotol) error {
+func (p eventsSomeListMessage) Read(iprot thrift.TProtocol) error {
 	panic("Not Implemented!")
 }
 

--- a/test/expected/go/variety/f_foo_service.txt
+++ b/test/expected/go/variety/f_foo_service.txt
@@ -437,7 +437,7 @@ func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
 	}
 	result := FooPingResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -452,9 +452,9 @@ func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 			p.SendError(ctx, oprot, typedError.TypeId(), "ping", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
 	}
-	return p.SendReply(ctx, oprot, "ping", result)
+	return p.SendReply(ctx, oprot, "ping", &result)
 }
 
 type fooFBlah struct {
@@ -466,7 +466,7 @@ func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
 	}
 	result := FooBlahResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.Num, args.Str, args.Event})
@@ -487,13 +487,13 @@ func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 		case *golang.APIException:
 			result.API = v
 		default:
-			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
+			return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
 		}
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "blah", result)
+	return p.SendReply(ctx, oprot, "blah", &result)
 }
 
 type fooFOneWay struct {
@@ -505,7 +505,7 @@ func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
 	}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ID, args.Req})
 	if len(ret) != 1 {
@@ -519,7 +519,7 @@ func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol
 			p.SendError(ctx, oprot, typedError.TypeId(), "oneWay", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
 	}
 	return err
 }
@@ -533,7 +533,7 @@ func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProto
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
 	}
 	result := FooBinMethodResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.Bin, args.Str})
@@ -552,13 +552,13 @@ func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProto
 		case *golang.APIException:
 			result.API = v
 		default:
-			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
+			return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
 		}
 	} else {
 		var retval []byte = ret[0].([]byte)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "bin_method", result)
+	return p.SendReply(ctx, oprot, "bin_method", &result)
 }
 
 type fooFParamModifiers struct {
@@ -570,7 +570,7 @@ func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.F
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
 	}
 	result := FooParamModifiersResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.OptNum, args.DefaultNum, args.ReqNum})
@@ -585,12 +585,12 @@ func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.F
 			p.SendError(ctx, oprot, typedError.TypeId(), "param_modifiers", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "param_modifiers", result)
+	return p.SendReply(ctx, oprot, "param_modifiers", &result)
 }
 
 type fooFUnderlyingTypesTest struct {
@@ -602,7 +602,7 @@ func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *fru
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
 	}
 	result := FooUnderlyingTypesTestResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ListType, args.SetType})
@@ -617,12 +617,12 @@ func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *fru
 			p.SendError(ctx, oprot, typedError.TypeId(), "underlying_types_test", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
 	} else {
 		var retval []ID = ret[0].([]ID)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "underlying_types_test", result)
+	return p.SendReply(ctx, oprot, "underlying_types_test", &result)
 }
 
 type fooFGetThing struct {
@@ -634,7 +634,7 @@ func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
 	}
 	result := FooGetThingResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -649,12 +649,12 @@ func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "getThing", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
 	} else {
 		var retval *validStructs.Thing = ret[0].(*validStructs.Thing)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "getThing", result)
+	return p.SendReply(ctx, oprot, "getThing", &result)
 }
 
 type fooFGetMyInt struct {
@@ -666,7 +666,7 @@ func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
 	}
 	result := FooGetMyIntResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -681,12 +681,12 @@ func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "getMyInt", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
 	} else {
 		var retval ValidTypes.MyInt = ret[0].(ValidTypes.MyInt)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "getMyInt", result)
+	return p.SendReply(ctx, oprot, "getMyInt", &result)
 }
 
 type fooFUseSubdirStruct struct {
@@ -698,7 +698,7 @@ func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
 	}
 	result := FooUseSubdirStructResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.A})
@@ -713,12 +713,12 @@ func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.
 			p.SendError(ctx, oprot, typedError.TypeId(), "use_subdir_struct", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
 	} else {
 		var retval *subdir_include.A = ret[0].(*subdir_include.A)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "use_subdir_struct", result)
+	return p.SendReply(ctx, oprot, "use_subdir_struct", &result)
 }
 
 type fooFSayHelloWith struct {
@@ -730,7 +730,7 @@ func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
 	}
 	result := FooSayHelloWithResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.NewMessage_})
@@ -745,12 +745,12 @@ func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 			p.SendError(ctx, oprot, typedError.TypeId(), "sayHelloWith", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "sayHelloWith", result)
+	return p.SendReply(ctx, oprot, "sayHelloWith", &result)
 }
 
 type fooFWhatDoYouSay struct {
@@ -762,7 +762,7 @@ func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
 	}
 	result := FooWhatDoYouSayResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageArgs_})
@@ -777,12 +777,12 @@ func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 			p.SendError(ctx, oprot, typedError.TypeId(), "whatDoYouSay", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "whatDoYouSay", result)
+	return p.SendReply(ctx, oprot, "whatDoYouSay", &result)
 }
 
 type fooFSayAgain struct {
@@ -794,7 +794,7 @@ func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
 	}
 	result := FooSayAgainResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageResult_})
@@ -809,12 +809,12 @@ func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "sayAgain", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "sayAgain", result)
+	return p.SendReply(ctx, oprot, "sayAgain", &result)
 }
 
 type FooPingArgs struct {

--- a/test/expected/go/variety/f_foo_service.txt
+++ b/test/expected/go/variety/f_foo_service.txt
@@ -49,18 +49,14 @@ type FFoo interface {
 // a frugal Context for each service call.
 type FFooClient struct {
 	*golang.FBaseFooClient
-	transport       frugal.FTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	methods map[string]*frugal.Method
 }
 
 func NewFFooClient(provider *frugal.FServiceProvider, middleware ...frugal.ServiceMiddleware) *FFooClient {
 	methods := make(map[string]*frugal.Method)
 	client := &FFooClient{
-		FBaseFooClient:  golang.NewFBaseFooClient(provider, middleware...),
-		transport:       provider.GetTransport(),
-		protocolFactory: provider.GetProtocolFactory(),
-		methods:         methods,
+		FBaseFooClient: golang.NewFBaseFooClient(provider, middleware...),
+		methods:        methods,
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
 	methods["ping"] = frugal.NewMethod(client, client.ping, "ping", middleware)
@@ -93,67 +89,10 @@ func (f *FFooClient) Ping(ctx frugal.FContext) (err error) {
 }
 
 func (f *FFooClient) ping(ctx frugal.FContext) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("ping", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooPingArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "ping" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "ping failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "ping failed: invalid message type")
-		return
-	}
 	result := FooPingResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "ping", &args, &result)
+	if err != nil {
 		return
 	}
 	return
@@ -175,71 +114,14 @@ func (f *FFooClient) Blah(ctx frugal.FContext, num int32, str string, event *Eve
 }
 
 func (f *FFooClient) blah(ctx frugal.FContext, num int32, str string, event *Event) (r int64, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("blah", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooBlahArgs{
 		Num:   num,
 		Str:   str,
 		Event: event,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "blah" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "blah failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "blah failed: invalid message type")
-		return
-	}
 	result := FooBlahResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "blah", &args, &result)
+	if err != nil {
 		return
 	}
 	if result.Awe != nil {
@@ -267,29 +149,11 @@ func (f *FFooClient) OneWay(ctx frugal.FContext, id ID, req Request) (err error)
 }
 
 func (f *FFooClient) oneWay(ctx frugal.FContext, id ID, req Request) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("oneWay", thrift.ONEWAY, 0); err != nil {
-		return
-	}
 	args := FooOneWayArgs{
 		ID:  id,
 		Req: req,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	err = f.transport.Oneway(ctx, buffer.Bytes())
-	return
+	return f.Client_().Oneway(ctx, "oneWay", &args)
 }
 
 func (f *FFooClient) BinMethod(ctx frugal.FContext, bin []byte, str string) (r []byte, err error) {
@@ -307,70 +171,13 @@ func (f *FFooClient) BinMethod(ctx frugal.FContext, bin []byte, str string) (r [
 }
 
 func (f *FFooClient) bin_method(ctx frugal.FContext, bin []byte, str string) (r []byte, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("bin_method", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooBinMethodArgs{
 		Bin: bin,
 		Str: str,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "bin_method" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "bin_method failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "bin_method failed: invalid message type")
-		return
-	}
 	result := FooBinMethodResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "bin_method", &args, &result)
+	if err != nil {
 		return
 	}
 	if result.API != nil {
@@ -396,71 +203,14 @@ func (f *FFooClient) ParamModifiers(ctx frugal.FContext, opt_num int32, default_
 }
 
 func (f *FFooClient) param_modifiers(ctx frugal.FContext, opt_num int32, default_num int32, req_num int32) (r int64, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("param_modifiers", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooParamModifiersArgs{
 		OptNum:     opt_num,
 		DefaultNum: default_num,
 		ReqNum:     req_num,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "param_modifiers" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "param_modifiers failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "param_modifiers failed: invalid message type")
-		return
-	}
 	result := FooParamModifiersResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "param_modifiers", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -482,70 +232,13 @@ func (f *FFooClient) UnderlyingTypesTest(ctx frugal.FContext, list_type []ID, se
 }
 
 func (f *FFooClient) underlying_types_test(ctx frugal.FContext, list_type []ID, set_type map[ID]bool) (r []ID, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("underlying_types_test", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooUnderlyingTypesTestArgs{
 		ListType: list_type,
 		SetType:  set_type,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "underlying_types_test" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "underlying_types_test failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "underlying_types_test failed: invalid message type")
-		return
-	}
 	result := FooUnderlyingTypesTestResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "underlying_types_test", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -567,67 +260,10 @@ func (f *FFooClient) GetThing(ctx frugal.FContext) (r *validStructs.Thing, err e
 }
 
 func (f *FFooClient) getThing(ctx frugal.FContext) (r *validStructs.Thing, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("getThing", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooGetThingArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "getThing" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "getThing failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "getThing failed: invalid message type")
-		return
-	}
 	result := FooGetThingResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "getThing", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -649,67 +285,10 @@ func (f *FFooClient) GetMyInt(ctx frugal.FContext) (r ValidTypes.MyInt, err erro
 }
 
 func (f *FFooClient) getMyInt(ctx frugal.FContext) (r ValidTypes.MyInt, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("getMyInt", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooGetMyIntArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "getMyInt" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "getMyInt failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "getMyInt failed: invalid message type")
-		return
-	}
 	result := FooGetMyIntResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "getMyInt", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -731,69 +310,12 @@ func (f *FFooClient) UseSubdirStruct(ctx frugal.FContext, a *subdir_include.A) (
 }
 
 func (f *FFooClient) use_subdir_struct(ctx frugal.FContext, a *subdir_include.A) (r *subdir_include.A, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("use_subdir_struct", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooUseSubdirStructArgs{
 		A: a,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "use_subdir_struct" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "use_subdir_struct failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "use_subdir_struct failed: invalid message type")
-		return
-	}
 	result := FooUseSubdirStructResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "use_subdir_struct", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -815,69 +337,12 @@ func (f *FFooClient) SayHelloWith(ctx frugal.FContext, newmessage string) (r str
 }
 
 func (f *FFooClient) sayHelloWith(ctx frugal.FContext, newmessage string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("sayHelloWith", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooSayHelloWithArgs{
 		NewMessage_: newmessage,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "sayHelloWith" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "sayHelloWith failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "sayHelloWith failed: invalid message type")
-		return
-	}
 	result := FooSayHelloWithResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "sayHelloWith", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -899,69 +364,12 @@ func (f *FFooClient) WhatDoYouSay(ctx frugal.FContext, messageargs string) (r st
 }
 
 func (f *FFooClient) whatDoYouSay(ctx frugal.FContext, messageargs string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("whatDoYouSay", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooWhatDoYouSayArgs{
 		MessageArgs_: messageargs,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "whatDoYouSay" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "whatDoYouSay failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "whatDoYouSay failed: invalid message type")
-		return
-	}
 	result := FooWhatDoYouSayResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "whatDoYouSay", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -983,69 +391,12 @@ func (f *FFooClient) SayAgain(ctx frugal.FContext, messageresult string) (r stri
 }
 
 func (f *FFooClient) sayAgain(ctx frugal.FContext, messageresult string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("sayAgain", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooSayAgainArgs{
 		MessageResult_: messageresult,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "sayAgain" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "sayAgain failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "sayAgain failed: invalid message type")
-		return
-	}
 	result := FooSayAgainResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "sayAgain", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -1083,79 +434,27 @@ type fooFPing struct {
 func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	logrus.Warn("Deprecated function 'Foo.Ping' was called by a client")
 	args := FooPingArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
+	}
 	result := FooPingResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("ping", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "ping", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("ping", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "ping", result)
 }
 
 type fooFBlah struct {
@@ -1164,89 +463,37 @@ type fooFBlah struct {
 
 func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooBlahArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
+	}
 	result := FooBlahResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.Num, args.Str, args.Event})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("blah", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "blah", typedError.Error())
 			return nil
 		}
-		switch v := err2.(type) {
+		switch v := err.(type) {
 		case *AwesomeException:
 			result.Awe = v
 		case *golang.APIException:
 			result.API = v
 		default:
-			p.GetWriteMutex().Lock()
-			err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err2.Error())
-			p.GetWriteMutex().Unlock()
-			return err2
+			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
 		}
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("blah", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "blah", result)
 }
 
 type fooFOneWay struct {
@@ -1255,33 +502,24 @@ type fooFOneWay struct {
 
 func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooOneWayArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
-	var err2 error
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
+	}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ID, args.Req})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("oneWay", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "oneWay", typedError.Error())
 			return nil
 		}
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
 	}
 	return err
 }
@@ -1292,87 +530,35 @@ type fooFBinMethod struct {
 
 func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooBinMethodArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
+	}
 	result := FooBinMethodResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.Bin, args.Str})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("bin_method", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "bin_method", typedError.Error())
 			return nil
 		}
-		switch v := err2.(type) {
+		switch v := err.(type) {
 		case *golang.APIException:
 			result.API = v
 		default:
-			p.GetWriteMutex().Lock()
-			err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err2.Error())
-			p.GetWriteMutex().Unlock()
-			return err2
+			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
 		}
 	} else {
 		var retval []byte = ret[0].([]byte)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("bin_method", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "bin_method", result)
 }
 
 type fooFParamModifiers struct {
@@ -1381,82 +567,30 @@ type fooFParamModifiers struct {
 
 func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooParamModifiersArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
+	}
 	result := FooParamModifiersResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.OptNum, args.DefaultNum, args.ReqNum})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("param_modifiers", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "param_modifiers", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("param_modifiers", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "param_modifiers", result)
 }
 
 type fooFUnderlyingTypesTest struct {
@@ -1465,82 +599,30 @@ type fooFUnderlyingTypesTest struct {
 
 func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooUnderlyingTypesTestArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
+	}
 	result := FooUnderlyingTypesTestResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.ListType, args.SetType})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("underlying_types_test", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "underlying_types_test", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
 	} else {
 		var retval []ID = ret[0].([]ID)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("underlying_types_test", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "underlying_types_test", result)
 }
 
 type fooFGetThing struct {
@@ -1549,82 +631,30 @@ type fooFGetThing struct {
 
 func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooGetThingArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
+	}
 	result := FooGetThingResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("getThing", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "getThing", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
 	} else {
 		var retval *validStructs.Thing = ret[0].(*validStructs.Thing)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("getThing", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "getThing", result)
 }
 
 type fooFGetMyInt struct {
@@ -1633,82 +663,30 @@ type fooFGetMyInt struct {
 
 func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooGetMyIntArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
+	}
 	result := FooGetMyIntResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("getMyInt", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "getMyInt", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
 	} else {
 		var retval ValidTypes.MyInt = ret[0].(ValidTypes.MyInt)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("getMyInt", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "getMyInt", result)
 }
 
 type fooFUseSubdirStruct struct {
@@ -1717,82 +695,30 @@ type fooFUseSubdirStruct struct {
 
 func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooUseSubdirStructArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
+	}
 	result := FooUseSubdirStructResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.A})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("use_subdir_struct", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "use_subdir_struct", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
 	} else {
 		var retval *subdir_include.A = ret[0].(*subdir_include.A)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("use_subdir_struct", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "use_subdir_struct", result)
 }
 
 type fooFSayHelloWith struct {
@@ -1801,82 +727,30 @@ type fooFSayHelloWith struct {
 
 func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooSayHelloWithArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
+	}
 	result := FooSayHelloWithResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.NewMessage_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("sayHelloWith", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "sayHelloWith", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("sayHelloWith", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "sayHelloWith", result)
 }
 
 type fooFWhatDoYouSay struct {
@@ -1885,82 +759,30 @@ type fooFWhatDoYouSay struct {
 
 func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooWhatDoYouSayArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
+	}
 	result := FooWhatDoYouSayResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageArgs_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("whatDoYouSay", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "whatDoYouSay", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("whatDoYouSay", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "whatDoYouSay", result)
 }
 
 type fooFSayAgain struct {
@@ -1969,92 +791,30 @@ type fooFSayAgain struct {
 
 func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooSayAgainArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
+	}
 	result := FooSayAgainResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageResult_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("sayAgain", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "sayAgain", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("sayAgain", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
-}
-
-func fooWriteApplicationError(ctx frugal.FContext, oprot *frugal.FProtocol, type_ int32, method, message string) error {
-	x := thrift.NewTApplicationException(type_, message)
-	oprot.WriteResponseHeader(ctx)
-	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
-	x.Write(oprot)
-	oprot.WriteMessageEnd()
-	oprot.Flush()
-	return x
+	return p.SendReply(ctx, oprot, "sayAgain", result)
 }
 
 type FooPingArgs struct {

--- a/test/expected/go/variety_async/f_foo_service.txt
+++ b/test/expected/go/variety_async/f_foo_service.txt
@@ -596,7 +596,7 @@ func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
 	}
 	result := FooPingResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -611,9 +611,9 @@ func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 			p.SendError(ctx, oprot, typedError.TypeId(), "ping", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
 	}
-	return p.SendReply(ctx, oprot, "ping", result)
+	return p.SendReply(ctx, oprot, "ping", &result)
 }
 
 type fooFBlah struct {
@@ -625,7 +625,7 @@ func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
 	}
 	result := FooBlahResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.Num, args.Str, args.Event})
@@ -646,13 +646,13 @@ func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 		case *golang.APIException:
 			result.API = v
 		default:
-			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
+			return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
 		}
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "blah", result)
+	return p.SendReply(ctx, oprot, "blah", &result)
 }
 
 type fooFOneWay struct {
@@ -664,7 +664,7 @@ func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
 	}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ID, args.Req})
 	if len(ret) != 1 {
@@ -678,7 +678,7 @@ func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol
 			p.SendError(ctx, oprot, typedError.TypeId(), "oneWay", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
 	}
 	return err
 }
@@ -692,7 +692,7 @@ func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProto
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
 	}
 	result := FooBinMethodResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.Bin, args.Str})
@@ -711,13 +711,13 @@ func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProto
 		case *golang.APIException:
 			result.API = v
 		default:
-			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
+			return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
 		}
 	} else {
 		var retval []byte = ret[0].([]byte)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "bin_method", result)
+	return p.SendReply(ctx, oprot, "bin_method", &result)
 }
 
 type fooFParamModifiers struct {
@@ -729,7 +729,7 @@ func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.F
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
 	}
 	result := FooParamModifiersResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.OptNum, args.DefaultNum, args.ReqNum})
@@ -744,12 +744,12 @@ func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.F
 			p.SendError(ctx, oprot, typedError.TypeId(), "param_modifiers", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "param_modifiers", result)
+	return p.SendReply(ctx, oprot, "param_modifiers", &result)
 }
 
 type fooFUnderlyingTypesTest struct {
@@ -761,7 +761,7 @@ func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *fru
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
 	}
 	result := FooUnderlyingTypesTestResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ListType, args.SetType})
@@ -776,12 +776,12 @@ func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *fru
 			p.SendError(ctx, oprot, typedError.TypeId(), "underlying_types_test", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
 	} else {
 		var retval []ID = ret[0].([]ID)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "underlying_types_test", result)
+	return p.SendReply(ctx, oprot, "underlying_types_test", &result)
 }
 
 type fooFGetThing struct {
@@ -793,7 +793,7 @@ func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
 	}
 	result := FooGetThingResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -808,12 +808,12 @@ func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "getThing", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
 	} else {
 		var retval *validStructs.Thing = ret[0].(*validStructs.Thing)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "getThing", result)
+	return p.SendReply(ctx, oprot, "getThing", &result)
 }
 
 type fooFGetMyInt struct {
@@ -825,7 +825,7 @@ func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
 	}
 	result := FooGetMyIntResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -840,12 +840,12 @@ func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "getMyInt", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
 	} else {
 		var retval ValidTypes.MyInt = ret[0].(ValidTypes.MyInt)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "getMyInt", result)
+	return p.SendReply(ctx, oprot, "getMyInt", &result)
 }
 
 type fooFUseSubdirStruct struct {
@@ -857,7 +857,7 @@ func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
 	}
 	result := FooUseSubdirStructResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.A})
@@ -872,12 +872,12 @@ func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.
 			p.SendError(ctx, oprot, typedError.TypeId(), "use_subdir_struct", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
 	} else {
 		var retval *subdir_include.A = ret[0].(*subdir_include.A)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "use_subdir_struct", result)
+	return p.SendReply(ctx, oprot, "use_subdir_struct", &result)
 }
 
 type fooFSayHelloWith struct {
@@ -889,7 +889,7 @@ func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
 	}
 	result := FooSayHelloWithResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.NewMessage_})
@@ -904,12 +904,12 @@ func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 			p.SendError(ctx, oprot, typedError.TypeId(), "sayHelloWith", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "sayHelloWith", result)
+	return p.SendReply(ctx, oprot, "sayHelloWith", &result)
 }
 
 type fooFWhatDoYouSay struct {
@@ -921,7 +921,7 @@ func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
 	}
 	result := FooWhatDoYouSayResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageArgs_})
@@ -936,12 +936,12 @@ func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 			p.SendError(ctx, oprot, typedError.TypeId(), "whatDoYouSay", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "whatDoYouSay", result)
+	return p.SendReply(ctx, oprot, "whatDoYouSay", &result)
 }
 
 type fooFSayAgain struct {
@@ -953,7 +953,7 @@ func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
 	}
 	result := FooSayAgainResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageResult_})
@@ -968,12 +968,12 @@ func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "sayAgain", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "sayAgain", result)
+	return p.SendReply(ctx, oprot, "sayAgain", &result)
 }
 
 type FooPingArgs struct {

--- a/test/expected/go/variety_async/f_foo_service.txt
+++ b/test/expected/go/variety_async/f_foo_service.txt
@@ -49,18 +49,14 @@ type FFoo interface {
 // a frugal Context for each service call.
 type FFooClient struct {
 	*golang.FBaseFooClient
-	transport       frugal.FTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	methods map[string]*frugal.Method
 }
 
 func NewFFooClient(provider *frugal.FServiceProvider, middleware ...frugal.ServiceMiddleware) *FFooClient {
 	methods := make(map[string]*frugal.Method)
 	client := &FFooClient{
-		FBaseFooClient:  golang.NewFBaseFooClient(provider, middleware...),
-		transport:       provider.GetTransport(),
-		protocolFactory: provider.GetProtocolFactory(),
-		methods:         methods,
+		FBaseFooClient: golang.NewFBaseFooClient(provider, middleware...),
+		methods:        methods,
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
 	methods["ping"] = frugal.NewMethod(client, client.ping, "ping", middleware)
@@ -93,67 +89,10 @@ func (f *FFooClient) Ping(ctx frugal.FContext) (err error) {
 }
 
 func (f *FFooClient) ping(ctx frugal.FContext) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("ping", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooPingArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "ping" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "ping failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "ping failed: invalid message type")
-		return
-	}
 	result := FooPingResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "ping", &args, &result)
+	if err != nil {
 		return
 	}
 	return
@@ -184,71 +123,14 @@ func (f *FFooClient) Blah(ctx frugal.FContext, num int32, str string, event *Eve
 }
 
 func (f *FFooClient) blah(ctx frugal.FContext, num int32, str string, event *Event) (r int64, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("blah", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooBlahArgs{
 		Num:   num,
 		Str:   str,
 		Event: event,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "blah" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "blah failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "blah failed: invalid message type")
-		return
-	}
 	result := FooBlahResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "blah", &args, &result)
+	if err != nil {
 		return
 	}
 	if result.Awe != nil {
@@ -291,29 +173,11 @@ func (f *FFooClient) OneWay(ctx frugal.FContext, id ID, req Request) (err error)
 }
 
 func (f *FFooClient) oneWay(ctx frugal.FContext, id ID, req Request) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("oneWay", thrift.ONEWAY, 0); err != nil {
-		return
-	}
 	args := FooOneWayArgs{
 		ID:  id,
 		Req: req,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	err = f.transport.Oneway(ctx, buffer.Bytes())
-	return
+	return f.Client_().Oneway(ctx, "oneWay", &args)
 }
 
 // oneway methods don't receive a response from the server.
@@ -340,70 +204,13 @@ func (f *FFooClient) BinMethod(ctx frugal.FContext, bin []byte, str string) (r [
 }
 
 func (f *FFooClient) bin_method(ctx frugal.FContext, bin []byte, str string) (r []byte, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("bin_method", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooBinMethodArgs{
 		Bin: bin,
 		Str: str,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "bin_method" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "bin_method failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "bin_method failed: invalid message type")
-		return
-	}
 	result := FooBinMethodResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "bin_method", &args, &result)
+	if err != nil {
 		return
 	}
 	if result.API != nil {
@@ -443,71 +250,14 @@ func (f *FFooClient) ParamModifiers(ctx frugal.FContext, opt_num int32, default_
 }
 
 func (f *FFooClient) param_modifiers(ctx frugal.FContext, opt_num int32, default_num int32, req_num int32) (r int64, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("param_modifiers", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooParamModifiersArgs{
 		OptNum:     opt_num,
 		DefaultNum: default_num,
 		ReqNum:     req_num,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "param_modifiers" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "param_modifiers failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "param_modifiers failed: invalid message type")
-		return
-	}
 	result := FooParamModifiersResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "param_modifiers", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -543,70 +293,13 @@ func (f *FFooClient) UnderlyingTypesTest(ctx frugal.FContext, list_type []ID, se
 }
 
 func (f *FFooClient) underlying_types_test(ctx frugal.FContext, list_type []ID, set_type map[ID]bool) (r []ID, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("underlying_types_test", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooUnderlyingTypesTestArgs{
 		ListType: list_type,
 		SetType:  set_type,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "underlying_types_test" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "underlying_types_test failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "underlying_types_test failed: invalid message type")
-		return
-	}
 	result := FooUnderlyingTypesTestResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "underlying_types_test", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -642,67 +335,10 @@ func (f *FFooClient) GetThing(ctx frugal.FContext) (r *validStructs.Thing, err e
 }
 
 func (f *FFooClient) getThing(ctx frugal.FContext) (r *validStructs.Thing, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("getThing", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooGetThingArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "getThing" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "getThing failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "getThing failed: invalid message type")
-		return
-	}
 	result := FooGetThingResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "getThing", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -738,67 +374,10 @@ func (f *FFooClient) GetMyInt(ctx frugal.FContext) (r ValidTypes.MyInt, err erro
 }
 
 func (f *FFooClient) getMyInt(ctx frugal.FContext) (r ValidTypes.MyInt, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("getMyInt", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooGetMyIntArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "getMyInt" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "getMyInt failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "getMyInt failed: invalid message type")
-		return
-	}
 	result := FooGetMyIntResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "getMyInt", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -834,69 +413,12 @@ func (f *FFooClient) UseSubdirStruct(ctx frugal.FContext, a *subdir_include.A) (
 }
 
 func (f *FFooClient) use_subdir_struct(ctx frugal.FContext, a *subdir_include.A) (r *subdir_include.A, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("use_subdir_struct", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooUseSubdirStructArgs{
 		A: a,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "use_subdir_struct" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "use_subdir_struct failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "use_subdir_struct failed: invalid message type")
-		return
-	}
 	result := FooUseSubdirStructResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "use_subdir_struct", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -932,69 +454,12 @@ func (f *FFooClient) SayHelloWith(ctx frugal.FContext, newmessage string) (r str
 }
 
 func (f *FFooClient) sayHelloWith(ctx frugal.FContext, newmessage string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("sayHelloWith", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooSayHelloWithArgs{
 		NewMessage_: newmessage,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "sayHelloWith" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "sayHelloWith failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "sayHelloWith failed: invalid message type")
-		return
-	}
 	result := FooSayHelloWithResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "sayHelloWith", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -1030,69 +495,12 @@ func (f *FFooClient) WhatDoYouSay(ctx frugal.FContext, messageargs string) (r st
 }
 
 func (f *FFooClient) whatDoYouSay(ctx frugal.FContext, messageargs string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("whatDoYouSay", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooWhatDoYouSayArgs{
 		MessageArgs_: messageargs,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "whatDoYouSay" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "whatDoYouSay failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "whatDoYouSay failed: invalid message type")
-		return
-	}
 	result := FooWhatDoYouSayResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "whatDoYouSay", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -1128,69 +536,12 @@ func (f *FFooClient) SayAgain(ctx frugal.FContext, messageresult string) (r stri
 }
 
 func (f *FFooClient) sayAgain(ctx frugal.FContext, messageresult string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("sayAgain", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooSayAgainArgs{
 		MessageResult_: messageresult,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "sayAgain" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "sayAgain failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "sayAgain failed: invalid message type")
-		return
-	}
 	result := FooSayAgainResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "sayAgain", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -1242,79 +593,27 @@ type fooFPing struct {
 func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	logrus.Warn("Deprecated function 'Foo.Ping' was called by a client")
 	args := FooPingArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
+	}
 	result := FooPingResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("ping", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "ping", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("ping", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "ping", result)
 }
 
 type fooFBlah struct {
@@ -1323,89 +622,37 @@ type fooFBlah struct {
 
 func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooBlahArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
+	}
 	result := FooBlahResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.Num, args.Str, args.Event})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("blah", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "blah", typedError.Error())
 			return nil
 		}
-		switch v := err2.(type) {
+		switch v := err.(type) {
 		case *AwesomeException:
 			result.Awe = v
 		case *golang.APIException:
 			result.API = v
 		default:
-			p.GetWriteMutex().Lock()
-			err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err2.Error())
-			p.GetWriteMutex().Unlock()
-			return err2
+			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
 		}
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("blah", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "blah", result)
 }
 
 type fooFOneWay struct {
@@ -1414,33 +661,24 @@ type fooFOneWay struct {
 
 func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooOneWayArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
-	var err2 error
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
+	}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ID, args.Req})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("oneWay", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "oneWay", typedError.Error())
 			return nil
 		}
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
 	}
 	return err
 }
@@ -1451,87 +689,35 @@ type fooFBinMethod struct {
 
 func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooBinMethodArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
+	}
 	result := FooBinMethodResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.Bin, args.Str})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("bin_method", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "bin_method", typedError.Error())
 			return nil
 		}
-		switch v := err2.(type) {
+		switch v := err.(type) {
 		case *golang.APIException:
 			result.API = v
 		default:
-			p.GetWriteMutex().Lock()
-			err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err2.Error())
-			p.GetWriteMutex().Unlock()
-			return err2
+			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
 		}
 	} else {
 		var retval []byte = ret[0].([]byte)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("bin_method", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "bin_method", result)
 }
 
 type fooFParamModifiers struct {
@@ -1540,82 +726,30 @@ type fooFParamModifiers struct {
 
 func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooParamModifiersArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
+	}
 	result := FooParamModifiersResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.OptNum, args.DefaultNum, args.ReqNum})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("param_modifiers", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "param_modifiers", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("param_modifiers", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "param_modifiers", result)
 }
 
 type fooFUnderlyingTypesTest struct {
@@ -1624,82 +758,30 @@ type fooFUnderlyingTypesTest struct {
 
 func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooUnderlyingTypesTestArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
+	}
 	result := FooUnderlyingTypesTestResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.ListType, args.SetType})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("underlying_types_test", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "underlying_types_test", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
 	} else {
 		var retval []ID = ret[0].([]ID)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("underlying_types_test", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "underlying_types_test", result)
 }
 
 type fooFGetThing struct {
@@ -1708,82 +790,30 @@ type fooFGetThing struct {
 
 func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooGetThingArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
+	}
 	result := FooGetThingResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("getThing", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "getThing", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
 	} else {
 		var retval *validStructs.Thing = ret[0].(*validStructs.Thing)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("getThing", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "getThing", result)
 }
 
 type fooFGetMyInt struct {
@@ -1792,82 +822,30 @@ type fooFGetMyInt struct {
 
 func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooGetMyIntArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
+	}
 	result := FooGetMyIntResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("getMyInt", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "getMyInt", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
 	} else {
 		var retval ValidTypes.MyInt = ret[0].(ValidTypes.MyInt)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("getMyInt", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "getMyInt", result)
 }
 
 type fooFUseSubdirStruct struct {
@@ -1876,82 +854,30 @@ type fooFUseSubdirStruct struct {
 
 func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooUseSubdirStructArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
+	}
 	result := FooUseSubdirStructResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.A})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("use_subdir_struct", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "use_subdir_struct", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
 	} else {
 		var retval *subdir_include.A = ret[0].(*subdir_include.A)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("use_subdir_struct", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "use_subdir_struct", result)
 }
 
 type fooFSayHelloWith struct {
@@ -1960,82 +886,30 @@ type fooFSayHelloWith struct {
 
 func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooSayHelloWithArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
+	}
 	result := FooSayHelloWithResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.NewMessage_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("sayHelloWith", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "sayHelloWith", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("sayHelloWith", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "sayHelloWith", result)
 }
 
 type fooFWhatDoYouSay struct {
@@ -2044,82 +918,30 @@ type fooFWhatDoYouSay struct {
 
 func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooWhatDoYouSayArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
+	}
 	result := FooWhatDoYouSayResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageArgs_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("whatDoYouSay", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "whatDoYouSay", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("whatDoYouSay", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "whatDoYouSay", result)
 }
 
 type fooFSayAgain struct {
@@ -2128,92 +950,30 @@ type fooFSayAgain struct {
 
 func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooSayAgainArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
+	}
 	result := FooSayAgainResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageResult_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("sayAgain", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "sayAgain", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("sayAgain", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
-}
-
-func fooWriteApplicationError(ctx frugal.FContext, oprot *frugal.FProtocol, type_ int32, method, message string) error {
-	x := thrift.NewTApplicationException(type_, message)
-	oprot.WriteResponseHeader(ctx)
-	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
-	x.Write(oprot)
-	oprot.WriteMessageEnd()
-	oprot.Flush()
-	return x
+	return p.SendReply(ctx, oprot, "sayAgain", result)
 }
 
 type FooPingArgs struct {

--- a/test/expected/go/vendor/f_myscope_scope.txt
+++ b/test/expected/go/vendor/f_myscope_scope.txt
@@ -11,8 +11,6 @@ import (
 	"github.com/Workiva/some/vendored/place/vendor_namespace"
 )
 
-const delimiter = "."
-
 type MyScopePublisher interface {
 	Open() error
 	Close() error
@@ -20,30 +18,18 @@ type MyScopePublisher interface {
 }
 
 type myScopePublisher struct {
-	transport       frugal.FPublisherTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	client  frugal.FClient
+	methods map[string]*frugal.Method
 }
 
 func NewMyScopePublisher(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) MyScopePublisher {
-	transport, protocolFactory := provider.NewPublisher()
-	methods := make(map[string]*frugal.Method)
 	publisher := &myScopePublisher{
-		transport:       transport,
-		protocolFactory: protocolFactory,
-		methods:         methods,
+		client:  frugal.NewFPublisherClient(provider),
+		methods: make(map[string]*frugal.Method),
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
-	methods["publishnewItem"] = frugal.NewMethod(publisher, publisher.publishnewItem, "publishnewItem", middleware)
+	publisher.methods["publishnewItem"] = frugal.NewMethod(publisher, publisher.publishnewItem, "publishnewItem", middleware)
 	return publisher
-}
-
-func (p *myScopePublisher) Open() error {
-	return p.transport.Open()
-}
-
-func (p *myScopePublisher) Close() error {
-	return p.transport.Close()
 }
 
 func (p *myScopePublisher) PublishnewItem(ctx frugal.FContext, req *vendor_namespace.Item) error {
@@ -55,27 +41,9 @@ func (p *myScopePublisher) PublishnewItem(ctx frugal.FContext, req *vendor_names
 }
 
 func (p *myScopePublisher) publishnewItem(ctx frugal.FContext, req *vendor_namespace.Item) error {
-	op := "newItem"
 	prefix := ""
-	topic := fmt.Sprintf("%sMyScope%s%s", prefix, delimiter, op)
-	buffer := frugal.NewTMemoryOutputBuffer(p.transport.GetPublishSizeLimit())
-	oprot := p.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return err
-	}
-	if err := oprot.WriteMessageBegin(op, thrift.CALL, 0); err != nil {
-		return err
-	}
-	if err := req.Write(oprot); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", req), err)
-	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return err
-	}
-	if err := oprot.Flush(); err != nil {
-		return err
-	}
-	return p.transport.Publish(topic, buffer.Bytes())
+	topic := fmt.Sprintf("%sMyScope.%s", prefix, op)
+	return p.client.Publish(ctx, "newItem", topic, req)
 }
 
 type MyScopeSubscriber interface {
@@ -111,7 +79,7 @@ func (l *myScopeSubscriber) SubscribenewItem(handler func(frugal.FContext, *vend
 func (l *myScopeSubscriber) SubscribenewItemErrorable(handler func(frugal.FContext, *vendor_namespace.Item) error) (*frugal.FSubscription, error) {
 	op := "newItem"
 	prefix := ""
-	topic := fmt.Sprintf("%sMyScope%s%s", prefix, delimiter, op)
+	topic := fmt.Sprintf("%sMyScope.%s", prefix, op)
 	transport, protocolFactory := l.provider.NewSubscriber()
 	cb := l.recvnewItem(op, protocolFactory, handler)
 	if err := transport.Subscribe(topic, cb); err != nil {

--- a/test/expected/go/vendor/f_myscope_scope.txt
+++ b/test/expected/go/vendor/f_myscope_scope.txt
@@ -12,8 +12,6 @@ import (
 )
 
 type MyScopePublisher interface {
-	Open() error
-	Close() error
 	PublishnewItem(ctx frugal.FContext, req *vendor_namespace.Item) error
 }
 
@@ -24,7 +22,7 @@ type myScopePublisher struct {
 
 func NewMyScopePublisher(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) MyScopePublisher {
 	publisher := &myScopePublisher{
-		client:  frugal.NewFPublisherClient(provider),
+		client:  frugal.NewFScopeClient(provider),
 		methods: make(map[string]*frugal.Method),
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
@@ -42,8 +40,9 @@ func (p *myScopePublisher) PublishnewItem(ctx frugal.FContext, req *vendor_names
 
 func (p *myScopePublisher) publishnewItem(ctx frugal.FContext, req *vendor_namespace.Item) error {
 	prefix := ""
+	op := "newItem"
 	topic := fmt.Sprintf("%sMyScope.%s", prefix, op)
-	return p.client.Publish(ctx, "newItem", topic, req)
+	return p.client.Publish(ctx, op, topic, req)
 }
 
 type MyScopeSubscriber interface {

--- a/test/expected/go/vendor/f_myscope_scope.txt
+++ b/test/expected/go/vendor/f_myscope_scope.txt
@@ -12,6 +12,8 @@ import (
 )
 
 type MyScopePublisher interface {
+	Open() error
+	Close() error
 	PublishnewItem(ctx frugal.FContext, req *vendor_namespace.Item) error
 }
 
@@ -29,6 +31,9 @@ func NewMyScopePublisher(provider *frugal.FScopeProvider, middleware ...frugal.S
 	publisher.methods["publishnewItem"] = frugal.NewMethod(publisher, publisher.publishnewItem, "publishnewItem", middleware)
 	return publisher
 }
+
+func (p myScopePublisher) Open() error  { return p.client.Open() }
+func (p myScopePublisher) Close() error { return p.client.Close() }
 
 func (p *myScopePublisher) PublishnewItem(ctx frugal.FContext, req *vendor_namespace.Item) error {
 	ret := p.methods["publishnewItem"].Invoke([]interface{}{ctx, req})

--- a/test/expected/go/vendor/f_myservice_service.txt
+++ b/test/expected/go/vendor/f_myservice_service.txt
@@ -28,17 +28,13 @@ type FMyService interface {
 
 type FMyServiceClient struct {
 	*vendor_namespace.FVendoredBaseClient
-	transport       frugal.FTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	methods map[string]*frugal.Method
 }
 
 func NewFMyServiceClient(provider *frugal.FServiceProvider, middleware ...frugal.ServiceMiddleware) *FMyServiceClient {
 	methods := make(map[string]*frugal.Method)
 	client := &FMyServiceClient{
 		FVendoredBaseClient: vendor_namespace.NewFVendoredBaseClient(provider, middleware...),
-		transport:           provider.GetTransport(),
-		protocolFactory:     provider.GetProtocolFactory(),
 		methods:             methods,
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
@@ -61,67 +57,10 @@ func (f *FMyServiceClient) GetItem(ctx frugal.FContext) (r *vendor_namespace.Ite
 }
 
 func (f *FMyServiceClient) getItem(ctx frugal.FContext) (r *vendor_namespace.Item, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("getItem", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := MyServiceGetItemArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "getItem" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "getItem failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "getItem failed: invalid message type")
-		return
-	}
 	result := MyServiceGetItemResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "getItem", &args, &result)
+	if err != nil {
 		return
 	}
 	if result.D != nil {
@@ -148,97 +87,35 @@ type myserviceFGetItem struct {
 
 func (p *myserviceFGetItem) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := MyServiceGetItemArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = myserviceWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getItem", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getItem", err.Error())
+	}
 	result := MyServiceGetItemResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("getItem", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "getItem", typedError.Error())
 			return nil
 		}
-		switch v := err2.(type) {
+		switch v := err.(type) {
 		case *excepts.InvalidData:
 			result.D = v
 		default:
-			p.GetWriteMutex().Lock()
-			err2 := myserviceWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getItem", "Internal error processing getItem: "+err2.Error())
-			p.GetWriteMutex().Unlock()
-			return err2
+			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getItem", "Internal error processing getItem: "+err.Error())
 		}
 	} else {
 		var retval *vendor_namespace.Item = ret[0].(*vendor_namespace.Item)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			myserviceWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getItem", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("getItem", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			myserviceWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getItem", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			myserviceWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getItem", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			myserviceWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getItem", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			myserviceWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getItem", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
-}
-
-func myserviceWriteApplicationError(ctx frugal.FContext, oprot *frugal.FProtocol, type_ int32, method, message string) error {
-	x := thrift.NewTApplicationException(type_, message)
-	oprot.WriteResponseHeader(ctx)
-	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
-	x.Write(oprot)
-	oprot.WriteMessageEnd()
-	oprot.Flush()
-	return x
+	return p.SendReply(ctx, oprot, "getItem", result)
 }
 
 type MyServiceGetItemArgs struct {

--- a/test/expected/go/vendor/f_myservice_service.txt
+++ b/test/expected/go/vendor/f_myservice_service.txt
@@ -90,7 +90,7 @@ func (p *myserviceFGetItem) Process(ctx frugal.FContext, iprot, oprot *frugal.FP
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getItem", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getItem", err.Error())
 	}
 	result := MyServiceGetItemResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -109,13 +109,13 @@ func (p *myserviceFGetItem) Process(ctx frugal.FContext, iprot, oprot *frugal.FP
 		case *excepts.InvalidData:
 			result.D = v
 		default:
-			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getItem", "Internal error processing getItem: "+err.Error())
+			return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getItem", "Internal error processing getItem: "+err.Error())
 		}
 	} else {
 		var retval *vendor_namespace.Item = ret[0].(*vendor_namespace.Item)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "getItem", result)
+	return p.SendReply(ctx, oprot, "getItem", &result)
 }
 
 type MyServiceGetItemArgs struct {

--- a/test/expected/go/vendor_namespace/f_vendoredbase_service.txt
+++ b/test/expected/go/vendor_namespace/f_vendoredbase_service.txt
@@ -22,21 +22,21 @@ type FVendoredBase interface {
 }
 
 type FVendoredBaseClient struct {
-	transport       frugal.FTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	c       frugal.FClient
+	methods map[string]*frugal.Method
 }
 
 func NewFVendoredBaseClient(provider *frugal.FServiceProvider, middleware ...frugal.ServiceMiddleware) *FVendoredBaseClient {
 	methods := make(map[string]*frugal.Method)
 	client := &FVendoredBaseClient{
-		transport:       provider.GetTransport(),
-		protocolFactory: provider.GetProtocolFactory(),
-		methods:         methods,
+		c:       frugal.NewFStandardClient(provider),
+		methods: methods,
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
 	return client
 }
+
+func (f *FVendoredBaseClient) Client_() frugal.FClient { return f.c }
 
 type FVendoredBaseProcessor struct {
 	*frugal.FBaseProcessor
@@ -45,14 +45,4 @@ type FVendoredBaseProcessor struct {
 func NewFVendoredBaseProcessor(handler FVendoredBase, middleware ...frugal.ServiceMiddleware) *FVendoredBaseProcessor {
 	p := &FVendoredBaseProcessor{frugal.NewFBaseProcessor()}
 	return p
-}
-
-func vendoredbaseWriteApplicationError(ctx frugal.FContext, oprot *frugal.FProtocol, type_ int32, method, message string) error {
-	x := thrift.NewTApplicationException(type_, message)
-	oprot.WriteResponseHeader(ctx)
-	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
-	x.Write(oprot)
-	oprot.WriteMessageEnd()
-	oprot.Flush()
-	return x
 }

--- a/test/expected/gopherjs/actual_base/golang/f_basefoo_service.go
+++ b/test/expected/gopherjs/actual_base/golang/f_basefoo_service.go
@@ -15,22 +15,22 @@ type FBaseFoo interface {
 }
 
 type FBaseFooClient struct {
-	transport       frugal.FTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	c       frugal.FClient
+	methods map[string]*frugal.Method
 }
 
 func NewFBaseFooClient(provider *frugal.FServiceProvider, middleware ...frugal.ServiceMiddleware) *FBaseFooClient {
 	methods := make(map[string]*frugal.Method)
 	client := &FBaseFooClient{
-		transport:       provider.GetTransport(),
-		protocolFactory: provider.GetProtocolFactory(),
-		methods:         methods,
+		c:       frugal.NewFStandardClient(provider),
+		methods: methods,
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
 	methods["basePing"] = frugal.NewMethod(client, client.basePing, "basePing", middleware)
 	return client
 }
+
+func (f *FBaseFooClient) Client_() frugal.FClient { return f.c }
 
 func (f *FBaseFooClient) BasePing(ctx frugal.FContext) (err error) {
 	ret := f.methods["basePing"].Invoke([]interface{}{ctx})
@@ -44,67 +44,10 @@ func (f *FBaseFooClient) BasePing(ctx frugal.FContext) (err error) {
 }
 
 func (f *FBaseFooClient) basePing(ctx frugal.FContext) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("basePing", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := BaseFooBasePingArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "basePing" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "basePing failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "basePing failed: invalid message type")
-		return
-	}
 	result := BaseFooBasePingResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "basePing", &args, &result)
+	if err != nil {
 		return
 	}
 	return
@@ -126,89 +69,27 @@ type basefooFBasePing struct {
 
 func (p *basefooFBasePing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := BaseFooBasePingArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "basePing", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "basePing", err.Error())
+	}
 	result := BaseFooBasePingResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("basePing", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "basePing", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "basePing", "Internal error processing basePing: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "basePing", "Internal error processing basePing: "+err.Error())
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "basePing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("basePing", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "basePing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "basePing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "basePing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			basefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "basePing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
-}
-
-func basefooWriteApplicationError(ctx frugal.FContext, oprot *frugal.FProtocol, type_ int32, method, message string) error {
-	x := thrift.NewTApplicationException(type_, message)
-	oprot.WriteResponseHeader(ctx)
-	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
-	x.Write(oprot)
-	oprot.WriteMessageEnd()
-	oprot.Flush()
-	return x
+	return p.SendReply(ctx, oprot, "basePing", result)
 }
 
 type BaseFooBasePingArgs struct {

--- a/test/expected/gopherjs/actual_base/golang/f_basefoo_service.go
+++ b/test/expected/gopherjs/actual_base/golang/f_basefoo_service.go
@@ -72,7 +72,7 @@ func (p *basefooFBasePing) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "basePing", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "basePing", err.Error())
 	}
 	result := BaseFooBasePingResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -87,9 +87,9 @@ func (p *basefooFBasePing) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 			p.SendError(ctx, oprot, typedError.TypeId(), "basePing", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "basePing", "Internal error processing basePing: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "basePing", "Internal error processing basePing: "+err.Error())
 	}
-	return p.SendReply(ctx, oprot, "basePing", result)
+	return p.SendReply(ctx, oprot, "basePing", &result)
 }
 
 type BaseFooBasePingArgs struct {

--- a/test/expected/gopherjs/intermediate_include/f_intermediatefoo_service.go
+++ b/test/expected/gopherjs/intermediate_include/f_intermediatefoo_service.go
@@ -72,7 +72,7 @@ func (p *intermediatefooFIntermeidateFoo) Process(ctx frugal.FContext, iprot, op
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "intermeidateFoo", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "intermeidateFoo", err.Error())
 	}
 	result := IntermediateFooIntermeidateFooResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -87,9 +87,9 @@ func (p *intermediatefooFIntermeidateFoo) Process(ctx frugal.FContext, iprot, op
 			p.SendError(ctx, oprot, typedError.TypeId(), "intermeidateFoo", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "intermeidateFoo", "Internal error processing intermeidateFoo: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "intermeidateFoo", "Internal error processing intermeidateFoo: "+err.Error())
 	}
-	return p.SendReply(ctx, oprot, "intermeidateFoo", result)
+	return p.SendReply(ctx, oprot, "intermeidateFoo", &result)
 }
 
 type IntermediateFooIntermeidateFooArgs struct {

--- a/test/expected/gopherjs/intermediate_include/f_intermediatefoo_service.go
+++ b/test/expected/gopherjs/intermediate_include/f_intermediatefoo_service.go
@@ -15,22 +15,22 @@ type FIntermediateFoo interface {
 }
 
 type FIntermediateFooClient struct {
-	transport       frugal.FTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	c       frugal.FClient
+	methods map[string]*frugal.Method
 }
 
 func NewFIntermediateFooClient(provider *frugal.FServiceProvider, middleware ...frugal.ServiceMiddleware) *FIntermediateFooClient {
 	methods := make(map[string]*frugal.Method)
 	client := &FIntermediateFooClient{
-		transport:       provider.GetTransport(),
-		protocolFactory: provider.GetProtocolFactory(),
-		methods:         methods,
+		c:       frugal.NewFStandardClient(provider),
+		methods: methods,
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
 	methods["intermeidateFoo"] = frugal.NewMethod(client, client.intermeidateFoo, "intermeidateFoo", middleware)
 	return client
 }
+
+func (f *FIntermediateFooClient) Client_() frugal.FClient { return f.c }
 
 func (f *FIntermediateFooClient) IntermeidateFoo(ctx frugal.FContext) (err error) {
 	ret := f.methods["intermeidateFoo"].Invoke([]interface{}{ctx})
@@ -44,67 +44,10 @@ func (f *FIntermediateFooClient) IntermeidateFoo(ctx frugal.FContext) (err error
 }
 
 func (f *FIntermediateFooClient) intermeidateFoo(ctx frugal.FContext) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("intermeidateFoo", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := IntermediateFooIntermeidateFooArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "intermeidateFoo" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "intermeidateFoo failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "intermeidateFoo failed: invalid message type")
-		return
-	}
 	result := IntermediateFooIntermeidateFooResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "intermeidateFoo", &args, &result)
+	if err != nil {
 		return
 	}
 	return
@@ -126,89 +69,27 @@ type intermediatefooFIntermeidateFoo struct {
 
 func (p *intermediatefooFIntermeidateFoo) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := IntermediateFooIntermeidateFooArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = intermediatefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "intermeidateFoo", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "intermeidateFoo", err.Error())
+	}
 	result := IntermediateFooIntermeidateFooResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("intermeidateFoo", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "intermeidateFoo", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := intermediatefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "intermeidateFoo", "Internal error processing intermeidateFoo: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "intermeidateFoo", "Internal error processing intermeidateFoo: "+err.Error())
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			intermediatefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "intermeidateFoo", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("intermeidateFoo", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			intermediatefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "intermeidateFoo", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			intermediatefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "intermeidateFoo", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			intermediatefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "intermeidateFoo", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			intermediatefooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "intermeidateFoo", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
-}
-
-func intermediatefooWriteApplicationError(ctx frugal.FContext, oprot *frugal.FProtocol, type_ int32, method, message string) error {
-	x := thrift.NewTApplicationException(type_, message)
-	oprot.WriteResponseHeader(ctx)
-	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
-	x.Write(oprot)
-	oprot.WriteMessageEnd()
-	oprot.Flush()
-	return x
+	return p.SendReply(ctx, oprot, "intermeidateFoo", result)
 }
 
 type IntermediateFooIntermeidateFooArgs struct {

--- a/test/expected/gopherjs/variety/f_events_scope.go
+++ b/test/expected/gopherjs/variety/f_events_scope.go
@@ -14,6 +14,8 @@ import (
 // the @ sign. Prefix specifies topic prefix tokens, which can be static or
 // variable.
 type EventsPublisher interface {
+	Open() error
+	Close() error
 	PublishEventCreated(ctx frugal.FContext, user string, req *Event) error
 	PublishSomeInt(ctx frugal.FContext, user string, req int64) error
 	PublishSomeStr(ctx frugal.FContext, user string, req string) error
@@ -37,6 +39,9 @@ func NewEventsPublisher(provider *frugal.FScopeProvider, middleware ...frugal.Se
 	publisher.methods["publishSomeList"] = frugal.NewMethod(publisher, publisher.publishSomeList, "publishSomeList", middleware)
 	return publisher
 }
+
+func (p eventsPublisher) Open() error  { return p.client.Open() }
+func (p eventsPublisher) Close() error { return p.client.Close() }
 
 // This is a docstring.
 func (p *eventsPublisher) PublishEventCreated(ctx frugal.FContext, user string, req *Event) error {

--- a/test/expected/gopherjs/variety/f_events_scope.go
+++ b/test/expected/gopherjs/variety/f_events_scope.go
@@ -10,8 +10,6 @@ import (
 	"github.com/Workiva/frugal/lib/gopherjs/thrift"
 )
 
-const delimiter = "."
-
 // This docstring gets added to the generated code because it has
 // the @ sign. Prefix specifies topic prefix tokens, which can be static or
 // variable.
@@ -25,33 +23,21 @@ type EventsPublisher interface {
 }
 
 type eventsPublisher struct {
-	transport       frugal.FPublisherTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	client  frugal.FClient
+	methods map[string]*frugal.Method
 }
 
 func NewEventsPublisher(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) EventsPublisher {
-	transport, protocolFactory := provider.NewPublisher()
-	methods := make(map[string]*frugal.Method)
 	publisher := &eventsPublisher{
-		transport:       transport,
-		protocolFactory: protocolFactory,
-		methods:         methods,
+		client:  frugal.NewFPublisherClient(provider),
+		methods: make(map[string]*frugal.Method),
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
-	methods["publishEventCreated"] = frugal.NewMethod(publisher, publisher.publishEventCreated, "publishEventCreated", middleware)
-	methods["publishSomeInt"] = frugal.NewMethod(publisher, publisher.publishSomeInt, "publishSomeInt", middleware)
-	methods["publishSomeStr"] = frugal.NewMethod(publisher, publisher.publishSomeStr, "publishSomeStr", middleware)
-	methods["publishSomeList"] = frugal.NewMethod(publisher, publisher.publishSomeList, "publishSomeList", middleware)
+	publisher.methods["publishEventCreated"] = frugal.NewMethod(publisher, publisher.publishEventCreated, "publishEventCreated", middleware)
+	publisher.methods["publishSomeInt"] = frugal.NewMethod(publisher, publisher.publishSomeInt, "publishSomeInt", middleware)
+	publisher.methods["publishSomeStr"] = frugal.NewMethod(publisher, publisher.publishSomeStr, "publishSomeStr", middleware)
+	publisher.methods["publishSomeList"] = frugal.NewMethod(publisher, publisher.publishSomeList, "publishSomeList", middleware)
 	return publisher
-}
-
-func (p *eventsPublisher) Open() error {
-	return p.transport.Open()
-}
-
-func (p *eventsPublisher) Close() error {
-	return p.transport.Close()
 }
 
 // This is a docstring.
@@ -65,27 +51,9 @@ func (p *eventsPublisher) PublishEventCreated(ctx frugal.FContext, user string, 
 
 func (p *eventsPublisher) publishEventCreated(ctx frugal.FContext, user string, req *Event) error {
 	ctx.AddRequestHeader("_topic_user", user)
-	op := "EventCreated"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
-	buffer := frugal.NewTMemoryOutputBuffer(p.transport.GetPublishSizeLimit())
-	oprot := p.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return err
-	}
-	if err := oprot.WriteMessageBegin(op, thrift.CALL, 0); err != nil {
-		return err
-	}
-	if err := req.Write(oprot); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", req), err)
-	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return err
-	}
-	if err := oprot.Flush(); err != nil {
-		return err
-	}
-	return p.transport.Publish(topic, buffer.Bytes())
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
+	return p.client.Publish(ctx, "EventCreated", topic, req)
 }
 
 func (p *eventsPublisher) PublishSomeInt(ctx frugal.FContext, user string, req int64) error {
@@ -98,27 +66,22 @@ func (p *eventsPublisher) PublishSomeInt(ctx frugal.FContext, user string, req i
 
 func (p *eventsPublisher) publishSomeInt(ctx frugal.FContext, user string, req int64) error {
 	ctx.AddRequestHeader("_topic_user", user)
-	op := "SomeInt"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
-	buffer := frugal.NewTMemoryOutputBuffer(p.transport.GetPublishSizeLimit())
-	oprot := p.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return err
-	}
-	if err := oprot.WriteMessageBegin(op, thrift.CALL, 0); err != nil {
-		return err
-	}
-	if err := oprot.WriteI64(int64(req)); err != nil {
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
+	return p.client.Publish(ctx, "SomeInt", topic, eventsSomeIntMessage(req))
+}
+
+type eventsSomeIntMessage int64
+
+func (p eventsSomeIntMessage) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteI64(int64(p)); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
 	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return err
-	}
-	if err := oprot.Flush(); err != nil {
-		return err
-	}
-	return p.transport.Publish(topic, buffer.Bytes())
+	return nil
+}
+
+func (p eventsSomeIntMessage) Read(iprot thrift.TProcotol) error {
+	panic("Not Implemented!")
 }
 
 func (p *eventsPublisher) PublishSomeStr(ctx frugal.FContext, user string, req string) error {
@@ -131,27 +94,22 @@ func (p *eventsPublisher) PublishSomeStr(ctx frugal.FContext, user string, req s
 
 func (p *eventsPublisher) publishSomeStr(ctx frugal.FContext, user string, req string) error {
 	ctx.AddRequestHeader("_topic_user", user)
-	op := "SomeStr"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
-	buffer := frugal.NewTMemoryOutputBuffer(p.transport.GetPublishSizeLimit())
-	oprot := p.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return err
-	}
-	if err := oprot.WriteMessageBegin(op, thrift.CALL, 0); err != nil {
-		return err
-	}
-	if err := oprot.WriteString(string(req)); err != nil {
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
+	return p.client.Publish(ctx, "SomeStr", topic, eventsSomeStrMessage(req))
+}
+
+type eventsSomeStrMessage string
+
+func (p eventsSomeStrMessage) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteString(string(p)); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T. (0) field write error: ", p), err)
 	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return err
-	}
-	if err := oprot.Flush(); err != nil {
-		return err
-	}
-	return p.transport.Publish(topic, buffer.Bytes())
+	return nil
+}
+
+func (p eventsSomeStrMessage) Read(iprot thrift.TProcotol) error {
+	panic("Not Implemented!")
 }
 
 func (p *eventsPublisher) PublishSomeList(ctx frugal.FContext, user string, req []map[ID]*Event) error {
@@ -164,21 +122,18 @@ func (p *eventsPublisher) PublishSomeList(ctx frugal.FContext, user string, req 
 
 func (p *eventsPublisher) publishSomeList(ctx frugal.FContext, user string, req []map[ID]*Event) error {
 	ctx.AddRequestHeader("_topic_user", user)
-	op := "SomeList"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
-	buffer := frugal.NewTMemoryOutputBuffer(p.transport.GetPublishSizeLimit())
-	oprot := p.protocolFactory.GetProtocol(buffer)
-	if err := oprot.WriteRequestHeader(ctx); err != nil {
-		return err
-	}
-	if err := oprot.WriteMessageBegin(op, thrift.CALL, 0); err != nil {
-		return err
-	}
-	if err := oprot.WriteListBegin(thrift.MAP, len(req)); err != nil {
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
+	return p.client.Publish(ctx, "SomeList", topic, eventsSomeListMessage(req))
+}
+
+type eventsSomeListMessage []map[ID]*Event
+
+func (p eventsSomeListMessage) Write(oprot thrift.TProtocol) error {
+	if err := oprot.WriteListBegin(thrift.MAP, len(p)); err != nil {
 		return thrift.PrependError("error writing list begin: ", err)
 	}
-	for _, v := range req {
+	for _, v := range p {
 		if err := oprot.WriteMapBegin(thrift.I64, thrift.STRUCT, len(v)); err != nil {
 			return thrift.PrependError("error writing map begin: ", err)
 		}
@@ -197,13 +152,11 @@ func (p *eventsPublisher) publishSomeList(ctx frugal.FContext, user string, req 
 	if err := oprot.WriteListEnd(); err != nil {
 		return thrift.PrependError("error writing list end: ", err)
 	}
-	if err := oprot.WriteMessageEnd(); err != nil {
-		return err
-	}
-	if err := oprot.Flush(); err != nil {
-		return err
-	}
-	return p.transport.Publish(topic, buffer.Bytes())
+	return nil
+}
+
+func (p eventsSomeListMessage) Read(iprot thrift.TProcotol) error {
+	panic("Not Implemented!")
 }
 
 // This docstring gets added to the generated code because it has
@@ -253,7 +206,7 @@ func (l *eventsSubscriber) SubscribeEventCreated(user string, handler func(fruga
 func (l *eventsSubscriber) SubscribeEventCreatedErrorable(user string, handler func(frugal.FContext, *Event) error) (*frugal.FSubscription, error) {
 	op := "EventCreated"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
 	transport, protocolFactory := l.provider.NewSubscriber()
 	cb := l.recvEventCreated(op, protocolFactory, handler)
 	if err := transport.Subscribe(topic, cb); err != nil {
@@ -303,7 +256,7 @@ func (l *eventsSubscriber) SubscribeSomeInt(user string, handler func(frugal.FCo
 func (l *eventsSubscriber) SubscribeSomeIntErrorable(user string, handler func(frugal.FContext, int64) error) (*frugal.FSubscription, error) {
 	op := "SomeInt"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
 	transport, protocolFactory := l.provider.NewSubscriber()
 	cb := l.recvSomeInt(op, protocolFactory, handler)
 	if err := transport.Subscribe(topic, cb); err != nil {
@@ -355,7 +308,7 @@ func (l *eventsSubscriber) SubscribeSomeStr(user string, handler func(frugal.FCo
 func (l *eventsSubscriber) SubscribeSomeStrErrorable(user string, handler func(frugal.FContext, string) error) (*frugal.FSubscription, error) {
 	op := "SomeStr"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
 	transport, protocolFactory := l.provider.NewSubscriber()
 	cb := l.recvSomeStr(op, protocolFactory, handler)
 	if err := transport.Subscribe(topic, cb); err != nil {
@@ -407,7 +360,7 @@ func (l *eventsSubscriber) SubscribeSomeList(user string, handler func(frugal.FC
 func (l *eventsSubscriber) SubscribeSomeListErrorable(user string, handler func(frugal.FContext, []map[ID]*Event) error) (*frugal.FSubscription, error) {
 	op := "SomeList"
 	prefix := fmt.Sprintf("foo.%s.", user)
-	topic := fmt.Sprintf("%sEvents%s%s", prefix, delimiter, op)
+	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
 	transport, protocolFactory := l.provider.NewSubscriber()
 	cb := l.recvSomeList(op, protocolFactory, handler)
 	if err := transport.Subscribe(topic, cb); err != nil {

--- a/test/expected/gopherjs/variety/f_events_scope.go
+++ b/test/expected/gopherjs/variety/f_events_scope.go
@@ -14,8 +14,6 @@ import (
 // the @ sign. Prefix specifies topic prefix tokens, which can be static or
 // variable.
 type EventsPublisher interface {
-	Open() error
-	Close() error
 	PublishEventCreated(ctx frugal.FContext, user string, req *Event) error
 	PublishSomeInt(ctx frugal.FContext, user string, req int64) error
 	PublishSomeStr(ctx frugal.FContext, user string, req string) error
@@ -29,7 +27,7 @@ type eventsPublisher struct {
 
 func NewEventsPublisher(provider *frugal.FScopeProvider, middleware ...frugal.ServiceMiddleware) EventsPublisher {
 	publisher := &eventsPublisher{
-		client:  frugal.NewFPublisherClient(provider),
+		client:  frugal.NewFScopeClient(provider),
 		methods: make(map[string]*frugal.Method),
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
@@ -52,8 +50,9 @@ func (p *eventsPublisher) PublishEventCreated(ctx frugal.FContext, user string, 
 func (p *eventsPublisher) publishEventCreated(ctx frugal.FContext, user string, req *Event) error {
 	ctx.AddRequestHeader("_topic_user", user)
 	prefix := fmt.Sprintf("foo.%s.", user)
+	op := "EventCreated"
 	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
-	return p.client.Publish(ctx, "EventCreated", topic, req)
+	return p.client.Publish(ctx, op, topic, req)
 }
 
 func (p *eventsPublisher) PublishSomeInt(ctx frugal.FContext, user string, req int64) error {
@@ -67,8 +66,9 @@ func (p *eventsPublisher) PublishSomeInt(ctx frugal.FContext, user string, req i
 func (p *eventsPublisher) publishSomeInt(ctx frugal.FContext, user string, req int64) error {
 	ctx.AddRequestHeader("_topic_user", user)
 	prefix := fmt.Sprintf("foo.%s.", user)
+	op := "SomeInt"
 	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
-	return p.client.Publish(ctx, "SomeInt", topic, eventsSomeIntMessage(req))
+	return p.client.Publish(ctx, op, topic, eventsSomeIntMessage(req))
 }
 
 type eventsSomeIntMessage int64
@@ -80,7 +80,7 @@ func (p eventsSomeIntMessage) Write(oprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p eventsSomeIntMessage) Read(iprot thrift.TProcotol) error {
+func (p eventsSomeIntMessage) Read(iprot thrift.TProtocol) error {
 	panic("Not Implemented!")
 }
 
@@ -95,8 +95,9 @@ func (p *eventsPublisher) PublishSomeStr(ctx frugal.FContext, user string, req s
 func (p *eventsPublisher) publishSomeStr(ctx frugal.FContext, user string, req string) error {
 	ctx.AddRequestHeader("_topic_user", user)
 	prefix := fmt.Sprintf("foo.%s.", user)
+	op := "SomeStr"
 	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
-	return p.client.Publish(ctx, "SomeStr", topic, eventsSomeStrMessage(req))
+	return p.client.Publish(ctx, op, topic, eventsSomeStrMessage(req))
 }
 
 type eventsSomeStrMessage string
@@ -108,7 +109,7 @@ func (p eventsSomeStrMessage) Write(oprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p eventsSomeStrMessage) Read(iprot thrift.TProcotol) error {
+func (p eventsSomeStrMessage) Read(iprot thrift.TProtocol) error {
 	panic("Not Implemented!")
 }
 
@@ -123,8 +124,9 @@ func (p *eventsPublisher) PublishSomeList(ctx frugal.FContext, user string, req 
 func (p *eventsPublisher) publishSomeList(ctx frugal.FContext, user string, req []map[ID]*Event) error {
 	ctx.AddRequestHeader("_topic_user", user)
 	prefix := fmt.Sprintf("foo.%s.", user)
+	op := "SomeList"
 	topic := fmt.Sprintf("%sEvents.%s", prefix, op)
-	return p.client.Publish(ctx, "SomeList", topic, eventsSomeListMessage(req))
+	return p.client.Publish(ctx, op, topic, eventsSomeListMessage(req))
 }
 
 type eventsSomeListMessage []map[ID]*Event
@@ -155,7 +157,7 @@ func (p eventsSomeListMessage) Write(oprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p eventsSomeListMessage) Read(iprot thrift.TProcotol) error {
+func (p eventsSomeListMessage) Read(iprot thrift.TProtocol) error {
 	panic("Not Implemented!")
 }
 

--- a/test/expected/gopherjs/variety/f_foo_service.go
+++ b/test/expected/gopherjs/variety/f_foo_service.go
@@ -427,7 +427,7 @@ func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
 	}
 	result := FooPingResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -442,9 +442,9 @@ func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 			p.SendError(ctx, oprot, typedError.TypeId(), "ping", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
 	}
-	return p.SendReply(ctx, oprot, "ping", result)
+	return p.SendReply(ctx, oprot, "ping", &result)
 }
 
 type fooFBlah struct {
@@ -456,7 +456,7 @@ func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
 	}
 	result := FooBlahResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.Num, args.Str, args.Event})
@@ -477,13 +477,13 @@ func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) 
 		case *golang.APIException:
 			result.API = v
 		default:
-			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
+			return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
 		}
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "blah", result)
+	return p.SendReply(ctx, oprot, "blah", &result)
 }
 
 type fooFOneWay struct {
@@ -495,7 +495,7 @@ func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
 	}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ID, args.Req})
 	if len(ret) != 1 {
@@ -509,7 +509,7 @@ func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol
 			p.SendError(ctx, oprot, typedError.TypeId(), "oneWay", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
 	}
 	return err
 }
@@ -523,7 +523,7 @@ func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProto
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
 	}
 	result := FooBinMethodResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.Bin, args.Str})
@@ -542,13 +542,13 @@ func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProto
 		case *golang.APIException:
 			result.API = v
 		default:
-			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
+			return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
 		}
 	} else {
 		var retval []byte = ret[0].([]byte)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "bin_method", result)
+	return p.SendReply(ctx, oprot, "bin_method", &result)
 }
 
 type fooFParamModifiers struct {
@@ -560,7 +560,7 @@ func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.F
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
 	}
 	result := FooParamModifiersResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.OptNum, args.DefaultNum, args.ReqNum})
@@ -575,12 +575,12 @@ func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.F
 			p.SendError(ctx, oprot, typedError.TypeId(), "param_modifiers", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "param_modifiers", result)
+	return p.SendReply(ctx, oprot, "param_modifiers", &result)
 }
 
 type fooFUnderlyingTypesTest struct {
@@ -592,7 +592,7 @@ func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *fru
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
 	}
 	result := FooUnderlyingTypesTestResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ListType, args.SetType})
@@ -607,12 +607,12 @@ func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *fru
 			p.SendError(ctx, oprot, typedError.TypeId(), "underlying_types_test", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
 	} else {
 		var retval []ID = ret[0].([]ID)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "underlying_types_test", result)
+	return p.SendReply(ctx, oprot, "underlying_types_test", &result)
 }
 
 type fooFGetThing struct {
@@ -624,7 +624,7 @@ func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
 	}
 	result := FooGetThingResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -639,12 +639,12 @@ func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "getThing", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
 	} else {
 		var retval *validStructs.Thing = ret[0].(*validStructs.Thing)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "getThing", result)
+	return p.SendReply(ctx, oprot, "getThing", &result)
 }
 
 type fooFGetMyInt struct {
@@ -656,7 +656,7 @@ func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
 	}
 	result := FooGetMyIntResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -671,12 +671,12 @@ func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "getMyInt", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
 	} else {
 		var retval ValidTypes.MyInt = ret[0].(ValidTypes.MyInt)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "getMyInt", result)
+	return p.SendReply(ctx, oprot, "getMyInt", &result)
 }
 
 type fooFUseSubdirStruct struct {
@@ -688,7 +688,7 @@ func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
 	}
 	result := FooUseSubdirStructResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.A})
@@ -703,12 +703,12 @@ func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.
 			p.SendError(ctx, oprot, typedError.TypeId(), "use_subdir_struct", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
 	} else {
 		var retval *subdir_include.A = ret[0].(*subdir_include.A)
 		result.Success = retval
 	}
-	return p.SendReply(ctx, oprot, "use_subdir_struct", result)
+	return p.SendReply(ctx, oprot, "use_subdir_struct", &result)
 }
 
 type fooFSayHelloWith struct {
@@ -720,7 +720,7 @@ func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
 	}
 	result := FooSayHelloWithResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.NewMessage_})
@@ -735,12 +735,12 @@ func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 			p.SendError(ctx, oprot, typedError.TypeId(), "sayHelloWith", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "sayHelloWith", result)
+	return p.SendReply(ctx, oprot, "sayHelloWith", &result)
 }
 
 type fooFWhatDoYouSay struct {
@@ -752,7 +752,7 @@ func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
 	}
 	result := FooWhatDoYouSayResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageArgs_})
@@ -767,12 +767,12 @@ func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FPr
 			p.SendError(ctx, oprot, typedError.TypeId(), "whatDoYouSay", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "whatDoYouSay", result)
+	return p.SendReply(ctx, oprot, "whatDoYouSay", &result)
 }
 
 type fooFSayAgain struct {
@@ -784,7 +784,7 @@ func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
 	}
 	result := FooSayAgainResult{}
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageResult_})
@@ -799,12 +799,12 @@ func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtoc
 			p.SendError(ctx, oprot, typedError.TypeId(), "sayAgain", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	return p.SendReply(ctx, oprot, "sayAgain", result)
+	return p.SendReply(ctx, oprot, "sayAgain", &result)
 }
 
 type FooPingArgs struct {

--- a/test/expected/gopherjs/variety/f_foo_service.go
+++ b/test/expected/gopherjs/variety/f_foo_service.go
@@ -41,18 +41,14 @@ type FFoo interface {
 // a frugal Context for each service call.
 type FFooClient struct {
 	*golang.FBaseFooClient
-	transport       frugal.FTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	methods map[string]*frugal.Method
 }
 
 func NewFFooClient(provider *frugal.FServiceProvider, middleware ...frugal.ServiceMiddleware) *FFooClient {
 	methods := make(map[string]*frugal.Method)
 	client := &FFooClient{
-		FBaseFooClient:  golang.NewFBaseFooClient(provider, middleware...),
-		transport:       provider.GetTransport(),
-		protocolFactory: provider.GetProtocolFactory(),
-		methods:         methods,
+		FBaseFooClient: golang.NewFBaseFooClient(provider, middleware...),
+		methods:        methods,
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
 	methods["ping"] = frugal.NewMethod(client, client.ping, "ping", middleware)
@@ -84,67 +80,10 @@ func (f *FFooClient) Ping(ctx frugal.FContext) (err error) {
 }
 
 func (f *FFooClient) ping(ctx frugal.FContext) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("ping", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooPingArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "ping" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "ping failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "ping failed: invalid message type")
-		return
-	}
 	result := FooPingResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "ping", &args, &result)
+	if err != nil {
 		return
 	}
 	return
@@ -166,71 +105,14 @@ func (f *FFooClient) Blah(ctx frugal.FContext, num int32, str string, event *Eve
 }
 
 func (f *FFooClient) blah(ctx frugal.FContext, num int32, str string, event *Event) (r int64, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("blah", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooBlahArgs{
 		Num:   num,
 		Str:   str,
 		Event: event,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "blah" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "blah failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "blah failed: invalid message type")
-		return
-	}
 	result := FooBlahResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "blah", &args, &result)
+	if err != nil {
 		return
 	}
 	if result.Awe != nil {
@@ -258,29 +140,11 @@ func (f *FFooClient) OneWay(ctx frugal.FContext, id ID, req Request) (err error)
 }
 
 func (f *FFooClient) oneWay(ctx frugal.FContext, id ID, req Request) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("oneWay", thrift.ONEWAY, 0); err != nil {
-		return
-	}
 	args := FooOneWayArgs{
 		ID:  id,
 		Req: req,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	err = f.transport.Oneway(ctx, buffer.Bytes())
-	return
+	return f.Client_().Oneway(ctx, "oneWay", &args)
 }
 
 func (f *FFooClient) BinMethod(ctx frugal.FContext, bin []byte, str string) (r []byte, err error) {
@@ -298,70 +162,13 @@ func (f *FFooClient) BinMethod(ctx frugal.FContext, bin []byte, str string) (r [
 }
 
 func (f *FFooClient) bin_method(ctx frugal.FContext, bin []byte, str string) (r []byte, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("bin_method", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooBinMethodArgs{
 		Bin: bin,
 		Str: str,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "bin_method" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "bin_method failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "bin_method failed: invalid message type")
-		return
-	}
 	result := FooBinMethodResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "bin_method", &args, &result)
+	if err != nil {
 		return
 	}
 	if result.API != nil {
@@ -387,71 +194,14 @@ func (f *FFooClient) ParamModifiers(ctx frugal.FContext, opt_num int32, default_
 }
 
 func (f *FFooClient) param_modifiers(ctx frugal.FContext, opt_num int32, default_num int32, req_num int32) (r int64, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("param_modifiers", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooParamModifiersArgs{
 		OptNum:     opt_num,
 		DefaultNum: default_num,
 		ReqNum:     req_num,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "param_modifiers" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "param_modifiers failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "param_modifiers failed: invalid message type")
-		return
-	}
 	result := FooParamModifiersResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "param_modifiers", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -473,70 +223,13 @@ func (f *FFooClient) UnderlyingTypesTest(ctx frugal.FContext, list_type []ID, se
 }
 
 func (f *FFooClient) underlying_types_test(ctx frugal.FContext, list_type []ID, set_type map[ID]bool) (r []ID, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("underlying_types_test", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooUnderlyingTypesTestArgs{
 		ListType: list_type,
 		SetType:  set_type,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "underlying_types_test" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "underlying_types_test failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "underlying_types_test failed: invalid message type")
-		return
-	}
 	result := FooUnderlyingTypesTestResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "underlying_types_test", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -558,67 +251,10 @@ func (f *FFooClient) GetThing(ctx frugal.FContext) (r *validStructs.Thing, err e
 }
 
 func (f *FFooClient) getThing(ctx frugal.FContext) (r *validStructs.Thing, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("getThing", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooGetThingArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "getThing" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "getThing failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "getThing failed: invalid message type")
-		return
-	}
 	result := FooGetThingResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "getThing", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -640,67 +276,10 @@ func (f *FFooClient) GetMyInt(ctx frugal.FContext) (r ValidTypes.MyInt, err erro
 }
 
 func (f *FFooClient) getMyInt(ctx frugal.FContext) (r ValidTypes.MyInt, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("getMyInt", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooGetMyIntArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "getMyInt" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "getMyInt failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "getMyInt failed: invalid message type")
-		return
-	}
 	result := FooGetMyIntResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "getMyInt", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -722,69 +301,12 @@ func (f *FFooClient) UseSubdirStruct(ctx frugal.FContext, a *subdir_include.A) (
 }
 
 func (f *FFooClient) use_subdir_struct(ctx frugal.FContext, a *subdir_include.A) (r *subdir_include.A, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("use_subdir_struct", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooUseSubdirStructArgs{
 		A: a,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "use_subdir_struct" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "use_subdir_struct failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "use_subdir_struct failed: invalid message type")
-		return
-	}
 	result := FooUseSubdirStructResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "use_subdir_struct", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -806,69 +328,12 @@ func (f *FFooClient) SayHelloWith(ctx frugal.FContext, newmessage string) (r str
 }
 
 func (f *FFooClient) sayHelloWith(ctx frugal.FContext, newmessage string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("sayHelloWith", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooSayHelloWithArgs{
 		NewMessage_: newmessage,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "sayHelloWith" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "sayHelloWith failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "sayHelloWith failed: invalid message type")
-		return
-	}
 	result := FooSayHelloWithResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "sayHelloWith", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -890,69 +355,12 @@ func (f *FFooClient) WhatDoYouSay(ctx frugal.FContext, messageargs string) (r st
 }
 
 func (f *FFooClient) whatDoYouSay(ctx frugal.FContext, messageargs string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("whatDoYouSay", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooWhatDoYouSayArgs{
 		MessageArgs_: messageargs,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "whatDoYouSay" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "whatDoYouSay failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "whatDoYouSay failed: invalid message type")
-		return
-	}
 	result := FooWhatDoYouSayResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "whatDoYouSay", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -974,69 +382,12 @@ func (f *FFooClient) SayAgain(ctx frugal.FContext, messageresult string) (r stri
 }
 
 func (f *FFooClient) sayAgain(ctx frugal.FContext, messageresult string) (r string, err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("sayAgain", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooSayAgainArgs{
 		MessageResult_: messageresult,
 	}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "sayAgain" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "sayAgain failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "sayAgain failed: invalid message type")
-		return
-	}
 	result := FooSayAgainResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "sayAgain", &args, &result)
+	if err != nil {
 		return
 	}
 	r = result.GetSuccess()
@@ -1073,79 +424,27 @@ type fooFPing struct {
 
 func (p *fooFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooPingArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
+	}
 	result := FooPingResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("ping", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "ping", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("ping", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "ping", result)
 }
 
 type fooFBlah struct {
@@ -1154,89 +453,37 @@ type fooFBlah struct {
 
 func (p *fooFBlah) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooBlahArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "blah", err.Error())
+	}
 	result := FooBlahResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.Num, args.Str, args.Event})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("blah", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "blah", typedError.Error())
 			return nil
 		}
-		switch v := err2.(type) {
+		switch v := err.(type) {
 		case *AwesomeException:
 			result.Awe = v
 		case *golang.APIException:
 			result.API = v
 		default:
-			p.GetWriteMutex().Lock()
-			err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err2.Error())
-			p.GetWriteMutex().Unlock()
-			return err2
+			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "blah", "Internal error processing blah: "+err.Error())
 		}
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("blah", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "blah", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "blah", result)
 }
 
 type fooFOneWay struct {
@@ -1245,33 +492,24 @@ type fooFOneWay struct {
 
 func (p *fooFOneWay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooOneWayArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
-	var err2 error
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "oneWay", err.Error())
+	}
 	ret := p.InvokeMethod([]interface{}{ctx, args.ID, args.Req})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("oneWay", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "oneWay", typedError.Error())
 			return nil
 		}
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "oneWay", "Internal error processing oneWay: "+err.Error())
 	}
 	return err
 }
@@ -1282,87 +520,35 @@ type fooFBinMethod struct {
 
 func (p *fooFBinMethod) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooBinMethodArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "bin_method", err.Error())
+	}
 	result := FooBinMethodResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.Bin, args.Str})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("bin_method", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "bin_method", typedError.Error())
 			return nil
 		}
-		switch v := err2.(type) {
+		switch v := err.(type) {
 		case *golang.APIException:
 			result.API = v
 		default:
-			p.GetWriteMutex().Lock()
-			err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err2.Error())
-			p.GetWriteMutex().Unlock()
-			return err2
+			return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "bin_method", "Internal error processing bin_method: "+err.Error())
 		}
 	} else {
 		var retval []byte = ret[0].([]byte)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("bin_method", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "bin_method", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "bin_method", result)
 }
 
 type fooFParamModifiers struct {
@@ -1371,82 +557,30 @@ type fooFParamModifiers struct {
 
 func (p *fooFParamModifiers) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooParamModifiersArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "param_modifiers", err.Error())
+	}
 	result := FooParamModifiersResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.OptNum, args.DefaultNum, args.ReqNum})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("param_modifiers", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "param_modifiers", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "param_modifiers", "Internal error processing param_modifiers: "+err.Error())
 	} else {
 		var retval int64 = ret[0].(int64)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("param_modifiers", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "param_modifiers", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "param_modifiers", result)
 }
 
 type fooFUnderlyingTypesTest struct {
@@ -1455,82 +589,30 @@ type fooFUnderlyingTypesTest struct {
 
 func (p *fooFUnderlyingTypesTest) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooUnderlyingTypesTestArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "underlying_types_test", err.Error())
+	}
 	result := FooUnderlyingTypesTestResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.ListType, args.SetType})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("underlying_types_test", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "underlying_types_test", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "underlying_types_test", "Internal error processing underlying_types_test: "+err.Error())
 	} else {
 		var retval []ID = ret[0].([]ID)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("underlying_types_test", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "underlying_types_test", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "underlying_types_test", result)
 }
 
 type fooFGetThing struct {
@@ -1539,82 +621,30 @@ type fooFGetThing struct {
 
 func (p *fooFGetThing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooGetThingArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getThing", err.Error())
+	}
 	result := FooGetThingResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("getThing", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "getThing", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getThing", "Internal error processing getThing: "+err.Error())
 	} else {
 		var retval *validStructs.Thing = ret[0].(*validStructs.Thing)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("getThing", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getThing", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "getThing", result)
 }
 
 type fooFGetMyInt struct {
@@ -1623,82 +653,30 @@ type fooFGetMyInt struct {
 
 func (p *fooFGetMyInt) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooGetMyIntArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "getMyInt", err.Error())
+	}
 	result := FooGetMyIntResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("getMyInt", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "getMyInt", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "getMyInt", "Internal error processing getMyInt: "+err.Error())
 	} else {
 		var retval ValidTypes.MyInt = ret[0].(ValidTypes.MyInt)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("getMyInt", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "getMyInt", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "getMyInt", result)
 }
 
 type fooFUseSubdirStruct struct {
@@ -1707,82 +685,30 @@ type fooFUseSubdirStruct struct {
 
 func (p *fooFUseSubdirStruct) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooUseSubdirStructArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "use_subdir_struct", err.Error())
+	}
 	result := FooUseSubdirStructResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.A})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("use_subdir_struct", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "use_subdir_struct", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "use_subdir_struct", "Internal error processing use_subdir_struct: "+err.Error())
 	} else {
 		var retval *subdir_include.A = ret[0].(*subdir_include.A)
 		result.Success = retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("use_subdir_struct", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "use_subdir_struct", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "use_subdir_struct", result)
 }
 
 type fooFSayHelloWith struct {
@@ -1791,82 +717,30 @@ type fooFSayHelloWith struct {
 
 func (p *fooFSayHelloWith) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooSayHelloWithArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayHelloWith", err.Error())
+	}
 	result := FooSayHelloWithResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.NewMessage_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("sayHelloWith", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "sayHelloWith", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayHelloWith", "Internal error processing sayHelloWith: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("sayHelloWith", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayHelloWith", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "sayHelloWith", result)
 }
 
 type fooFWhatDoYouSay struct {
@@ -1875,82 +749,30 @@ type fooFWhatDoYouSay struct {
 
 func (p *fooFWhatDoYouSay) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooWhatDoYouSayArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "whatDoYouSay", err.Error())
+	}
 	result := FooWhatDoYouSayResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageArgs_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("whatDoYouSay", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "whatDoYouSay", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "whatDoYouSay", "Internal error processing whatDoYouSay: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("whatDoYouSay", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "whatDoYouSay", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
+	return p.SendReply(ctx, oprot, "whatDoYouSay", result)
 }
 
 type fooFSayAgain struct {
@@ -1959,92 +781,30 @@ type fooFSayAgain struct {
 
 func (p *fooFSayAgain) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooSayAgainArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "sayAgain", err.Error())
+	}
 	result := FooSayAgainResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx, args.MessageResult_})
 	if len(ret) != 2 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 2", len(ret)))
 	}
 	if ret[1] != nil {
-		err2 = ret[1].(error)
+		err = ret[1].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("sayAgain", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "sayAgain", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "sayAgain", "Internal error processing sayAgain: "+err.Error())
 	} else {
 		var retval string = ret[0].(string)
 		result.Success = &retval
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("sayAgain", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			fooWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "sayAgain", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
-}
-
-func fooWriteApplicationError(ctx frugal.FContext, oprot *frugal.FProtocol, type_ int32, method, message string) error {
-	x := thrift.NewTApplicationException(type_, message)
-	oprot.WriteResponseHeader(ctx)
-	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
-	x.Write(oprot)
-	oprot.WriteMessageEnd()
-	oprot.Flush()
-	return x
+	return p.SendReply(ctx, oprot, "sayAgain", result)
 }
 
 type FooPingArgs struct {

--- a/test/expected/gopherjs/variety/f_footransitivedeps_service.go
+++ b/test/expected/gopherjs/variety/f_footransitivedeps_service.go
@@ -73,7 +73,7 @@ func (p *footransitivedepsFPing) Process(ctx frugal.FContext, iprot, oprot *frug
 	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
 	if err != nil {
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
 	}
 	result := FooTransitiveDepsPingResult{}
 	ret := p.InvokeMethod([]interface{}{ctx})
@@ -88,9 +88,9 @@ func (p *footransitivedepsFPing) Process(ctx frugal.FContext, iprot, oprot *frug
 			p.SendError(ctx, oprot, typedError.TypeId(), "ping", typedError.Error())
 			return nil
 		}
-		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
+		return p.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
 	}
-	return p.SendReply(ctx, oprot, "ping", result)
+	return p.SendReply(ctx, oprot, "ping", &result)
 }
 
 type FooTransitiveDepsPingArgs struct {

--- a/test/expected/gopherjs/variety/f_footransitivedeps_service.go
+++ b/test/expected/gopherjs/variety/f_footransitivedeps_service.go
@@ -19,17 +19,13 @@ type FFooTransitiveDeps interface {
 
 type FFooTransitiveDepsClient struct {
 	*intermediate_include.FIntermediateFooClient
-	transport       frugal.FTransport
-	protocolFactory *frugal.FProtocolFactory
-	methods         map[string]*frugal.Method
+	methods map[string]*frugal.Method
 }
 
 func NewFFooTransitiveDepsClient(provider *frugal.FServiceProvider, middleware ...frugal.ServiceMiddleware) *FFooTransitiveDepsClient {
 	methods := make(map[string]*frugal.Method)
 	client := &FFooTransitiveDepsClient{
 		FIntermediateFooClient: intermediate_include.NewFIntermediateFooClient(provider, middleware...),
-		transport:              provider.GetTransport(),
-		protocolFactory:        provider.GetProtocolFactory(),
 		methods:                methods,
 	}
 	middleware = append(middleware, provider.GetMiddleware()...)
@@ -49,67 +45,10 @@ func (f *FFooTransitiveDepsClient) Ping(ctx frugal.FContext) (err error) {
 }
 
 func (f *FFooTransitiveDepsClient) ping(ctx frugal.FContext) (err error) {
-	buffer := frugal.NewTMemoryOutputBuffer(f.transport.GetRequestSizeLimit())
-	oprot := f.protocolFactory.GetProtocol(buffer)
-	if err = oprot.WriteRequestHeader(ctx); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageBegin("ping", thrift.CALL, 0); err != nil {
-		return
-	}
 	args := FooTransitiveDepsPingArgs{}
-	if err = args.Write(oprot); err != nil {
-		return
-	}
-	if err = oprot.WriteMessageEnd(); err != nil {
-		return
-	}
-	if err = oprot.Flush(); err != nil {
-		return
-	}
-	var resultTransport thrift.TTransport
-	resultTransport, err = f.transport.Request(ctx, buffer.Bytes())
-	if err != nil {
-		return
-	}
-	iprot := f.protocolFactory.GetProtocol(resultTransport)
-	if err = iprot.ReadResponseHeader(ctx); err != nil {
-		return
-	}
-	method, mTypeId, _, err := iprot.ReadMessageBegin()
-	if err != nil {
-		return
-	}
-	if method != "ping" {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_WRONG_METHOD_NAME, "ping failed: wrong method name")
-		return
-	}
-	if mTypeId == thrift.EXCEPTION {
-		error0 := thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
-		if err != nil {
-			return
-		}
-		if err = iprot.ReadMessageEnd(); err != nil {
-			return
-		}
-		if error1.TypeId() == frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			err = thrift.NewTTransportException(frugal.TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
-			return
-		}
-		err = error1
-		return
-	}
-	if mTypeId != thrift.REPLY {
-		err = thrift.NewTApplicationException(frugal.APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, "ping failed: invalid message type")
-		return
-	}
 	result := FooTransitiveDepsPingResult{}
-	if err = result.Read(iprot); err != nil {
-		return
-	}
-	if err = iprot.ReadMessageEnd(); err != nil {
+	err = f.Client_().Call(ctx, "ping", &args, &result)
+	if err != nil {
 		return
 	}
 	return
@@ -131,89 +70,27 @@ type footransitivedepsFPing struct {
 
 func (p *footransitivedepsFPing) Process(ctx frugal.FContext, iprot, oprot *frugal.FProtocol) error {
 	args := FooTransitiveDepsPingArgs{}
-	var err error
-	if err = args.Read(iprot); err != nil {
-		iprot.ReadMessageEnd()
-		p.GetWriteMutex().Lock()
-		err = footransitivedepsWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
-		p.GetWriteMutex().Unlock()
-		return err
-	}
-
+	err := args.Read(iprot)
 	iprot.ReadMessageEnd()
+	if err != nil {
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_PROTOCOL_ERROR, "ping", err.Error())
+	}
 	result := FooTransitiveDepsPingResult{}
-	var err2 error
 	ret := p.InvokeMethod([]interface{}{ctx})
 	if len(ret) != 1 {
 		panic(fmt.Sprintf("Middleware returned %d arguments, expected 1", len(ret)))
 	}
 	if ret[0] != nil {
-		err2 = ret[0].(error)
+		err = ret[0].(error)
 	}
-	if err2 != nil {
-		if err3, ok := err2.(thrift.TApplicationException); ok {
-			p.GetWriteMutex().Lock()
-			oprot.WriteResponseHeader(ctx)
-			oprot.WriteMessageBegin("ping", thrift.EXCEPTION, 0)
-			err3.Write(oprot)
-			oprot.WriteMessageEnd()
-			oprot.Flush()
-			p.GetWriteMutex().Unlock()
+	if err != nil {
+		if typedError, ok := err.(thrift.TApplicationException); ok {
+			p.SendError(ctx, oprot, typedError.TypeId(), "ping", typedError.Error())
 			return nil
 		}
-		p.GetWriteMutex().Lock()
-		err2 := footransitivedepsWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err2.Error())
-		p.GetWriteMutex().Unlock()
-		return err2
+		return f.SendError(ctx, oprot, frugal.APPLICATION_EXCEPTION_INTERNAL_ERROR, "ping", "Internal error processing ping: "+err.Error())
 	}
-	p.GetWriteMutex().Lock()
-	defer p.GetWriteMutex().Unlock()
-	if err2 = oprot.WriteResponseHeader(ctx); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			footransitivedepsWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageBegin("ping", thrift.REPLY, 0); err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			footransitivedepsWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = result.Write(oprot); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			footransitivedepsWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			footransitivedepsWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	if err2 = oprot.Flush(); err == nil && err2 != nil {
-		if frugal.IsErrTooLarge(err2) {
-			footransitivedepsWriteApplicationError(ctx, oprot, frugal.APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE, "ping", err2.Error())
-			return nil
-		}
-		err = err2
-	}
-	return err
-}
-
-func footransitivedepsWriteApplicationError(ctx frugal.FContext, oprot *frugal.FProtocol, type_ int32, method, message string) error {
-	x := thrift.NewTApplicationException(type_, message)
-	oprot.WriteResponseHeader(ctx)
-	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
-	x.Write(oprot)
-	oprot.WriteMessageEnd()
-	oprot.Flush()
-	return x
+	return p.SendReply(ctx, oprot, "ping", result)
 }
 
 type FooTransitiveDepsPingArgs struct {


### PR DESCRIPTION
# [SPLAT-65](https://jira.atl.workiva.net/browse/SPLAT-65)
![Issue Status](http://bender.workiva.org:9000/Bender/status/SPLAT-65)

This should make moving to thrift 0.13.0 a little easier

### Story:
Similar to https://github.com/Workiva/frugal/pull/1337, but slightly more complicated with the target branches, given that we have tagged v3.10.0 and v3.11.0 already.

Thrfit 0.13.0 converts [TProtocol's `Flush()` to `Flush(ctx)`](https://github.com/apache/thrift/blob/v0.13.0/lib/go/thrift/protocol.go#L78) (where ctx is a `context.Context`)(changes can be seen here https://github.com/Workiva/frugal/pull/1350).  This effort aims to internalize `Flush` calls into the frugal library, such that generated code can be backwards and forwards compatible with thrift 0.13.0 and 0.9.3.  This change is targeting 0.9.3, and will allow the update to thrift 0.13.0 be a library only change, not affecting the generated code.

```
# Another chagne in thrift 0.13.0
have GetTransport(thrift.TTransport) thrift.TTransport
want GetTransport(thrift.TTransport) (thrift.TTransport, error)
# We should be able to just make this change as the only function with this signature is not used outside this repo.
# Searched our orgs sourcegraph: `NewTFramedTransport -file:(^|/)vendor/ lang:go`
# Or searching all of github: https://github.com/search?p=2&q=frugal.NewTFramedTransport&type=Code
```

To encapsulate some of the work a `frugal.FClient` has been added (similar to Java's FClient added in #1337) that encapsulates some of the lower level send/receive/publish methods.  This is generally not for external use and should only be consumed by generated code.

While making these changes, minor cleanup to publish logic was included to make generated code somewhat more readable.  While this was not necessary explicitly, it allowed for `TStruct` to be the primary interface between generated clients and the actions performed with them.

### Acceptance Criteria:
- [ ] At least one Service Platform member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
FClient is similar to thrift's TClient, but includes all the other fun things that frugal can do: https://github.com/apache/thrift/blob/v0.13.0/lib/go/thrift/client.go#L8

Follow up questions:

1. Do we need `Open()` or `Close()` on Publisher transports?  The Nats and Stomp implementations don't really do much, and are better managed by the parent provider, and not in generated logic IMO.
2. Can we update subscribers to use the same helpers the publishers now use?
3. Can we move to a single dependency management solution for go, this project now has, godep, glide and module support?

### How To Test:
```sh
cd examples/go
make install
rm -rf vendor/git.apache.org # updated to 0.13.0 on my machine and couldn't figure out how to rollback
go get git.apache.org/thrift.git
pushd $GOPATH/src/git.apache.org/thrift.git
git checkout 0.9.3
popd
go run ./httpServer &
go run ./httpClient
```

### My Test Results:

```sh
# Server
$ go run ./httpServer/                                     
Starting the http server...
WARN[0041] Deprecated function 'Store.EnterAlbumGiveaway' was called by a client

# Client
 $ go run ./httpClient/
==== CALLING *music.FStoreClient.buyAlbum ====
==== CALLED  *music.FStoreClient.buyAlbum ====
Bought an album Album({Tracks:[Track({Title:Comme des enfants Artist:Coeur de pirate Publisher:Grosse Boîte Composer:Béatrice Martin Duration:169 Pro:ASCAP})] Duration:1200 ASIN:c54d385a-5024-4f3f-86ef-6314546a7e7f})
WARN[0000] Call to deprecated function 'Store.EnterAlbumGiveaway'
==== CALLING *music.FStoreClient.enterAlbumGiveaway ====
==== CALLED  *music.FStoreClient.enterAlbumGiveaway ====
```

#### Reviewers:
@Workiva/service-platform 