### PR TITLE
Consume Go 1.15 and goplusjs fork of gopherjs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: bionic
 language: go
 go:
-  - "1.12.x"
+  - "1.15.x"
 git:
   depth: 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock.workiva.net/workiva/messaging-docker-images:2569314 as build
+FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.7 as build
 
 RUN yum update -y && \
     yum upgrade -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.2 as build
+FROM drydock.workiva.net/workiva/messaging-docker-images:2569314 as build
 
 RUN yum update -y && \
     yum upgrade -y && \

--- a/lib/go/frugal_test.go
+++ b/lib/go/frugal_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func init() {
+	testing.Init()
 	flag.Parse()
 	logger := logrus.New()
 	if testing.Verbose() {

--- a/lib/go/http_transport_test.go
+++ b/lib/go/http_transport_test.go
@@ -655,7 +655,7 @@ func TestHTTPTransportBadURL(t *testing.T) {
 
 	// Flush
 	expectedErr := thrift.NewTTransportException(TRANSPORT_EXCEPTION_UNKNOWN,
-		"Post nobody/home: unsupported protocol scheme \"\"")
+		"Post \"nobody/home\": unsupported protocol scheme \"\"")
 	_, actualErr := transport.Request(ctx, requestBytes)
 	assert.Equal(actualErr.(thrift.TTransportException).TypeId(), expectedErr.TypeId())
 	assert.Equal(actualErr.(thrift.TTransportException).Error(), expectedErr.Error())

--- a/lib/gopherjs/frugal/frugal_js.go
+++ b/lib/gopherjs/frugal/frugal_js.go
@@ -2,7 +2,7 @@
 
 package frugal
 
-import "github.com/gopherjs/gopherjs/js"
+import "github.com/goplusjs/gopherjs/js"
 
 type safeLogger struct{}
 

--- a/lib/gopherjs/frugal/frugal_test.go
+++ b/lib/gopherjs/frugal/frugal_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func init() {
+	testing.Init()
 	flag.Parse()
 	logger := logrus.New()
 	if testing.Verbose() {

--- a/lib/gopherjs/thrift/simple_json_js.go
+++ b/lib/gopherjs/thrift/simple_json_js.go
@@ -2,7 +2,7 @@
 
 package thrift
 
-import "github.com/gopherjs/gopherjs/js"
+import "github.com/goplusjs/gopherjs/js"
 
 func jsonQuote(s string) string {
 	return js.Global.Get("JSON").Call("stringify", js.InternalObject(s)).String()

--- a/test/integration/readme.md
+++ b/test/integration/readme.md
@@ -8,7 +8,7 @@ across all supported languages.
 The cross language tests assume that the test environment has:
 - `python2` executable exists on the `$PATH`
 - `python3` executable exists on the `$PATH`
-- `go` executable exists on the `$PATH` and is v1.12 ??
+- `go` executable exists on the `$PATH` and is v1.15
 - `dart` executable exists on the `$PATH` and is v??
 - `/usr/bin/java` executable exists and is v1.8 or greater
 - `virtualenv` module has been installed for `python2`


### PR DESCRIPTION
### Story:
Currently several repos are locked into Go <=1.12 because they depend on [gopherjs](https://github.com/gopherjs/gopherjs), which is no longer under active development. We have decided to adopt the [goplusjs fork of gopherjs](https://github.com/goplusjs/gopherjs), which supports Go >=1.13.

This PR updates this repo to consume Go1.15 and switches us over to the goplusjs fork of gopherjs.

### Acceptance Criteria:
- [x] At least one InfRe Squad 2 member has reviewed and +1'd
- [x] Code has been tested and results documented
- [x] Unit tests have been updated
- [x] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
All consumers of gopherjs have been updated to build their bindings and run their tests with the goplusjs fork (or, in a few cases, will be very shortly). 

### How To Test:
Verify that this can be consumed by a library consuming goplusjs should be sufficient. A passing build in [DPC](https://github.com/Workiva/doc_plat_client/pull/11770) may be sufficient, but I will defer to repo maintainers if they would like further verification.

### My Test Results:
I pulled [this frugal change into DPC](https://github.com/Workiva/doc_plat_client/pull/11770/) (manually) and verified gopherjs network requests still worked and bindings were still appropriately sized.

#### Reviewers:
@Workiva/product2 