### PR TITLE
SPLAT-189: Go: Thrift 0.13.0

### DIFF
--- a/examples/go/glide.yaml
+++ b/examples/go/glide.yaml
@@ -2,7 +2,7 @@ import:
 - package: git.apache.org/thrift.git
   subpackages:
   - lib/go/thrift
-  version: 0.9.3
+  version: 0.13.0
 - package: github.com/Sirupsen/logrus
   repo: git@github.com:/sirupsen/logrus
   vcs: git

--- a/lib/go/adapter_transport.go
+++ b/lib/go/adapter_transport.go
@@ -15,6 +15,7 @@ package frugal
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"sync"
 	"time"
@@ -225,7 +226,7 @@ func (f *fAdapterTransport) send(payload []byte, errorC chan error, oneway bool)
 		errorC <- err
 		return
 	}
-	if err := f.transport.Flush(); err != nil {
+	if err := f.transport.Flush(context.TODO()); err != nil {
 		errorC <- err
 		return
 	}

--- a/lib/go/adapter_transport.go
+++ b/lib/go/adapter_transport.go
@@ -187,10 +187,7 @@ func (f *fAdapterTransport) close(cause error) error {
 // present on the context.
 func (f *fAdapterTransport) Oneway(ctx FContext, payload []byte) error {
 	errorC := make(chan error, 1)
-	c, done := toCTX(ctx)
-	defer done()
-
-	go f.send(c, payload, errorC, true)
+	go f.send(toCTX(ctx), payload, errorC, true)
 
 	select {
 	case err := <-errorC:
@@ -210,10 +207,7 @@ func (f *fAdapterTransport) Request(ctx FContext, payload []byte) (thrift.TTrans
 	f.registry.Register(ctx, resultC)
 	defer f.registry.Unregister(ctx)
 
-	c, done := toCTX(ctx)
-	defer done()
-
-	go f.send(c, payload, errorC, false)
+	go f.send(toCTX(ctx), payload, errorC, false)
 
 	select {
 	case result := <-resultC:

--- a/lib/go/client.go
+++ b/lib/go/client.go
@@ -1,6 +1,10 @@
 package frugal
 
-import "git.apache.org/thrift.git/lib/go/thrift"
+import (
+	"context"
+
+	"git.apache.org/thrift.git/lib/go/thrift"
+)
 
 var _ FClient = (*FStandardClient)(nil)
 
@@ -98,7 +102,7 @@ func (client FStandardClient) prepareMessage(ctx FContext, method string, args t
 	if err := oprot.WriteMessageEnd(); err != nil {
 		return nil, err
 	}
-	if err := oprot.Flush(); err != nil {
+	if err := oprot.Flush(context.TODO()); err != nil {
 		return nil, err
 	}
 	return buffer.Bytes(), nil
@@ -118,18 +122,17 @@ func (client FStandardClient) processReply(ctx FContext, method string, result t
 	}
 	if mTypeID == thrift.EXCEPTION {
 		error0 := thrift.NewTApplicationException(APPLICATION_EXCEPTION_UNKNOWN, "Unknown Exception")
-		var error1 thrift.TApplicationException
-		error1, err = error0.Read(iprot)
+		err = error0.Read(iprot)
 		if err != nil {
 			return err
 		}
 		if err = iprot.ReadMessageEnd(); err != nil {
 			return err
 		}
-		if error1.TypeId() == APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
-			return thrift.NewTTransportException(TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error1.Error())
+		if error0.TypeId() == APPLICATION_EXCEPTION_RESPONSE_TOO_LARGE {
+			return thrift.NewTTransportException(TRANSPORT_EXCEPTION_RESPONSE_TOO_LARGE, error0.Error())
 		}
-		return error1
+		return error0
 	}
 	if mTypeID != thrift.REPLY {
 		return thrift.NewTApplicationException(APPLICATION_EXCEPTION_INVALID_MESSAGE_TYPE, method+" failed: invalid message type")

--- a/lib/go/client.go
+++ b/lib/go/client.go
@@ -98,9 +98,7 @@ func (client FStandardClient) prepareMessage(ctx FContext, method string, args t
 	if err := oprot.WriteMessageEnd(); err != nil {
 		return nil, err
 	}
-	c, done := toCTX(ctx)
-	defer done()
-	if err := oprot.Flush(c); err != nil {
+	if err := oprot.Flush(toCTX(ctx)); err != nil {
 		return nil, err
 	}
 	return buffer.Bytes(), nil

--- a/lib/go/client.go
+++ b/lib/go/client.go
@@ -1,10 +1,6 @@
 package frugal
 
-import (
-	"context"
-
-	"git.apache.org/thrift.git/lib/go/thrift"
-)
+import "git.apache.org/thrift.git/lib/go/thrift"
 
 var _ FClient = (*FStandardClient)(nil)
 
@@ -102,7 +98,9 @@ func (client FStandardClient) prepareMessage(ctx FContext, method string, args t
 	if err := oprot.WriteMessageEnd(); err != nil {
 		return nil, err
 	}
-	if err := oprot.Flush(context.TODO()); err != nil {
+	c, done := toCTX(ctx)
+	defer done()
+	if err := oprot.Flush(c); err != nil {
 		return nil, err
 	}
 	return buffer.Bytes(), nil

--- a/lib/go/client_test.go
+++ b/lib/go/client_test.go
@@ -91,7 +91,7 @@ func TestFClientPublish(t *testing.T) {
 	mockTProtocolFactory.On("GetProtocol", mock.Anything).Return(proto)
 	mockTransport.On("Write", mock.Anything).Return(55, nil)
 	obj.On("Write", mock.Anything).Return(nil)
-	mockTransport.On("Flush").Return(nil)
+	mockTransport.On("Flush", mock.Anything).Return(nil)
 	publisher.On("Publish", "topic", []byte{0, 0, 0, 0}).Return(nil)
 
 	assert.NoError(t, client.Publish(ctx, "op", "topic", obj))
@@ -118,7 +118,7 @@ func TestFClientOneway(t *testing.T) {
 	mockTProtocolFactory.On("GetProtocol", mock.Anything).Return(proto)
 	mockTransport.On("Write", mock.Anything).Return(55, nil)
 	obj.On("Write", mock.Anything).Return(nil)
-	mockTransport.On("Flush").Return(nil)
+	mockTransport.On("Flush", mock.Anything).Return(nil)
 	transport.On("Oneway").Return(nil)
 
 	assert.NoError(t, client.Oneway(ctx, "method", obj))
@@ -147,7 +147,7 @@ func TestFClientCall(t *testing.T) {
 	mockTProtocolFactory.On("GetProtocol", mock.Anything).Return(proto)
 	mockTransport.On("Write", mock.Anything).Return(55, nil)
 	args.On("Write", mock.Anything).Return(nil)
-	mockTransport.On("Flush").Return(nil)
+	mockTransport.On("Flush", mock.Anything).Return(nil)
 	transport.On("Request").Return(resultTransport, nil)
 	calls := 0
 	output := append([]byte{0, 0, 0, 0, 0}, []byte(`[1, "method", 2, 0]`)...)

--- a/lib/go/framed_transport.go
+++ b/lib/go/framed_transport.go
@@ -16,6 +16,7 @@ package frugal
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -57,8 +58,12 @@ func NewTFramedTransportFactoryMaxLength(factory thrift.TTransportFactory, maxLe
 }
 
 // GetTransport creates a new TFramedTransport wrapping the given TTransport.
-func (p *tFramedTransportFactory) GetTransport(base thrift.TTransport) thrift.TTransport {
-	return NewTFramedTransportMaxLength(p.factory.GetTransport(base), p.maxLength)
+func (p *tFramedTransportFactory) GetTransport(base thrift.TTransport) (thrift.TTransport, error) {
+	trans, err := p.factory.GetTransport(base)
+	if err != nil {
+		return nil, err
+	}
+	return NewTFramedTransportMaxLength(trans, p.maxLength), nil
 }
 
 // NewTFramedTransport creates a new TFramedTransport wrapping the given
@@ -125,7 +130,7 @@ func (p *TFramedTransport) Write(buf []byte) (int, error) {
 }
 
 // Flush the transport.
-func (p *TFramedTransport) Flush() error {
+func (p *TFramedTransport) Flush(ctx context.Context) error {
 	size := p.buf.Len()
 	buf := p.writeBuffer[:4]
 	binary.BigEndian.PutUint32(buf, uint32(size))
@@ -141,7 +146,7 @@ func (p *TFramedTransport) Flush() error {
 			return thrift.NewTTransportExceptionFromError(err)
 		}
 	}
-	err = p.transport.Flush()
+	err = p.transport.Flush(ctx)
 	return thrift.NewTTransportExceptionFromError(err)
 }
 

--- a/lib/go/framed_transport_test.go
+++ b/lib/go/framed_transport_test.go
@@ -14,6 +14,7 @@
 package frugal
 
 import (
+	"context"
 	"errors"
 	"io"
 	"testing"
@@ -69,8 +70,8 @@ func (m *mockTTransport) Write(b []byte) (int, error) {
 	return args.Int(0), args.Error(1)
 }
 
-func (m *mockTTransport) Flush() error {
-	return m.Called().Error(0)
+func (m *mockTTransport) Flush(ctx context.Context) error {
+	return m.Called(ctx).Error(0)
 }
 
 func (m *mockTTransport) RemainingBytes() uint64 {
@@ -81,8 +82,9 @@ type mockTTransportFactory struct {
 	mock.Mock
 }
 
-func (m *mockTTransportFactory) GetTransport(tr thrift.TTransport) thrift.TTransport {
-	return m.Called(tr).Get(0).(thrift.TTransport)
+func (m *mockTTransportFactory) GetTransport(tr thrift.TTransport) (thrift.TTransport, error) {
+	call := m.Called(tr)
+	return call.Get(0).(thrift.TTransport), call.Error(1)
 }
 
 // Ensures NewTFramedTransportFactory creates a tFramedTransportFactory with
@@ -92,10 +94,10 @@ func TestTFramedTransportFactory(t *testing.T) {
 	mockTrFactory := new(mockTTransportFactory)
 	trFactory := NewTFramedTransportFactory(mockTrFactory)
 	mockTr := new(mockTTransport)
-	mockTrFactory.On("GetTransport", mockTr).Return(mockTr)
+	mockTrFactory.On("GetTransport", mockTr).Return(mockTr, nil)
 
-	tr := trFactory.GetTransport(mockTr)
-
+	tr, err := trFactory.GetTransport(mockTr)
+	assert.NoError(t, err)
 	assert.Equal(t, mockTr, tr.(*TFramedTransport).transport)
 	assert.Equal(t, uint32(defaultMaxLength), tr.(*TFramedTransport).maxLength)
 	mockTrFactory.AssertExpectations(t)
@@ -109,10 +111,10 @@ func TestTFramedTransportFactoryMaxLength(t *testing.T) {
 	maxLength := uint32(1024)
 	trFactory := NewTFramedTransportFactoryMaxLength(mockTrFactory, maxLength)
 	mockTr := new(mockTTransport)
-	mockTrFactory.On("GetTransport", mockTr).Return(mockTr)
+	mockTrFactory.On("GetTransport", mockTr).Return(mockTr, nil)
 
-	tr := trFactory.GetTransport(mockTr)
-
+	tr, err := trFactory.GetTransport(mockTr)
+	assert.NoError(t, err)
 	assert.Equal(t, mockTr, tr.(*TFramedTransport).transport)
 	assert.Equal(t, maxLength, tr.(*TFramedTransport).maxLength)
 	mockTrFactory.AssertExpectations(t)
@@ -251,9 +253,9 @@ func TestFlush(t *testing.T) {
 	assert.Nil(t, err)
 	mockTr.On("Write", []byte{0, 0, 0, 10}).Return(4, nil)
 	mockTr.On("Write", buff).Return(len(buff), nil)
-	mockTr.On("Flush").Return(nil)
+	mockTr.On("Flush", mock.Anything).Return(nil)
 
-	assert.Nil(t, tr.Flush())
+	assert.Nil(t, tr.Flush(context.TODO()))
 	mockTr.AssertExpectations(t)
 }
 
@@ -267,7 +269,7 @@ func TestFlushFrameSizeError(t *testing.T) {
 	assert.Nil(t, err)
 	mockTr.On("Write", []byte{0, 0, 0, 10}).Return(0, errors.New("error"))
 
-	assert.Error(t, tr.Flush())
+	assert.Error(t, tr.Flush(context.TODO()))
 	mockTr.AssertExpectations(t)
 }
 
@@ -282,7 +284,7 @@ func TestFlushWriteError(t *testing.T) {
 	mockTr.On("Write", []byte{0, 0, 0, 10}).Return(4, nil)
 	mockTr.On("Write", buff).Return(0, errors.New("error"))
 
-	assert.Error(t, tr.Flush())
+	assert.Error(t, tr.Flush(context.TODO()))
 	mockTr.AssertExpectations(t)
 }
 
@@ -295,9 +297,9 @@ func TestFlushError(t *testing.T) {
 	assert.Nil(t, err)
 	mockTr.On("Write", []byte{0, 0, 0, 10}).Return(4, nil)
 	mockTr.On("Write", buff).Return(len(buff), nil)
-	mockTr.On("Flush").Return(errors.New("error"))
+	mockTr.On("Flush", mock.Anything).Return(errors.New("error"))
 
-	assert.Error(t, tr.Flush())
+	assert.Error(t, tr.Flush(context.TODO()))
 	mockTr.AssertExpectations(t)
 }
 

--- a/lib/go/go.mod
+++ b/lib/go/go.mod
@@ -1,13 +1,17 @@
 module github.com/Workiva/frugal/lib/go
 
 require (
-	git.apache.org/thrift.git v0.0.0-20161221203622-b2a4d4ae21c7
+	git.apache.org/thrift.git v0.13.0
 	github.com/Sirupsen/logrus v0.11.5
 	github.com/go-stomp/stomp v2.0.6+incompatible
 	github.com/mattrobenolt/gocql v0.0.0-20130828033103-56c5a46b65ee
+	github.com/nats-io/gnatsd v1.4.1
 	github.com/nats-io/go-nats v0.0.0-20161120202126-6b6bf392d34d
-	github.com/nats-io/nats-server/v2 v2.1.8
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/stretchr/testify v1.6.1
+	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 // indirect
+	golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e // indirect
+	google.golang.org/protobuf v1.22.0 // indirect
 )
 
-replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20161221203622-b2a4d4ae21c7
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.13.0

--- a/lib/go/processor.go
+++ b/lib/go/processor.go
@@ -14,7 +14,6 @@
 package frugal
 
 import (
-	"context"
 	"sync"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
@@ -105,7 +104,9 @@ func (f *FBaseProcessor) Process(iprot, oprot *FProtocol) error {
 	if err := oprot.WriteMessageEnd(); err != nil {
 		return err
 	}
-	if err := oprot.Flush(context.TODO()); err != nil {
+	c, done := toCTX(ctx)
+	defer done()
+	if err := oprot.Flush(c); err != nil {
 		return err
 	}
 	return nil
@@ -211,7 +212,9 @@ func (f *FBaseProcessorFunction) sendError(ctx FContext, oprot *FProtocol, kind 
 	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
 	err.Write(oprot)
 	oprot.WriteMessageEnd()
-	oprot.Flush(context.TODO())
+	c, done := toCTX(ctx)
+	defer done()
+	oprot.Flush(c)
 	return err
 }
 
@@ -231,7 +234,9 @@ func (f *FBaseProcessorFunction) SendReply(ctx FContext, oprot *FProtocol, metho
 	if err := oprot.WriteMessageEnd(); err != nil {
 		return f.trapError(ctx, oprot, method, err)
 	}
-	if err := oprot.Flush(context.TODO()); err != nil {
+	c, done := toCTX(ctx)
+	defer done()
+	if err := oprot.Flush(c); err != nil {
 		return f.trapError(ctx, oprot, method, err)
 	}
 	return nil

--- a/lib/go/processor.go
+++ b/lib/go/processor.go
@@ -104,9 +104,7 @@ func (f *FBaseProcessor) Process(iprot, oprot *FProtocol) error {
 	if err := oprot.WriteMessageEnd(); err != nil {
 		return err
 	}
-	c, done := toCTX(ctx)
-	defer done()
-	if err := oprot.Flush(c); err != nil {
+	if err := oprot.Flush(toCTX(ctx)); err != nil {
 		return err
 	}
 	return nil
@@ -212,9 +210,7 @@ func (f *FBaseProcessorFunction) sendError(ctx FContext, oprot *FProtocol, kind 
 	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
 	err.Write(oprot)
 	oprot.WriteMessageEnd()
-	c, done := toCTX(ctx)
-	defer done()
-	oprot.Flush(c)
+	oprot.Flush(toCTX(ctx))
 	return err
 }
 
@@ -234,9 +230,7 @@ func (f *FBaseProcessorFunction) SendReply(ctx FContext, oprot *FProtocol, metho
 	if err := oprot.WriteMessageEnd(); err != nil {
 		return f.trapError(ctx, oprot, method, err)
 	}
-	c, done := toCTX(ctx)
-	defer done()
-	if err := oprot.Flush(c); err != nil {
+	if err := oprot.Flush(toCTX(ctx)); err != nil {
 		return f.trapError(ctx, oprot, method, err)
 	}
 	return nil

--- a/lib/go/processor.go
+++ b/lib/go/processor.go
@@ -14,6 +14,7 @@
 package frugal
 
 import (
+	"context"
 	"sync"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
@@ -104,7 +105,7 @@ func (f *FBaseProcessor) Process(iprot, oprot *FProtocol) error {
 	if err := oprot.WriteMessageEnd(); err != nil {
 		return err
 	}
-	if err := oprot.Flush(); err != nil {
+	if err := oprot.Flush(context.TODO()); err != nil {
 		return err
 	}
 	return nil
@@ -210,7 +211,7 @@ func (f *FBaseProcessorFunction) sendError(ctx FContext, oprot *FProtocol, kind 
 	oprot.WriteMessageBegin(method, thrift.EXCEPTION, 0)
 	err.Write(oprot)
 	oprot.WriteMessageEnd()
-	oprot.Flush()
+	oprot.Flush(context.TODO())
 	return err
 }
 
@@ -230,7 +231,7 @@ func (f *FBaseProcessorFunction) SendReply(ctx FContext, oprot *FProtocol, metho
 	if err := oprot.WriteMessageEnd(); err != nil {
 		return f.trapError(ctx, oprot, method, err)
 	}
-	if err := oprot.Flush(); err != nil {
+	if err := oprot.Flush(context.TODO()); err != nil {
 		return f.trapError(ctx, oprot, method, err)
 	}
 	return nil

--- a/lib/go/processor_test.go
+++ b/lib/go/processor_test.go
@@ -150,7 +150,7 @@ func TestFBaseProcessorNoProcessorFunction(t *testing.T) {
 		125, 125, 93,
 	}
 	mockTransport.On("Write", responseBody).Return(len(responseBody), nil).Once()
-	mockTransport.On("Flush").Return(nil)
+	mockTransport.On("Flush", mock.Anything).Return(nil)
 	proto := &FProtocol{TProtocol: thrift.NewTJSONProtocol(mockTransport)}
 	processor := NewFBaseProcessor()
 
@@ -232,7 +232,7 @@ func TestFBaseProcessorNoProcessorFunctionFlushError(t *testing.T) {
 		125, 125, 93,
 	}
 	mockTransport.On("Write", responseBody).Return(len(responseBody), nil).Once()
-	mockTransport.On("Flush").Return(errors.New("error"))
+	mockTransport.On("Flush", mock.Anything).Return(errors.New("error"))
 	proto := &FProtocol{TProtocol: thrift.NewTJSONProtocol(mockTransport)}
 	processor := NewFBaseProcessor()
 

--- a/lib/go/transport_monitor_test.go
+++ b/lib/go/transport_monitor_test.go
@@ -14,6 +14,7 @@
 package frugal
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -357,10 +358,10 @@ func (m *mockFTransport) RemainingBytes() uint64 {
 	return args.Get(0).(uint64)
 }
 
-func (m *mockFTransport) Flush() (err error) {
+func (m *mockFTransport) Flush(ctx context.Context) (err error) {
 	m.Lock()
 	defer m.Unlock()
-	args := m.Called()
+	args := m.Called(ctx)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
# [SPLAT-189](https://jira.atl.workiva.net/browse/SPLAT-189)
![Issue Status](http://bender.workiva.org:9000/Bender/status/SPLAT-189)

### Story:
We took what we learned from https://github.com/Workiva/frugal/pull/1350 (pre v3.10.1)
Applied it to v3.10.1 code generator https://github.com/Workiva/frugal/pull/1352 so generated code shouldn't break.
Consume both changes on develop, and roll out with thrift 0.13.0 support!

Changing go Interfaces in Thrift 0.13.0

```diff
type TTransport interface {
-	Flush() error
+	Flush(ctx context.Context) error
	// ... other fields omitted ...
}

type TTransportFactory interface {
-	GetTransport(trans TTransport) error
+	GetTransport(trans TTransport) (TTransport, error)
}

type TApplicationException interface {
-	Read(iprot TProtocol) (TApplicationException, error)
+	Read(iprot TProtocol) error
	// ... other fields omitted ...
}
```

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
See previous PRs for details, but essentially, previous work was done to ensure the update to thrift 0.13.0 only requires library changes in frugal to consume, and few (if any) externally accessible interfaces should break at this time.

`toCTX` was added for internal access only, given that `FContext` and `context.Context` share no fields, at some point, we might be able to start migrating to the more adopted `context.Context` and [follow some of the patterns set forth by thrift](https://github.com/apache/thrift/blob/master/lib/go/thrift/header_context.go).  But for now, if desired folks can pass `FContext`'s that also implements the `context.Context` interface to the frugal handlers, and the protocols should use their context for the `Flush` calls, otherwise, a new context is created with the deadline from the `FContext`.

### How To Test:
TODO

### My Test Results:
TODO

#### Reviewers:
@Workiva/product2