### PR TITLE
SPLAT-382: aiohttp issues

### DIFF
--- a/lib/python/requirements_dev_asyncio.txt
+++ b/lib/python/requirements_dev_asyncio.txt
@@ -1,4 +1,4 @@
-aiohttp==3.6.2
+aiohttp==3.6.3
 aiostomp==1.6.2
 asyncio-nats-client==0.11.2
 async-timeout>=2.0.1,<4

--- a/lib/python/requirements_dev_asyncio.txt
+++ b/lib/python/requirements_dev_asyncio.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.0.9,<4
+aiohttp==3.6.2
 aiostomp==1.6.2
 asyncio-nats-client==0.11.2
 async-timeout>=2.0.1,<4


### PR DESCRIPTION
# [SPLAT-382](https://jira.atl.workiva.net/browse/SPLAT-382)
![Issue Status](http://bender.workiva.org:9000/Bender/status/SPLAT-382)

### Story:
Looks like a recent version of aiohttp broke the mock usage. Version 3.7.2 break, pinning back to 3.6.2/3.6.3 to see if that resolves for the short-term.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
TODO

### My Test Results:
TODO

#### Reviewers:
@Workiva/product2