### PR TITLE
go: Update internal deps

### DIFF
--- a/compiler/generator/golang/generator.go
+++ b/compiler/generator/golang/generator.go
@@ -1196,7 +1196,7 @@ func (g *Generator) GenerateServiceImports(file *os.File, s *parser.Service) err
 	} else {
 		imports += "\t\"github.com/Workiva/frugal/lib/go\"\n"
 	}
-	imports += "\t\"github.com/Sirupsen/logrus\"\n"
+	imports += "\t\"github.com/sirupsen/logrus\"\n"
 
 	pkgPrefix := g.Options[packagePrefixOption]
 	includes, err := s.ReferencedIncludes()

--- a/examples/go/gen-go/v1/music/f_store_service.go
+++ b/examples/go/gen-go/v1/music/f_store_service.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/Sirupsen/logrus"
 	"github.com/Workiva/frugal/lib/go"
+	"github.com/sirupsen/logrus"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/examples/go/natsClient/main.go
+++ b/examples/go/natsClient/main.go
@@ -5,10 +5,10 @@ import (
 	"reflect"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 
 	"github.com/Workiva/frugal/examples/go/gen-go/v1/music"
-	"github.com/Workiva/frugal/lib/go"
+	frugal "github.com/Workiva/frugal/lib/go"
 )
 
 // Run a NATS client

--- a/examples/go/natsPublisher/main.go
+++ b/examples/go/natsPublisher/main.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 
 	"github.com/Workiva/frugal/examples/go/gen-go/v1/music"
-	"github.com/Workiva/frugal/lib/go"
+	frugal "github.com/Workiva/frugal/lib/go"
 )
 
 // Run a NATS publisher

--- a/examples/go/natsServer/main.go
+++ b/examples/go/natsServer/main.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 
 	"github.com/Workiva/frugal/examples/go/gen-go/v1/music"
-	"github.com/Workiva/frugal/lib/go"
+	frugal "github.com/Workiva/frugal/lib/go"
 )
 
 func main() {

--- a/examples/go/natsSubscriber/main.go
+++ b/examples/go/natsSubscriber/main.go
@@ -5,10 +5,10 @@ import (
 	"sync"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 
 	"github.com/Workiva/frugal/examples/go/gen-go/v1/music"
-	"github.com/Workiva/frugal/lib/go"
+	frugal "github.com/Workiva/frugal/lib/go"
 )
 
 // Run a NATS subscriber

--- a/lib/go/context.go
+++ b/lib/go/context.go
@@ -16,12 +16,11 @@ package frugal
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/mattrobenolt/gocql/uuid"
+	"github.com/nats-io/nuid"
 )
 
 const (
@@ -124,8 +123,8 @@ func Clone(ctx FContext) FContext {
 	}
 
 	clone := &FContextImpl{
-		requestHeaders:  ctx.RequestHeaders(),
-		responseHeaders: ctx.ResponseHeaders(),
+		requestHeaders:      ctx.RequestHeaders(),
+		responseHeaders:     ctx.ResponseHeaders(),
 		ephemeralProperties: make(map[interface{}]interface{}),
 	}
 
@@ -161,7 +160,7 @@ func NewFContext(correlationID string) FContext {
 			opIDHeader:    getNextOpID(),
 			timeoutHeader: strconv.FormatInt(int64(defaultTimeout/time.Millisecond), 10),
 		},
-		responseHeaders: make(map[string]string),
+		responseHeaders:     make(map[string]string),
 		ephemeralProperties: make(map[interface{}]interface{}),
 	}
 
@@ -258,8 +257,8 @@ func (c *FContextImpl) Timeout() time.Duration {
 // handling opids correctly.
 func (c *FContextImpl) Clone() FContextWithEphemeralProperties {
 	cloned := &FContextImpl{
-		requestHeaders: c.RequestHeaders(),
-		responseHeaders: c.ResponseHeaders(),
+		requestHeaders:      c.RequestHeaders(),
+		responseHeaders:     c.ResponseHeaders(),
 		ephemeralProperties: c.EphemeralProperties(),
 	}
 	cloned.requestHeaders[opIDHeader] = getNextOpID()
@@ -323,5 +322,5 @@ func setResponseOpID(ctx FContext, id string) {
 // generateCorrelationID returns a random string id. It's assigned to a var for
 // testability purposes.
 var generateCorrelationID = func() string {
-	return strings.Replace(uuid.RandomUUID().String(), "-", "", -1)
+	return nuid.Next()
 }

--- a/lib/go/frugal.go
+++ b/lib/go/frugal.go
@@ -17,7 +17,7 @@ package frugal
 import (
 	"sync"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/go/frugal_test.go
+++ b/lib/go/frugal_test.go
@@ -18,7 +18,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func init() {

--- a/lib/go/go.mod
+++ b/lib/go/go.mod
@@ -3,9 +3,9 @@ module github.com/Workiva/frugal/lib/go
 require (
 	git.apache.org/thrift.git v0.0.0-20161221203622-b2a4d4ae21c7
 	github.com/go-stomp/stomp v2.0.6+incompatible
-	github.com/mattrobenolt/gocql v0.0.0-20130828033103-56c5a46b65ee
 	github.com/nats-io/nats-server/v2 v2.1.8
 	github.com/nats-io/nats.go v1.10.0
+	github.com/nats-io/nuid v1.0.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1
 )

--- a/lib/go/go.mod
+++ b/lib/go/go.mod
@@ -2,12 +2,11 @@ module github.com/Workiva/frugal/lib/go
 
 require (
 	git.apache.org/thrift.git v0.0.0-20161221203622-b2a4d4ae21c7
-	github.com/Sirupsen/logrus v0.11.5
 	github.com/go-stomp/stomp v2.0.6+incompatible
 	github.com/mattrobenolt/gocql v0.0.0-20130828033103-56c5a46b65ee
-	github.com/nats-io/gnatsd v1.4.1
-	github.com/nats-io/go-nats v0.0.0-20161120202126-6b6bf392d34d
-	github.com/nats-io/nats-server/v2 v2.1.7 // indirect
+	github.com/nats-io/nats-server/v2 v2.1.8
+	github.com/nats-io/nats.go v1.10.0
+	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1
 )
 

--- a/lib/go/nats_scope_transport.go
+++ b/lib/go/nats_scope_transport.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 // frameBufferSize is the number of message frames to buffer on the subscriber.

--- a/lib/go/nats_scope_transport_test.go
+++ b/lib/go/nats_scope_transport_test.go
@@ -20,8 +20,8 @@ import (
 	"time"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/nats-io/gnatsd/server"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/lib/go/nats_server.go
+++ b/lib/go/nats_server.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 const (
@@ -29,23 +29,23 @@ const (
 )
 
 type frameWrapper struct {
-	frameBytes []byte
-	reply      string
+	frameBytes          []byte
+	reply               string
 	ephemeralProperties map[interface{}]interface{}
 }
 
 // FNatsServerBuilder configures and builds NATS server instances.
 type FNatsServerBuilder struct {
-	conn          *nats.Conn
-	processor     FProcessor
-	protoFactory  *FProtocolFactory
-	subjects      []string
-	queue         string
-	workerCount   uint
-	queueLen      uint
-	highWatermark time.Duration
+	conn              *nats.Conn
+	processor         FProcessor
+	protoFactory      *FProtocolFactory
+	subjects          []string
+	queue             string
+	workerCount       uint
+	queueLen          uint
+	highWatermark     time.Duration
 	onRequestReceived func(map[interface{}]interface{})
-	onRequestStarted func(map[interface{}]interface{})
+	onRequestStarted  func(map[interface{}]interface{})
 	onRequestFinished func(map[interface{}]interface{})
 }
 
@@ -170,16 +170,16 @@ func (f *FNatsServerBuilder) Build() FServer {
 	}
 
 	return &fNatsServer{
-		conn:          f.conn,
-		processor:     f.processor,
-		protoFactory:  f.protoFactory,
-		subjects:      f.subjects,
-		queue:         f.queue,
-		workerCount:   f.workerCount,
-		workC:         make(chan *frameWrapper, f.queueLen),
-		quit:          make(chan struct{}),
+		conn:              f.conn,
+		processor:         f.processor,
+		protoFactory:      f.protoFactory,
+		subjects:          f.subjects,
+		queue:             f.queue,
+		workerCount:       f.workerCount,
+		workC:             make(chan *frameWrapper, f.queueLen),
+		quit:              make(chan struct{}),
 		onRequestReceived: f.onRequestReceived,
-		onRequestStarted: f.onRequestStarted,
+		onRequestStarted:  f.onRequestStarted,
 		onRequestFinished: f.onRequestFinished,
 	}
 }
@@ -187,17 +187,17 @@ func (f *FNatsServerBuilder) Build() FServer {
 // fNatsServer implements FServer by using NATS as the underlying transport.
 // Clients must connect with the transport created by NewNatsFTransport.
 type fNatsServer struct {
-	conn          *nats.Conn
-	processor     FProcessor
-	protoFactory  *FProtocolFactory
-	subjects      []string
-	queue         string
-	workerCount   uint
-	workC         chan *frameWrapper
-	quit          chan struct{}
+	conn         *nats.Conn
+	processor    FProcessor
+	protoFactory *FProtocolFactory
+	subjects     []string
+	queue        string
+	workerCount  uint
+	workC        chan *frameWrapper
+	quit         chan struct{}
 
 	onRequestReceived func(map[interface{}]interface{})
-	onRequestStarted func(map[interface{}]interface{})
+	onRequestStarted  func(map[interface{}]interface{})
 	onRequestFinished func(map[interface{}]interface{})
 }
 

--- a/lib/go/nats_server_test.go
+++ b/lib/go/nats_server_test.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/lib/go/nats_transport.go
+++ b/lib/go/nats_transport.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 const (

--- a/lib/go/nats_transport_test.go
+++ b/lib/go/nats_transport_test.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/lib/go/processor_test.go
+++ b/lib/go/processor_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/lib/gopherjs/frugal/frugal.go
+++ b/lib/gopherjs/frugal/frugal.go
@@ -21,8 +21,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/nats-io/nuid"
+	"github.com/sirupsen/logrus"
 )
 
 var (

--- a/lib/gopherjs/frugal/frugal_test.go
+++ b/lib/gopherjs/frugal/frugal_test.go
@@ -18,7 +18,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func init() {

--- a/lib/gopherjs/frugal/nats_scope_transport.go
+++ b/lib/gopherjs/frugal/nats_scope_transport.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/Workiva/frugal/lib/gopherjs/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 // frameBufferSize is the number of message frames to buffer on the subscriber.

--- a/lib/gopherjs/frugal/nats_scope_transport_test.go
+++ b/lib/gopherjs/frugal/nats_scope_transport_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/Workiva/frugal/lib/gopherjs/thrift"
 	"github.com/nats-io/gnatsd/server"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/lib/gopherjs/frugal/nats_server.go
+++ b/lib/gopherjs/frugal/nats_server.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/Workiva/frugal/lib/gopherjs/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 const (

--- a/lib/gopherjs/frugal/nats_server_test.go
+++ b/lib/gopherjs/frugal/nats_server_test.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/Workiva/frugal/lib/gopherjs/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/lib/gopherjs/frugal/nats_transport.go
+++ b/lib/gopherjs/frugal/nats_transport.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/Workiva/frugal/lib/gopherjs/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 )
 
 const (

--- a/lib/gopherjs/frugal/nats_transport_test.go
+++ b/lib/gopherjs/frugal/nats_transport_test.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/Workiva/frugal/lib/gopherjs/thrift"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/lib/gopherjs/frugal/processor_test.go
+++ b/lib/gopherjs/frugal/processor_test.go
@@ -20,10 +20,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
-	"github.com/Workiva/frugal/lib/gopherjs/thrift"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/Workiva/frugal/lib/gopherjs/thrift"
 )
 
 // _opid0_cid123[1,"ping",1,0,{}]

--- a/scripts/skynet/cross/cross_setup.go
+++ b/scripts/skynet/cross/cross_setup.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	"os/exec"
-	"sync"
-	log "github.com/Sirupsen/logrus"
 	"io/ioutil"
 	"os"
+	"os/exec"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
 )
 
-func main(){
+func main() {
 
 	setupScriptDir := "scripts/skynet/cross/"
 	setupScripts := []string{"setup_dart.sh", "setup_go.sh", "setup_python.sh", "setup_java.sh"}
@@ -25,10 +26,10 @@ func main(){
 
 }
 
-func runSetupScript(script string, scriptDir string, wg *sync.WaitGroup){
+func runSetupScript(script string, scriptDir string, wg *sync.WaitGroup) {
 	fullScript := scriptDir + script
 	log.Info("Running setup script:", script)
-	out, err := exec.Command("sh", fullScript).CombinedOutput();
+	out, err := exec.Command("sh", fullScript).CombinedOutput()
 
 	if err != nil {
 		log.Errorf("Script '%s' failed with output:%s", script, out)
@@ -49,7 +50,7 @@ func runSetupScript(script string, scriptDir string, wg *sync.WaitGroup){
 
 }
 
-func writeFile(logFile string, commandData []byte) (error) {
+func writeFile(logFile string, commandData []byte) error {
 
 	return ioutil.WriteFile(logFile, commandData, 0644)
 

--- a/scripts/skynet/run_cross_skynet.sh
+++ b/scripts/skynet/run_cross_skynet.sh
@@ -27,7 +27,7 @@ frugal --gen py -r -out='test/integration/python/tornado/gen-py' test/integratio
 frugal --gen dart:use_enums=true -r --out='test/integration/dart/gen-dart' test/integration/frugalTest.frugal
 
 # integration tests use logrus, but frugal does not so it won't be in /vendor
-go get github.com/Sirupsen/logrus
+go get github.com/sirupsen/logrus
 
 # Set everything up in parallel (code generation is fast enough to not require in parallel)
 go run scripts/skynet/cross/cross_setup.go

--- a/scripts/smithy.sh
+++ b/scripts/smithy.sh
@@ -8,5 +8,5 @@ python $FRUGAL_HOME/scripts/smithy/verify_pr_target.py
 mkdir -p $FRUGAL_HOME/test_results/
 
 # Run each language build and tests in parallel
-go get github.com/Sirupsen/logrus
+go get github.com/sirupsen/logrus
 cd $FRUGAL_HOME && go run scripts/smithy/parallel_smithy.go

--- a/scripts/smithy/parallel_smithy.go
+++ b/scripts/smithy/parallel_smithy.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	"os/exec"
-	"sync"
 	"io/ioutil"
 	"os"
-	log "github.com/Sirupsen/logrus"
+	"os/exec"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
 )
 
-func main(){
+func main() {
 	// By setting ForceColors = true, this tricks logrus into thinking it is writing
 	// to a terminal output - this allows linebreaks and colors to be displayed on the
 	// Smithy webview
@@ -30,15 +31,14 @@ func main(){
 
 }
 
-func runTestScript(script string, scriptDir string, wg *sync.WaitGroup){
+func runTestScript(script string, scriptDir string, wg *sync.WaitGroup) {
 	fullScript := scriptDir + script
 	log.Info("Running script:", script)
-	out, err := exec.Command("/bin/bash", fullScript).CombinedOutput();
+	out, err := exec.Command("/bin/bash", fullScript).CombinedOutput()
 
 	if err != nil {
 		log.Errorf("Script '%s' failed with output:\n%s", script, out)
 	}
-
 
 	logFile := os.ExpandEnv("${FRUGAL_HOME}/test_results/" + script + "_out.txt")
 	err2 := writeFile(logFile, out)
@@ -56,7 +56,7 @@ func runTestScript(script string, scriptDir string, wg *sync.WaitGroup){
 
 }
 
-func writeFile(logFile string, commandData []byte) (error) {
+func writeFile(logFile string, commandData []byte) error {
 
 	return ioutil.WriteFile(logFile, commandData, 0644)
 

--- a/test/expected/go/actual_base/f_basefoo_service.txt
+++ b/test/expected/go/actual_base/f_basefoo_service.txt
@@ -8,8 +8,8 @@ import (
 	"fmt"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/Sirupsen/logrus"
 	"github.com/Workiva/frugal/lib/go"
+	"github.com/sirupsen/logrus"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/test/expected/go/deprecated_logging/f_foo_service.go
+++ b/test/expected/go/deprecated_logging/f_foo_service.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/Sirupsen/logrus"
 	"github.com/Workiva/frugal/lib/go"
 	"github.com/Workiva/frugal/test/out/ValidTypes"
 	"github.com/Workiva/frugal/test/out/actual_base/golang"
 	"github.com/Workiva/frugal/test/out/subdir_include"
 	"github.com/Workiva/frugal/test/out/validStructs"
+	"github.com/sirupsen/logrus"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/test/expected/go/variety/f_foo_service.txt
+++ b/test/expected/go/variety/f_foo_service.txt
@@ -8,12 +8,12 @@ import (
 	"fmt"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/Sirupsen/logrus"
 	"github.com/Workiva/frugal/lib/go"
 	"github.com/Workiva/frugal/test/out/ValidTypes"
 	"github.com/Workiva/frugal/test/out/actual_base/golang"
 	"github.com/Workiva/frugal/test/out/subdir_include"
 	"github.com/Workiva/frugal/test/out/validStructs"
+	"github.com/sirupsen/logrus"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/test/expected/go/variety_async/f_foo_service.txt
+++ b/test/expected/go/variety_async/f_foo_service.txt
@@ -8,12 +8,12 @@ import (
 	"fmt"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/Sirupsen/logrus"
 	"github.com/Workiva/frugal/lib/go"
 	"github.com/Workiva/frugal/test/out/async/ValidTypes"
 	"github.com/Workiva/frugal/test/out/async/actual_base/golang"
 	"github.com/Workiva/frugal/test/out/async/subdir_include"
 	"github.com/Workiva/frugal/test/out/async/validStructs"
+	"github.com/sirupsen/logrus"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/test/expected/go/vendor/f_myservice_service.txt
+++ b/test/expected/go/vendor/f_myservice_service.txt
@@ -8,10 +8,10 @@ import (
 	"fmt"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/Sirupsen/logrus"
 	"github.com/Workiva/frugal/lib/go"
 	"github.com/Workiva/frugal/test/out/excepts"
 	"github.com/Workiva/some/vendored/place/vendor_namespace"
+	"github.com/sirupsen/logrus"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/test/expected/go/vendor_namespace/f_vendoredbase_service.txt
+++ b/test/expected/go/vendor_namespace/f_vendoredbase_service.txt
@@ -8,8 +8,8 @@ import (
 	"fmt"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/Sirupsen/logrus"
 	"github.com/Workiva/frugal/lib/go"
+	"github.com/sirupsen/logrus"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/test/integration/crossrunner/run.go
+++ b/test/integration/crossrunner/run.go
@@ -17,10 +17,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os/exec"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
-	"os/exec"
+	log "github.com/sirupsen/logrus"
 )
 
 // RunConfig runs a client against a server.  Client/Server logs are created and

--- a/test/integration/crossrunner/test.go
+++ b/test/integration/crossrunner/test.go
@@ -16,13 +16,13 @@ package crossrunner
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
-	"os/exec"
+	log "github.com/sirupsen/logrus"
 )
 
 // a testCase is a pointer to a valid test pair (client/server) and port to run

--- a/test/integration/go/common/client.go
+++ b/test/integration/go/common/client.go
@@ -16,14 +16,13 @@ package common
 import (
 	"flag"
 	"fmt"
+	"net/http"
 	"time"
 
-	"net/http"
-
-	log "github.com/Sirupsen/logrus"
-
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/Workiva/frugal/lib/go"
+	log "github.com/sirupsen/logrus"
+
+	frugal "github.com/Workiva/frugal/lib/go"
 	"github.com/Workiva/frugal/test/integration/go/gen/frugaltest"
 )
 

--- a/test/integration/go/common/printing_handler.go
+++ b/test/integration/go/common/printing_handler.go
@@ -17,10 +17,10 @@ import (
 	"errors"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/Workiva/frugal/lib/go"
+	frugal "github.com/Workiva/frugal/lib/go"
 	. "github.com/Workiva/frugal/test/integration/go/gen/frugaltest"
 )
 

--- a/test/integration/go/common/server.go
+++ b/test/integration/go/common/server.go
@@ -18,10 +18,10 @@ import (
 	"net/http"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
-
 	"git.apache.org/thrift.git/lib/go/thrift"
-	"github.com/Workiva/frugal/lib/go"
+	log "github.com/sirupsen/logrus"
+
+	frugal "github.com/Workiva/frugal/lib/go"
 	"github.com/Workiva/frugal/test/integration/go/gen/frugaltest"
 )
 

--- a/test/integration/go/common/utils.go
+++ b/test/integration/go/common/utils.go
@@ -18,9 +18,9 @@ import (
 	"reflect"
 
 	"github.com/go-stomp/stomp"
-	"github.com/nats-io/go-nats"
+	"github.com/nats-io/nats.go"
 
-	"github.com/Workiva/frugal/lib/go"
+	frugal "github.com/Workiva/frugal/lib/go"
 )
 
 const (


### PR DESCRIPTION
### Story:
Seeing github.com/Sirupsen/logrus and github.com/sirupsen/logrus has been a thorn in my side for a while now, and has been making some of the thrift-0.13.0 updates more complicated of a change to the dependency tree than necessary.  This should update to the latest version of all dependendencies (except thrift) in the lib/go directory.  This includes a few major versions, package renames and other package changes.

* github.com/Sirupsen/logrus => github.com/sirupsen/logrus
* github.com/nats-io/go-nats => github.com/nats-io/nats.go
* github.com/nats-io/gnatsd/server => github.com/nats-io/nats-server/v2/server (v1 to v2)
* github.com/mattrobenolt/gocql/uuid => github.com/nats-io/nuid (or github.com/google/uuid)

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
TODO

### My Test Results:
TODO

#### Reviewers:
@Workiva/service-platform 