### PR TITLE
java: Add FJakartaServlet

### DIFF
--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -91,6 +91,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>5.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.30</version>

--- a/lib/java/src/main/java/com/workiva/frugal/server/FJakartaServlet.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FJakartaServlet.java
@@ -1,0 +1,271 @@
+package com.workiva.frugal.server;
+
+import com.workiva.frugal.processor.FProcessor;
+import com.workiva.frugal.protocol.FProtocol;
+import com.workiva.frugal.protocol.FProtocolFactory;
+import com.workiva.frugal.transport.TMemoryOutputBuffer;
+import org.apache.thrift.TException;
+import org.apache.thrift.transport.TMemoryInputTransport;
+import org.apache.thrift.transport.TTransport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Processes POST requests as Frugal requests for a processor.
+ * <p>
+ * By default, the HTTP request is limited to a 64MB Frugal payload size to
+ * prevent client requests from causing the server to allocate too much memory.
+ * <p>
+ * The HTTP request may include an X-Frugal-Payload-Limit header setting the size
+ * limit of responses from the server.
+ * <p>
+ * The HTTP processor returns a 500 response for any runtime errors when executing
+ * a frame, a 400 response for an invalid frame, and a 413 response if the response
+ * exceeds the payload limit specified by the client.
+ * <p>
+ * Both the request and response are base64 encoded.
+ */
+@SuppressWarnings("serial")
+public class FJakartaServlet extends HttpServlet {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FJakartaServlet.class);
+
+    private static final int DEFAULT_MAX_REQUEST_SIZE = 64 * 1024 * 1024;
+
+    private final FProcessor processor;
+    private final FProtocolFactory inProtocolFactory;
+    private final FProtocolFactory outProtocolFactory;
+    private final int maxRequestSize;
+    private final ExecutorService exec;
+    private final FServerEventHandler eventHandler;
+
+    /**
+     * Creates a servlet for the specified processor and protocol factory, which
+     * is used for both input and output.
+     */
+    public FJakartaServlet(FProcessor processor, FProtocolFactory protocolFactory) {
+        this(processor, protocolFactory, DEFAULT_MAX_REQUEST_SIZE);
+    }
+
+    /**
+     * Creates a servlet for the specified processor and protocol factory, which
+     * is used for both input and output.
+     *
+     * @param maxRequestSize the maximum Frugal request size in bytes
+     */
+    public FJakartaServlet(FProcessor processor, FProtocolFactory protocolFactory, int maxRequestSize) {
+        this(processor, protocolFactory, protocolFactory, maxRequestSize);
+    }
+
+    /**
+     * Creates a servlet for the specified processor and input/output protocol
+     * factories.
+     */
+    public FJakartaServlet(FProcessor processor, FProtocolFactory inProtocolFactory, FProtocolFactory outProtocolFactory) {
+        this(processor, inProtocolFactory, outProtocolFactory, DEFAULT_MAX_REQUEST_SIZE);
+    }
+
+    /**
+     * Creates a servlet for the specified processor and input/output protocol
+     * factories.
+     *
+     * @param maxRequestSize the maximum Frugal request size in bytes
+     */
+    public FJakartaServlet(
+            FProcessor processor,
+            FProtocolFactory inProtocolFactory,
+            FProtocolFactory outProtocolFactory,
+            int maxRequestSize) {
+        this(builder()
+                .processor(processor)
+                .inProtocolFactory(inProtocolFactory)
+                .outProtocolFactory(outProtocolFactory)
+                .maxRequestSize(maxRequestSize));
+    }
+
+    private FJakartaServlet(Builder b) {
+        this.processor = b.processor;
+        this.inProtocolFactory = b.inProtocolFactory;
+        this.outProtocolFactory = b.outProtocolFactory;
+        this.maxRequestSize = b.maxRequestSize;
+        this.exec = b.exec;
+        this.eventHandler = b.eventHandler != null ? b.eventHandler : new FDefaultServerEventHandler(5000);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        Map<Object, Object> ephemeralProperties = new HashMap<>();
+        eventHandler.onRequestReceived(ephemeralProperties);
+        try {
+            process(req, resp, ephemeralProperties);
+        } finally {
+            eventHandler.onRequestEnded(ephemeralProperties);
+        }
+    }
+
+    private void process(HttpServletRequest req, HttpServletResponse resp, Map<Object, Object> ephemeralProperties) throws ServletException, IOException {
+        byte[] frame;
+        try (InputStream decoderIn = Base64.getDecoder().wrap(req.getInputStream());
+                DataInputStream dataIn = new DataInputStream(decoderIn)) {
+            try {
+                long size = dataIn.readInt() & 0xffff_ffffL;
+                if (size > maxRequestSize) {
+                    LOGGER.debug("Request size too large. Received: {}, Limit: {}", size, maxRequestSize);
+                    resp.setStatus(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+                    return;
+                }
+
+                frame = new byte[(int) size];
+                dataIn.readFully(frame);
+            } catch (EOFException e) {
+                LOGGER.debug("Request body too short");
+                resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                return;
+            }
+
+            if (dataIn.read() != -1) {
+                LOGGER.debug("Request body too long");
+                resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                return;
+            }
+        }
+
+        byte[] data;
+        try {
+            if (exec == null) {
+                data = process(frame, ephemeralProperties);
+            } else {
+                try {
+                    data = exec.submit(() -> process(frame, ephemeralProperties)).get();
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof Error) {
+                        throw (Error) cause;
+                    }
+                    if (cause instanceof RuntimeException) {
+                        throw (RuntimeException) cause;
+                    }
+                    if (cause instanceof TException) {
+                        throw (TException) cause;
+                    }
+                    throw new RuntimeException(e);
+                }
+            }
+        } catch (InterruptedException | TException e) {
+            LOGGER.error("Frugal processor returned unhandled error", e);
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        int responseLimit = getResponseLimit(req);
+        if (responseLimit > 0 && data.length > responseLimit) {
+            LOGGER.debug("Response size too large for client. Received: {}, Limit: {}",
+                    data.length, responseLimit);
+            resp.setStatus(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE);
+            return;
+        }
+
+        resp.setContentType("application/x-frugal");
+        resp.setHeader("Content-Transfer-Encoding", "base64");
+        try (OutputStream out = Base64.getEncoder().wrap(resp.getOutputStream())) {
+            out.write(data);
+        }
+    }
+
+    private byte[] process(byte[] frame, Map<Object, Object> ephemeralProperties) throws TException {
+        eventHandler.onRequestStarted(ephemeralProperties);
+
+        TTransport inTransport = new TMemoryInputTransport(frame);
+        TMemoryOutputBuffer outTransport = new TMemoryOutputBuffer();
+        try {
+            FProtocol inProtocol = inProtocolFactory.getProtocol(inTransport);
+            FProtocol outProtocol = outProtocolFactory.getProtocol(outTransport);
+            processor.process(inProtocol, outProtocol);
+        } catch (RuntimeException e) {
+            // Already logged by FBaseProcessor and written to the output buffer
+            // as an application exception, so write that response back to the
+            // client just like FNatsServer.
+        }
+
+        return outTransport.getWriteBytes();
+    }
+
+    // Visible for testing.
+    static int getResponseLimit(HttpServletRequest req) {
+        String payloadHeader = req.getHeader("x-frugal-payload-limit");
+        int responseLimit;
+        try {
+            responseLimit = Integer.parseInt(payloadHeader);
+        } catch (NumberFormatException ignored) {
+            responseLimit = 0;
+        }
+        return responseLimit;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private FProcessor processor;
+        private FProtocolFactory inProtocolFactory;
+        private FProtocolFactory outProtocolFactory;
+        private int maxRequestSize = DEFAULT_MAX_REQUEST_SIZE;
+        private ExecutorService exec;
+        private FServerEventHandler eventHandler;
+
+        public FJakartaServlet build() {
+            return new FJakartaServlet(this);
+        }
+
+        public Builder processor(FProcessor processor) {
+            this.processor = processor;
+            return this;
+        }
+
+        public Builder protocolFactory(FProtocolFactory protocolFactory) {
+            return inProtocolFactory(protocolFactory)
+                    .outProtocolFactory(protocolFactory);
+        }
+
+        public Builder inProtocolFactory(FProtocolFactory inProtocolFactory) {
+            this.inProtocolFactory = inProtocolFactory;
+            return this;
+        }
+
+        public Builder outProtocolFactory(FProtocolFactory outProtocolFactory) {
+            this.outProtocolFactory = outProtocolFactory;
+            return this;
+        }
+
+        public Builder maxRequestSize(int maxRequestSize) {
+            this.maxRequestSize = maxRequestSize;
+            return this;
+        }
+
+        public Builder executorService(ExecutorService exec) {
+            this.exec = exec;
+            return this;
+        }
+
+        public Builder eventHandler(FServerEventHandler eventHandler) {
+            this.eventHandler = eventHandler;
+            return this;
+        }
+    }
+}

--- a/lib/java/src/test/java/com/workiva/frugal/server/FJakartaServletTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/server/FJakartaServletTest.java
@@ -1,0 +1,363 @@
+package com.workiva.frugal.server;
+
+import com.workiva.frugal.processor.FProcessor;
+import com.workiva.frugal.protocol.FProtocolFactory;
+import org.apache.thrift.TException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+
+/**
+ * Tests for {@link FJakartaServlet}.
+ */
+public class FJakartaServletTest {
+
+    private static class ProxyServletInputStream extends ServletInputStream {
+        private final InputStream in;
+
+        ProxyServletInputStream(InputStream in) {
+            this.in = in;
+        }
+
+        @Override
+        public int read() throws IOException {
+            return in.read();
+        }
+
+        @Override
+        public boolean isFinished() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isReady() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class ProxyServletOutputStream extends ServletOutputStream {
+        private final OutputStream out;
+
+        ProxyServletOutputStream(OutputStream out) {
+            this.out = out;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            out.write(b);
+        }
+
+        @Override
+        public boolean isReady() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setWriteListener(WriteListener writeListener) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private final FProcessor mockProcessor = mock(FProcessor.class);
+    private final FProtocolFactory mockProtocolFactory = mock(FProtocolFactory.class);
+    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final FServerEventHandler mockEventHandler = mock(FServerEventHandler.class);
+    private FJakartaServlet servlet = new FJakartaServlet(mockProcessor, mockProtocolFactory);
+
+    private final HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+    private final HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+
+    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    private final ServletOutputStream servletOut = new ProxyServletOutputStream(out);
+
+    @Before
+    public void before() throws Exception {
+        doReturn("POST").when(mockRequest).getMethod();
+        doReturn("HTTP/1.1").when(mockRequest).getProtocol();
+
+        doReturn(servletOut).when(mockResponse).getOutputStream();
+    }
+
+    @After
+    public void after() throws Exception {
+        verifyNoMoreInteractions(mockResponse);
+        executorService.shutdown();
+        assertThat(executorService.awaitTermination(5, TimeUnit.SECONDS), equalTo(true));
+    }
+
+    private void setupExecutor() {
+        servlet = FJakartaServlet.builder()
+                .processor(mockProcessor)
+                .protocolFactory(mockProtocolFactory)
+                .executorService(executorService)
+                .build();
+    }
+
+    private void setupEventHandler() {
+        servlet = FJakartaServlet.builder()
+                .processor(mockProcessor)
+                .protocolFactory(mockProtocolFactory)
+                .eventHandler(mockEventHandler)
+                .build();
+    }
+
+    @Test
+    public final void testValidResponseLimit() {
+        doReturn("2096").when(mockRequest).getHeader("x-frugal-payload-limit");
+
+        Integer limit = FJakartaServlet.getResponseLimit(mockRequest);
+        assertThat(limit, equalTo(2096));
+    }
+
+    @Test
+    public final void testNullResponseLimit() {
+        doReturn(null).when(mockRequest).getHeader("x-frugal-payload-limit");
+
+        Integer limit = FJakartaServlet.getResponseLimit(mockRequest);
+        assertThat(limit, equalTo(0));
+    }
+
+    @Test
+    public final void testStringResponseLimit() {
+        doReturn("not-a-number").when(mockRequest).getHeader("x-frugal-payload-limit");
+
+        Integer limit = FJakartaServlet.getResponseLimit(mockRequest);
+        assertThat(limit, equalTo(0));
+    }
+
+    @Test
+    public void testGet() throws Exception {
+        doReturn("GET").when(mockRequest).getMethod();
+        doReturn("HTTP/1.1").when(mockRequest).getProtocol();
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).sendError(eq(HttpServletResponse.SC_METHOD_NOT_ALLOWED), any());
+    }
+
+    @Test
+    public void testInputEmpty() throws Exception {
+        ByteArrayInputStream in = new ByteArrayInputStream(new byte[0]);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_BAD_REQUEST));
+    }
+
+    @Test
+    public void testInputTooShort() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(new byte[] { 0, 0, 0, 1 });
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_BAD_REQUEST));
+    }
+
+    @Test
+    public void testInputTooLong() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(new byte[5]);
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_BAD_REQUEST));
+    }
+
+    @Test
+    public void testDefaultRequestSize() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(new byte[] { (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff });
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE));
+    }
+
+    @Test
+    public void testRequestSize() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(new byte[] { 0, 0, 0, 2 });
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        servlet = new FJakartaServlet(mockProcessor, mockProtocolFactory, 1);
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE));
+    }
+
+    private static byte[] withLength(byte[] b) {
+        return ByteBuffer.allocate(4 + b.length)
+                .putInt(b.length)
+                .put(b)
+                .array();
+    }
+
+    @Test
+    public void testProcessorRuntimeException() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(withLength(new byte[0]));
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        doThrow(new RuntimeException("test")).when(mockProcessor).process(any(), any());
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setContentType("application/x-frugal");
+        verify(mockResponse).setHeader("Content-Transfer-Encoding", "base64");
+        verify(mockResponse).getOutputStream();
+    }
+
+    @Test
+    public void testProcessorRuntimeExceptionWithExecutor() throws Exception {
+        setupExecutor();
+        testProcessorRuntimeException();
+    }
+
+    @Test
+    public void testProcessorUnhandledException() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(withLength(new byte[0]));
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        doThrow(new TException("test")).when(mockProcessor).process(any(), any());
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+    }
+
+    @Test
+    public void testProcessorUnhandledExceptionWithExecutor() throws Exception {
+        setupExecutor();
+        testProcessorUnhandledException();
+    }
+
+    @Test
+    public void testResponseTooLong() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(withLength(new byte[2]));
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        doReturn("1").when(mockRequest).getHeader("x-frugal-payload-limit");
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setStatus(eq(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE));
+    }
+
+    @Test
+    public void testOk() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(withLength(new byte[0]));
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        Thread testThread = Thread.currentThread();
+        doAnswer(inv -> {
+            assertThat(Thread.currentThread(), sameInstance(testThread));
+            return null;
+        }).when(mockProcessor).process(any(), any());
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setContentType("application/x-frugal");
+        verify(mockResponse).setHeader("Content-Transfer-Encoding", "base64");
+        verify(mockResponse).getOutputStream();
+    }
+
+    @Test
+    public void testOkWithExecutor() throws Exception {
+        setupExecutor();
+
+        byte[] bytes = Base64.getEncoder().encode(withLength(new byte[0]));
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        Thread testThread = Thread.currentThread();
+        doAnswer(inv -> {
+            assertThat(Thread.currentThread(), not(sameInstance(testThread)));
+            return null;
+        }).when(mockProcessor).process(any(), any());
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setContentType("application/x-frugal");
+        verify(mockResponse).setHeader("Content-Transfer-Encoding", "base64");
+        verify(mockResponse).getOutputStream();
+    }
+
+    @Test
+    public void testOkWithEventHandler() throws Exception {
+        setupEventHandler();
+        testOk();
+
+        InOrder inOrder = inOrder(mockEventHandler, mockProcessor);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<Object, Object>> propsCaptor = ArgumentCaptor.forClass(Map.class);
+        inOrder.verify(mockEventHandler).onRequestReceived(propsCaptor.capture());
+        Map<Object, Object> props = propsCaptor.getValue();
+        inOrder.verify(mockEventHandler).onRequestStarted(argThat(sameInstance(props)));
+        inOrder.verify(mockProcessor).process(any(), any());
+        inOrder.verify(mockEventHandler).onRequestEnded(argThat(sameInstance(props)));
+    }
+
+    @Test
+    public void testOkPayloadLimit() throws Exception {
+        byte[] bytes = Base64.getEncoder().encode(withLength(new byte[0]));
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        doReturn(new ProxyServletInputStream(in)).when(mockRequest).getInputStream();
+
+        doReturn("4").when(mockRequest).getHeader("x-frugal-payload-limit");
+
+        servlet.service(mockRequest, mockResponse);
+
+        verify(mockResponse).setContentType("application/x-frugal");
+        verify(mockResponse).setHeader("Content-Transfer-Encoding", "base64");
+        verify(mockResponse).getOutputStream();
+    }
+}


### PR DESCRIPTION
### Story:
See commit message.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
There is little room for code sharing between the two servlet implementations (the accesses to `javax.servlet`/`jakarta.servlet` types is spread throughout the class).  Ultimately, these classes don't change much, so I concluded it was easier to simply copy.

### How To Test:
Temporarily update `TestServletServer` to use Jetty 11 and `FJakartaServlet`.  There can only be one dependency on Jetty in the integration test, and 9->11 is a breaking change for javax->jakarta, so it's non-trivial to automate.

### My Test Results:
Manually tested with an existing service using Jetty 9 with `FServlet` and confirmed it works the same after upgrading to Jetty 11 and the `FJakartaServlet`

#### Reviewers:
@Workiva/product2