### PR TITLE
SPLAT-196: Drop glide dep in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   # - sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
   - sudo add-apt-repository -y ppa:masterminds/glide
   - sudo apt update
-  - sudo apt -y install python3-pip python3-venv python-dev python-virtualenv build-essential glide openjdk-8-jdk
+  - sudo apt -y install python3-pip python3-venv python-dev python-virtualenv build-essential golang-glide openjdk-8-jdk
   # The travis image comes with openjdk11 which has some bugs with checkstyle and javadoc.
   # Force openjdk1.8 until we can upgrade to 11 or 13
   - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   # - sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
   # - sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
   - sudo apt update
-  - sudo apt -y install python3-pip python3-venv python-dev python-virtualenv build-essential golang-glide openjdk-8-jdk
+  - sudo apt -y install python3-pip python3-venv python-dev python-virtualenv build-essential openjdk-8-jdk
   # The travis image comes with openjdk11 which has some bugs with checkstyle and javadoc.
   # Force openjdk1.8 until we can upgrade to 11 or 13
   - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ before_install:
   # No need to install dart yet as we can't run the tests until thrift publishes dart to pub
   # - sudo sh -c 'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -'
   # - sudo sh -c 'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list'
-  - sudo add-apt-repository -y ppa:masterminds/glide
   - sudo apt update
   - sudo apt -y install python3-pip python3-venv python-dev python-virtualenv build-essential golang-glide openjdk-8-jdk
   # The travis image comes with openjdk11 which has some bugs with checkstyle and javadoc.


### PR DESCRIPTION
# [SPLAT-196](https://jira.atl.workiva.net/browse/SPLAT-196)
![Issue Status](http://bender.workiva.org:9000/Bender/status/SPLAT-196)

### Story:
Looks like glide was renamed golang-glide sometime in the past week or so.

*EDIT: our `ubuntu-latest` runners must have been updated*
> On Ubuntu Zesty (17.04) the package is called golang-glide.
> Source: https://salsa.debian.org/go-team/packages/golang-glide

*EDIT(2): Looks like `ppa:masterminds/glide` was experiencing some network issues; swapping to default apt repository.*
```
# source: https://travis-ci.org/github/Workiva/frugal/builds/731287506
$ sudo add-apt-repository -y ppa:masterminds/glide
// ... snipped ...
Reading package lists...
W: Failed to fetch http://ppa.launchpad.net/masterminds/glide/ubuntu/dists/bionic/main/binary-i386/Packages  Could not connect to ppa.launchpad.net:80 (91.189.95.83), connection timed out [IP: 91.189.95.83 80]
W: Failed to fetch http://ppa.launchpad.net/masterminds/glide/ubuntu/dists/bionic/main/binary-amd64/Packages  Unable to connect to ppa.launchpad.net:http: [IP: 91.189.95.83 80]
W: Failed to fetch http://ppa.launchpad.net/masterminds/glide/ubuntu/dists/bionic/main/i18n/Translation-en  Unable to connect to ppa.launchpad.net:http: [IP: 91.189.95.83 80]
W: Some index files failed to download. They have been ignored, or old ones used instead.
```

*EDIT(3): Looks like the make target CI hits doesn't even use glide, removing*

### Acceptance Criteria:
- [ ] At least one Service Paltform member has reviewed and +1'd
- [x] Code has been tested and results documented
- [x] Unit tests have been updated
- [x] Updates to documentation if necessary
- [x] Verify and document changes to any other Messaging components
- ~~Pull request made against the 'develop' branch, not master~~ (release hotfix)

### Design Notes:
Force-Push required to get CI to trigger with the correct destination branches.

### How To Test:
CI

### My Test Results:
🟢 

#### Reviewers:
@Workiva/service-platform 