### PR TITLE
CT-29  Share packing and unpacking code in dart generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ unit: clean unit-cli unit-go unit-java unit-py2 unit-py3
 unit-cli:
 	go test ./test -race
 
+# update the expected generated files; for those times when you change the generation
+unit-cli-copy:
+	go test ./test -copy-files
+
 unit-go:
 	cd lib/go && GO111MODULE=on go mod vendor && go test -v -race 
 

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1833,14 +1833,17 @@ func (g *Generator) generateClient(service *parser.Service) string {
 	contents += tabtab + "}\n"
 	contents += tabtab + "return null;\n"
 	contents += tab + "}\n"
-	contents += "\n"
-
+	
 	for _, method := range service.Methods {
+		contents += "\n"
 		contents += g.generateClientMethod(service, method)
 	}
 
-	contents += g.generatePrepareMessage();
-	contents += g.generateProcessReply();
+	if len(service.Methods) > 0 {
+		contents += "\n"
+		contents += g.generatePrepareMessage();
+		contents += g.generateProcessReply();
+	}
 
 	contents += "}\n\n"
 
@@ -1950,7 +1953,7 @@ func (g *Generator) generateClientMethod(service *parser.Service, method *parser
 
 	if method.Oneway {
 		contents += indent + "await _transport.oneway(ctx, message);\n"
-		contents += tab + "}\n\n"
+		contents += tab + "}\n"
 		return contents
 	}
 
@@ -1973,7 +1976,7 @@ func (g *Generator) generateClientMethod(service *parser.Service, method *parser
 			nameLower)
 		contents += tabtab + ");\n"
 	}
-	contents += tab + "}\n"
+	contents += tab + "}"
 
 	return contents
 }

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1853,7 +1853,8 @@ func (g *Generator) generateClient(service *parser.Service) string {
 func (g *Generator) generatePrepareMessage() string {
 	indent := tab
 
-	contents := indent + "\nUint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {\n"
+	contents := "\n"
+	contents += indent + "Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {\n"
 
 	indent = tabtab
 	contents += indent + "final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);\n"
@@ -1874,7 +1875,8 @@ func (g *Generator) generatePrepareMessage() string {
 func (g *Generator) generateProcessReply() string {
 	indent := tab
 
-	contents := indent + "\nvoid _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {\n"
+	contents := "\n"
+	contents += indent + "void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {\n"
 
 	indent = tabtab
 	contents += indent + "final iprot = _protocolFactory.getProtocol(response);\n"

--- a/lib/dart/lib/frugal.dart
+++ b/lib/dart/lib/frugal.dart
@@ -42,3 +42,4 @@ export 'src/frugal.dart'
         TMemoryOutputBuffer,
         TMemoryTransport,
         debugMiddleware;
+export 'src/frugal/f_packers.dart' show prepareMessage, processReply;

--- a/lib/dart/lib/src/frugal/f_packers.dart
+++ b/lib/dart/lib/src/frugal/f_packers.dart
@@ -1,0 +1,34 @@
+import 'dart:typed_data';
+
+import 'package:frugal/src/frugal.dart';
+import 'package:thrift/thrift.dart';
+
+/// Pack the arguments for transmission
+Uint8List prepareMessage(FContext ctx, String method, TBase args, int kind, FProtocolFactory pfactory, int limit) {
+  final memoryBuffer = TMemoryOutputBuffer(limit);
+  final oprot = pfactory.getProtocol(memoryBuffer);
+  oprot.writeRequestHeader(ctx);
+  oprot.writeMessageBegin(TMessage(method, kind, 0));
+  args.write(oprot);
+  oprot.writeMessageEnd();
+  return memoryBuffer.writeBytes;
+}
+
+/// Unpack the response into the [result]
+void processReply(FContext ctx, TBase result, TTransport response, FProtocolFactory pfactory) {
+  final iprot = pfactory.getProtocol(response);
+  iprot.readResponseHeader(ctx);
+  final msg = iprot.readMessageBegin();
+  if (msg.type == TMessageType.EXCEPTION) {
+    final error = TApplicationError.read(iprot);
+    iprot.readMessageEnd();
+    if (error.type == FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
+      throw TTransportError(
+          FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
+    }
+    throw error;
+  }
+
+  result.read(iprot);
+  iprot.readMessageEnd();
+}

--- a/lib/dart/lib/src/frugal/f_packers.dart
+++ b/lib/dart/lib/src/frugal/f_packers.dart
@@ -4,7 +4,14 @@ import 'package:frugal/src/frugal.dart';
 import 'package:thrift/thrift.dart';
 
 /// Pack the arguments for transmission
-Uint8List prepareMessage(FContext ctx, String method, TBase args, int kind, FProtocolFactory pfactory, int limit) {
+Uint8List prepareMessage(
+  FContext ctx,
+  String method,
+  TBase args,
+  int kind,
+  FProtocolFactory pfactory,
+  int limit,
+) {
   final memoryBuffer = TMemoryOutputBuffer(limit);
   final oprot = pfactory.getProtocol(memoryBuffer);
   oprot.writeRequestHeader(ctx);
@@ -15,7 +22,12 @@ Uint8List prepareMessage(FContext ctx, String method, TBase args, int kind, FPro
 }
 
 /// Unpack the response into the [result]
-void processReply(FContext ctx, TBase result, TTransport response, FProtocolFactory pfactory) {
+void processReply(
+  FContext ctx,
+  TBase result,
+  TTransport response,
+  FProtocolFactory pfactory,
+) {
   final iprot = pfactory.getProtocol(response);
   iprot.readResponseHeader(ctx);
   final msg = iprot.readMessageBegin();

--- a/lib/go/go.mod
+++ b/lib/go/go.mod
@@ -1,7 +1,5 @@
 module github.com/Workiva/frugal/lib/go
 
-go 1.15
-
 require (
 	github.com/apache/thrift v0.13.0
 	github.com/go-stomp/stomp v2.1.0+incompatible

--- a/lib/go/go.mod
+++ b/lib/go/go.mod
@@ -1,5 +1,7 @@
 module github.com/Workiva/frugal/lib/go
 
+go 1.15
+
 require (
 	github.com/apache/thrift v0.13.0
 	github.com/go-stomp/stomp v2.1.0+incompatible

--- a/test/expected/dart.nullunset/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart.nullunset/actual_base/f_base_foo_service.dart
@@ -57,39 +57,11 @@ class FBaseFooClient extends disposable.Disposable implements FBaseFoo {
 
   Future _basePing(frugal.FContext ctx) async {
     final args = basePing_args();
-    final message = _prepareMessage(ctx, 'basePing', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'basePing', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = basePing_result();
-    _processReply(ctx, result, response);
-  }
-
-  Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
-    final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    final oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage(method, kind, 0));
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    return memoryBuffer.writeBytes;
-  }
-
-  void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
-    final iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    final msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      final error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    result.read(iprot);
-    iprot.readMessageEnd();
+    frugal.processReply(ctx, result, response, _protocolFactory);
   }
 }
 

--- a/test/expected/dart.nullunset/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart.nullunset/actual_base/f_base_foo_service.dart
@@ -63,8 +63,8 @@ class FBaseFooClient extends disposable.Disposable implements FBaseFoo {
     final result = basePing_result();
     _processReply(ctx, result, response);
   }
-  
-Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
+
+  Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
     final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
     final oprot = _protocolFactory.getProtocol(memoryBuffer);
     oprot.writeRequestHeader(ctx);
@@ -73,8 +73,8 @@ Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args,
     oprot.writeMessageEnd();
     return memoryBuffer.writeBytes;
   }
-  
-void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
+
+  void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
     final iprot = _protocolFactory.getProtocol(response);
     iprot.readResponseHeader(ctx);
     final msg = iprot.readMessageBegin();

--- a/test/expected/dart.nullunset/variety/f_foo_service.dart
+++ b/test/expected/dart.nullunset/variety/f_foo_service.dart
@@ -110,31 +110,12 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future _ping(frugal.FContext ctx) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('ping', thrift.TMessageType.CALL, 0));
-    Ping_args args = Ping_args();
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final args = Ping_args();
+    final message = _prepareMessage(ctx, 'ping', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    Ping_result result = Ping_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = Ping_result();
+    _processReply(ctx, result, response);
   }
   /// Blah the server.
   @override
@@ -143,34 +124,15 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<int> _blah(frugal.FContext ctx, int num, String str, t_variety.Event event) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('blah', thrift.TMessageType.CALL, 0));
-    blah_args args = blah_args();
+    final args = blah_args();
     args.num = num;
     args.str = str;
     args.event = event;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'blah', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    blah_result result = blah_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = blah_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -192,16 +154,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future _oneWay(frugal.FContext ctx, int id, Map<int, String> req) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('oneWay', thrift.TMessageType.ONEWAY, 0));
-    oneWay_args args = oneWay_args();
+    final args = oneWay_args();
     args.id = id;
     args.req = req;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    await _transport.oneway(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'oneWay', args, thrift.TMessageType.ONEWAY);
+    await _transport.oneway(ctx, message);
   }
 
   @override
@@ -210,33 +167,14 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<Uint8List> _bin_method(frugal.FContext ctx, Uint8List bin, String str) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('bin_method', thrift.TMessageType.CALL, 0));
-    bin_method_args args = bin_method_args();
+    final args = bin_method_args();
     args.bin = bin;
     args.str = str;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'bin_method', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    bin_method_result result = bin_method_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = bin_method_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -254,34 +192,15 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<int> _param_modifiers(frugal.FContext ctx, int opt_num, int default_num, int req_num) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('param_modifiers', thrift.TMessageType.CALL, 0));
-    param_modifiers_args args = param_modifiers_args();
+    final args = param_modifiers_args();
     args.opt_num = opt_num;
     args.default_num = default_num;
     args.req_num = req_num;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'param_modifiers', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    param_modifiers_result result = param_modifiers_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = param_modifiers_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -296,33 +215,14 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<List<int>> _underlying_types_test(frugal.FContext ctx, List<int> list_type, Set<int> set_type) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('underlying_types_test', thrift.TMessageType.CALL, 0));
-    underlying_types_test_args args = underlying_types_test_args();
+    final args = underlying_types_test_args();
     args.list_type = list_type;
     args.set_type = set_type;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'underlying_types_test', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    underlying_types_test_result result = underlying_types_test_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = underlying_types_test_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -337,31 +237,12 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<t_validStructs.Thing> _getThing(frugal.FContext ctx) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('getThing', thrift.TMessageType.CALL, 0));
-    getThing_args args = getThing_args();
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final args = getThing_args();
+    final message = _prepareMessage(ctx, 'getThing', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    getThing_result result = getThing_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = getThing_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -376,31 +257,12 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<int> _getMyInt(frugal.FContext ctx) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('getMyInt', thrift.TMessageType.CALL, 0));
-    getMyInt_args args = getMyInt_args();
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final args = getMyInt_args();
+    final message = _prepareMessage(ctx, 'getMyInt', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    getMyInt_result result = getMyInt_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = getMyInt_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -415,32 +277,13 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<t_subdir_include_ns.A> _use_subdir_struct(frugal.FContext ctx, t_subdir_include_ns.A a) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('use_subdir_struct', thrift.TMessageType.CALL, 0));
-    use_subdir_struct_args args = use_subdir_struct_args();
+    final args = use_subdir_struct_args();
     args.a = a;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'use_subdir_struct', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    use_subdir_struct_result result = use_subdir_struct_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = use_subdir_struct_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -455,32 +298,13 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<String> _sayHelloWith(frugal.FContext ctx, String newMessage) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('sayHelloWith', thrift.TMessageType.CALL, 0));
-    sayHelloWith_args args = sayHelloWith_args();
+    final args = sayHelloWith_args();
     args.newMessage = newMessage;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'sayHelloWith', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    sayHelloWith_result result = sayHelloWith_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = sayHelloWith_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -495,32 +319,13 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<String> _whatDoYouSay(frugal.FContext ctx, String messageArgs) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('whatDoYouSay', thrift.TMessageType.CALL, 0));
-    whatDoYouSay_args args = whatDoYouSay_args();
+    final args = whatDoYouSay_args();
     args.messageArgs = messageArgs;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'whatDoYouSay', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    whatDoYouSay_result result = whatDoYouSay_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = whatDoYouSay_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -535,21 +340,38 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<String> _sayAgain(frugal.FContext ctx, String messageResult) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('sayAgain', thrift.TMessageType.CALL, 0));
-    sayAgain_args args = sayAgain_args();
+    final args = sayAgain_args();
     args.messageResult = messageResult;
+    final message = _prepareMessage(ctx, 'sayAgain', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
+
+    final result = sayAgain_result();
+    _processReply(ctx, result, response);
+    if (result.isSetSuccess()) {
+      return result.success;
+    }
+
+    throw thrift.TApplicationError(
+      frugal.FrugalTApplicationErrorType.MISSING_RESULT, 'sayAgain failed: unknown result'
+    );
+  }
+  
+Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
+    final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
+    final oprot = _protocolFactory.getProtocol(memoryBuffer);
+    oprot.writeRequestHeader(ctx);
+    oprot.writeMessageBegin(thrift.TMessage(method, kind, 0));
     args.write(oprot);
     oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
-
-    var iprot = _protocolFactory.getProtocol(response);
+    return memoryBuffer.writeBytes;
+  }
+  
+void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
+    final iprot = _protocolFactory.getProtocol(response);
     iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
+    final msg = iprot.readMessageBegin();
     if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
+      final error = thrift.TApplicationError.read(iprot);
       iprot.readMessageEnd();
       if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
         throw thrift.TTransportError(
@@ -558,16 +380,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
       throw error;
     }
 
-    sayAgain_result result = sayAgain_result();
     result.read(iprot);
     iprot.readMessageEnd();
-    if (result.isSetSuccess()) {
-      return result.success;
-    }
-
-    throw thrift.TApplicationError(
-      frugal.FrugalTApplicationErrorType.MISSING_RESULT, 'sayAgain failed: unknown result'
-    );
   }
 }
 

--- a/test/expected/dart.nullunset/variety/f_foo_service.dart
+++ b/test/expected/dart.nullunset/variety/f_foo_service.dart
@@ -355,8 +355,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
       frugal.FrugalTApplicationErrorType.MISSING_RESULT, 'sayAgain failed: unknown result'
     );
   }
-  
-Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
+
+  Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
     final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
     final oprot = _protocolFactory.getProtocol(memoryBuffer);
     oprot.writeRequestHeader(ctx);
@@ -365,8 +365,8 @@ Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args,
     oprot.writeMessageEnd();
     return memoryBuffer.writeBytes;
   }
-  
-void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
+
+  void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
     final iprot = _protocolFactory.getProtocol(response);
     iprot.readResponseHeader(ctx);
     final msg = iprot.readMessageBegin();

--- a/test/expected/dart.nullunset/variety/f_foo_service.dart
+++ b/test/expected/dart.nullunset/variety/f_foo_service.dart
@@ -111,11 +111,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
 
   Future _ping(frugal.FContext ctx) async {
     final args = Ping_args();
-    final message = _prepareMessage(ctx, 'ping', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'ping', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = Ping_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
   }
   /// Blah the server.
   @override
@@ -128,11 +128,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
     args.num = num;
     args.str = str;
     args.event = event;
-    final message = _prepareMessage(ctx, 'blah', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'blah', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = blah_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -157,7 +157,7 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
     final args = oneWay_args();
     args.id = id;
     args.req = req;
-    final message = _prepareMessage(ctx, 'oneWay', args, thrift.TMessageType.ONEWAY);
+    final message = frugal.prepareMessage(ctx, 'oneWay', args, thrift.TMessageType.ONEWAY, _protocolFactory, _transport.requestSizeLimit);
     await _transport.oneway(ctx, message);
   }
 
@@ -170,11 +170,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
     final args = bin_method_args();
     args.bin = bin;
     args.str = str;
-    final message = _prepareMessage(ctx, 'bin_method', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'bin_method', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = bin_method_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -196,11 +196,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
     args.opt_num = opt_num;
     args.default_num = default_num;
     args.req_num = req_num;
-    final message = _prepareMessage(ctx, 'param_modifiers', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'param_modifiers', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = param_modifiers_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -218,11 +218,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
     final args = underlying_types_test_args();
     args.list_type = list_type;
     args.set_type = set_type;
-    final message = _prepareMessage(ctx, 'underlying_types_test', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'underlying_types_test', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = underlying_types_test_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -238,11 +238,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
 
   Future<t_validStructs.Thing> _getThing(frugal.FContext ctx) async {
     final args = getThing_args();
-    final message = _prepareMessage(ctx, 'getThing', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'getThing', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = getThing_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -258,11 +258,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
 
   Future<int> _getMyInt(frugal.FContext ctx) async {
     final args = getMyInt_args();
-    final message = _prepareMessage(ctx, 'getMyInt', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'getMyInt', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = getMyInt_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -279,11 +279,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   Future<t_subdir_include_ns.A> _use_subdir_struct(frugal.FContext ctx, t_subdir_include_ns.A a) async {
     final args = use_subdir_struct_args();
     args.a = a;
-    final message = _prepareMessage(ctx, 'use_subdir_struct', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'use_subdir_struct', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = use_subdir_struct_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -300,11 +300,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   Future<String> _sayHelloWith(frugal.FContext ctx, String newMessage) async {
     final args = sayHelloWith_args();
     args.newMessage = newMessage;
-    final message = _prepareMessage(ctx, 'sayHelloWith', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'sayHelloWith', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = sayHelloWith_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -321,11 +321,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   Future<String> _whatDoYouSay(frugal.FContext ctx, String messageArgs) async {
     final args = whatDoYouSay_args();
     args.messageArgs = messageArgs;
-    final message = _prepareMessage(ctx, 'whatDoYouSay', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'whatDoYouSay', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = whatDoYouSay_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -342,11 +342,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   Future<String> _sayAgain(frugal.FContext ctx, String messageResult) async {
     final args = sayAgain_args();
     args.messageResult = messageResult;
-    final message = _prepareMessage(ctx, 'sayAgain', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'sayAgain', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = sayAgain_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -354,34 +354,6 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
     throw thrift.TApplicationError(
       frugal.FrugalTApplicationErrorType.MISSING_RESULT, 'sayAgain failed: unknown result'
     );
-  }
-
-  Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
-    final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    final oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage(method, kind, 0));
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    return memoryBuffer.writeBytes;
-  }
-
-  void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
-    final iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    final msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      final error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    result.read(iprot);
-    iprot.readMessageEnd();
   }
 }
 

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -57,39 +57,11 @@ class FBaseFooClient extends disposable.Disposable implements FBaseFoo {
 
   Future _basePing(frugal.FContext ctx) async {
     final args = basePing_args();
-    final message = _prepareMessage(ctx, 'basePing', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'basePing', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = basePing_result();
-    _processReply(ctx, result, response);
-  }
-
-  Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
-    final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    final oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage(method, kind, 0));
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    return memoryBuffer.writeBytes;
-  }
-
-  void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
-    final iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    final msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      final error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    result.read(iprot);
-    iprot.readMessageEnd();
+    frugal.processReply(ctx, result, response, _protocolFactory);
   }
 }
 

--- a/test/expected/dart/actual_base/f_base_foo_service.dart
+++ b/test/expected/dart/actual_base/f_base_foo_service.dart
@@ -63,8 +63,8 @@ class FBaseFooClient extends disposable.Disposable implements FBaseFoo {
     final result = basePing_result();
     _processReply(ctx, result, response);
   }
-  
-Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
+
+  Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
     final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
     final oprot = _protocolFactory.getProtocol(memoryBuffer);
     oprot.writeRequestHeader(ctx);
@@ -73,8 +73,8 @@ Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args,
     oprot.writeMessageEnd();
     return memoryBuffer.writeBytes;
   }
-  
-void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
+
+  void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
     final iprot = _protocolFactory.getProtocol(response);
     iprot.readResponseHeader(ctx);
     final msg = iprot.readMessageBegin();

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -63,11 +63,11 @@ class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient with dispo
 
   Future<t_vendor_namespace.Item> _getItem(frugal.FContext ctx) async {
     final args = getItem_args();
-    final message = _prepareMessage(ctx, 'getItem', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'getItem', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = getItem_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -78,34 +78,6 @@ class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient with dispo
     throw thrift.TApplicationError(
       frugal.FrugalTApplicationErrorType.MISSING_RESULT, 'getItem failed: unknown result'
     );
-  }
-
-  Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
-    final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    final oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage(method, kind, 0));
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    return memoryBuffer.writeBytes;
-  }
-
-  void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
-    final iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    final msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      final error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    result.read(iprot);
-    iprot.readMessageEnd();
   }
 }
 

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -79,8 +79,8 @@ class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient with dispo
       frugal.FrugalTApplicationErrorType.MISSING_RESULT, 'getItem failed: unknown result'
     );
   }
-  
-Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
+
+  Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
     final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
     final oprot = _protocolFactory.getProtocol(memoryBuffer);
     oprot.writeRequestHeader(ctx);
@@ -89,8 +89,8 @@ Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args,
     oprot.writeMessageEnd();
     return memoryBuffer.writeBytes;
   }
-  
-void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
+
+  void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
     final iprot = _protocolFactory.getProtocol(response);
     iprot.readResponseHeader(ctx);
     final msg = iprot.readMessageBegin();

--- a/test/expected/dart/include_vendor/f_my_service_service.dart
+++ b/test/expected/dart/include_vendor/f_my_service_service.dart
@@ -62,31 +62,12 @@ class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient with dispo
   }
 
   Future<t_vendor_namespace.Item> _getItem(frugal.FContext ctx) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('getItem', thrift.TMessageType.CALL, 0));
-    getItem_args args = getItem_args();
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final args = getItem_args();
+    final message = _prepareMessage(ctx, 'getItem', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    getItem_result result = getItem_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = getItem_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -97,6 +78,34 @@ class FMyServiceClient extends t_vendor_namespace.FVendoredBaseClient with dispo
     throw thrift.TApplicationError(
       frugal.FrugalTApplicationErrorType.MISSING_RESULT, 'getItem failed: unknown result'
     );
+  }
+  
+Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
+    final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
+    final oprot = _protocolFactory.getProtocol(memoryBuffer);
+    oprot.writeRequestHeader(ctx);
+    oprot.writeMessageBegin(thrift.TMessage(method, kind, 0));
+    args.write(oprot);
+    oprot.writeMessageEnd();
+    return memoryBuffer.writeBytes;
+  }
+  
+void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
+    final iprot = _protocolFactory.getProtocol(response);
+    iprot.readResponseHeader(ctx);
+    final msg = iprot.readMessageBegin();
+    if (msg.type == thrift.TMessageType.EXCEPTION) {
+      final error = thrift.TApplicationError.read(iprot);
+      iprot.readMessageEnd();
+      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
+        throw thrift.TTransportError(
+            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
+      }
+      throw error;
+    }
+
+    result.read(iprot);
+    iprot.readMessageEnd();
   }
 }
 

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -110,31 +110,12 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future _ping(frugal.FContext ctx) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('ping', thrift.TMessageType.CALL, 0));
-    Ping_args args = Ping_args();
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final args = Ping_args();
+    final message = _prepareMessage(ctx, 'ping', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    Ping_result result = Ping_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = Ping_result();
+    _processReply(ctx, result, response);
   }
   /// Blah the server.
   @override
@@ -143,34 +124,15 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<int> _blah(frugal.FContext ctx, int num, String str, t_variety.Event event) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('blah', thrift.TMessageType.CALL, 0));
-    blah_args args = blah_args();
+    final args = blah_args();
     args.num = num;
     args.str = str;
     args.event = event;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'blah', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    blah_result result = blah_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = blah_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -192,16 +154,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future _oneWay(frugal.FContext ctx, int id, Map<int, String> req) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('oneWay', thrift.TMessageType.ONEWAY, 0));
-    oneWay_args args = oneWay_args();
+    final args = oneWay_args();
     args.id = id;
     args.req = req;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    await _transport.oneway(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'oneWay', args, thrift.TMessageType.ONEWAY);
+    await _transport.oneway(ctx, message);
   }
 
   @override
@@ -210,33 +167,14 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<Uint8List> _bin_method(frugal.FContext ctx, Uint8List bin, String str) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('bin_method', thrift.TMessageType.CALL, 0));
-    bin_method_args args = bin_method_args();
+    final args = bin_method_args();
     args.bin = bin;
     args.str = str;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'bin_method', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    bin_method_result result = bin_method_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = bin_method_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -254,34 +192,15 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<int> _param_modifiers(frugal.FContext ctx, int opt_num, int default_num, int req_num) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('param_modifiers', thrift.TMessageType.CALL, 0));
-    param_modifiers_args args = param_modifiers_args();
+    final args = param_modifiers_args();
     args.opt_num = opt_num;
     args.default_num = default_num;
     args.req_num = req_num;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'param_modifiers', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    param_modifiers_result result = param_modifiers_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = param_modifiers_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -296,33 +215,14 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<List<int>> _underlying_types_test(frugal.FContext ctx, List<int> list_type, Set<int> set_type) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('underlying_types_test', thrift.TMessageType.CALL, 0));
-    underlying_types_test_args args = underlying_types_test_args();
+    final args = underlying_types_test_args();
     args.list_type = list_type;
     args.set_type = set_type;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'underlying_types_test', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    underlying_types_test_result result = underlying_types_test_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = underlying_types_test_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -337,31 +237,12 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<t_validStructs.Thing> _getThing(frugal.FContext ctx) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('getThing', thrift.TMessageType.CALL, 0));
-    getThing_args args = getThing_args();
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final args = getThing_args();
+    final message = _prepareMessage(ctx, 'getThing', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    getThing_result result = getThing_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = getThing_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -376,31 +257,12 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<int> _getMyInt(frugal.FContext ctx) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('getMyInt', thrift.TMessageType.CALL, 0));
-    getMyInt_args args = getMyInt_args();
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final args = getMyInt_args();
+    final message = _prepareMessage(ctx, 'getMyInt', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    getMyInt_result result = getMyInt_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = getMyInt_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -415,32 +277,13 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<t_subdir_include_ns.A> _use_subdir_struct(frugal.FContext ctx, t_subdir_include_ns.A a) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('use_subdir_struct', thrift.TMessageType.CALL, 0));
-    use_subdir_struct_args args = use_subdir_struct_args();
+    final args = use_subdir_struct_args();
     args.a = a;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'use_subdir_struct', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    use_subdir_struct_result result = use_subdir_struct_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = use_subdir_struct_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -455,32 +298,13 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<String> _sayHelloWith(frugal.FContext ctx, String newMessage) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('sayHelloWith', thrift.TMessageType.CALL, 0));
-    sayHelloWith_args args = sayHelloWith_args();
+    final args = sayHelloWith_args();
     args.newMessage = newMessage;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'sayHelloWith', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    sayHelloWith_result result = sayHelloWith_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = sayHelloWith_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -495,32 +319,13 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<String> _whatDoYouSay(frugal.FContext ctx, String messageArgs) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('whatDoYouSay', thrift.TMessageType.CALL, 0));
-    whatDoYouSay_args args = whatDoYouSay_args();
+    final args = whatDoYouSay_args();
     args.messageArgs = messageArgs;
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
+    final message = _prepareMessage(ctx, 'whatDoYouSay', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
 
-    var iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    whatDoYouSay_result result = whatDoYouSay_result();
-    result.read(iprot);
-    iprot.readMessageEnd();
+    final result = whatDoYouSay_result();
+    _processReply(ctx, result, response);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -535,21 +340,38 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   }
 
   Future<String> _sayAgain(frugal.FContext ctx, String messageResult) async {
-    var memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    var oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage('sayAgain', thrift.TMessageType.CALL, 0));
-    sayAgain_args args = sayAgain_args();
+    final args = sayAgain_args();
     args.messageResult = messageResult;
+    final message = _prepareMessage(ctx, 'sayAgain', args, thrift.TMessageType.CALL);
+    var response = await _transport.request(ctx, message);
+
+    final result = sayAgain_result();
+    _processReply(ctx, result, response);
+    if (result.isSetSuccess()) {
+      return result.success;
+    }
+
+    throw thrift.TApplicationError(
+      frugal.FrugalTApplicationErrorType.MISSING_RESULT, 'sayAgain failed: unknown result'
+    );
+  }
+  
+Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
+    final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
+    final oprot = _protocolFactory.getProtocol(memoryBuffer);
+    oprot.writeRequestHeader(ctx);
+    oprot.writeMessageBegin(thrift.TMessage(method, kind, 0));
     args.write(oprot);
     oprot.writeMessageEnd();
-    var response = await _transport.request(ctx, memoryBuffer.writeBytes);
-
-    var iprot = _protocolFactory.getProtocol(response);
+    return memoryBuffer.writeBytes;
+  }
+  
+void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
+    final iprot = _protocolFactory.getProtocol(response);
     iprot.readResponseHeader(ctx);
-    thrift.TMessage msg = iprot.readMessageBegin();
+    final msg = iprot.readMessageBegin();
     if (msg.type == thrift.TMessageType.EXCEPTION) {
-      thrift.TApplicationError error = thrift.TApplicationError.read(iprot);
+      final error = thrift.TApplicationError.read(iprot);
       iprot.readMessageEnd();
       if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
         throw thrift.TTransportError(
@@ -558,16 +380,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
       throw error;
     }
 
-    sayAgain_result result = sayAgain_result();
     result.read(iprot);
     iprot.readMessageEnd();
-    if (result.isSetSuccess()) {
-      return result.success;
-    }
-
-    throw thrift.TApplicationError(
-      frugal.FrugalTApplicationErrorType.MISSING_RESULT, 'sayAgain failed: unknown result'
-    );
   }
 }
 

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -355,8 +355,8 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
       frugal.FrugalTApplicationErrorType.MISSING_RESULT, 'sayAgain failed: unknown result'
     );
   }
-  
-Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
+
+  Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
     final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
     final oprot = _protocolFactory.getProtocol(memoryBuffer);
     oprot.writeRequestHeader(ctx);
@@ -365,8 +365,8 @@ Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args,
     oprot.writeMessageEnd();
     return memoryBuffer.writeBytes;
   }
-  
-void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
+
+  void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
     final iprot = _protocolFactory.getProtocol(response);
     iprot.readResponseHeader(ctx);
     final msg = iprot.readMessageBegin();

--- a/test/expected/dart/variety/f_foo_service.dart
+++ b/test/expected/dart/variety/f_foo_service.dart
@@ -111,11 +111,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
 
   Future _ping(frugal.FContext ctx) async {
     final args = Ping_args();
-    final message = _prepareMessage(ctx, 'ping', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'ping', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = Ping_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
   }
   /// Blah the server.
   @override
@@ -128,11 +128,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
     args.num = num;
     args.str = str;
     args.event = event;
-    final message = _prepareMessage(ctx, 'blah', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'blah', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = blah_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -157,7 +157,7 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
     final args = oneWay_args();
     args.id = id;
     args.req = req;
-    final message = _prepareMessage(ctx, 'oneWay', args, thrift.TMessageType.ONEWAY);
+    final message = frugal.prepareMessage(ctx, 'oneWay', args, thrift.TMessageType.ONEWAY, _protocolFactory, _transport.requestSizeLimit);
     await _transport.oneway(ctx, message);
   }
 
@@ -170,11 +170,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
     final args = bin_method_args();
     args.bin = bin;
     args.str = str;
-    final message = _prepareMessage(ctx, 'bin_method', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'bin_method', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = bin_method_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -196,11 +196,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
     args.opt_num = opt_num;
     args.default_num = default_num;
     args.req_num = req_num;
-    final message = _prepareMessage(ctx, 'param_modifiers', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'param_modifiers', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = param_modifiers_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -218,11 +218,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
     final args = underlying_types_test_args();
     args.list_type = list_type;
     args.set_type = set_type;
-    final message = _prepareMessage(ctx, 'underlying_types_test', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'underlying_types_test', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = underlying_types_test_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -238,11 +238,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
 
   Future<t_validStructs.Thing> _getThing(frugal.FContext ctx) async {
     final args = getThing_args();
-    final message = _prepareMessage(ctx, 'getThing', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'getThing', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = getThing_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -258,11 +258,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
 
   Future<int> _getMyInt(frugal.FContext ctx) async {
     final args = getMyInt_args();
-    final message = _prepareMessage(ctx, 'getMyInt', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'getMyInt', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = getMyInt_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -279,11 +279,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   Future<t_subdir_include_ns.A> _use_subdir_struct(frugal.FContext ctx, t_subdir_include_ns.A a) async {
     final args = use_subdir_struct_args();
     args.a = a;
-    final message = _prepareMessage(ctx, 'use_subdir_struct', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'use_subdir_struct', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = use_subdir_struct_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -300,11 +300,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   Future<String> _sayHelloWith(frugal.FContext ctx, String newMessage) async {
     final args = sayHelloWith_args();
     args.newMessage = newMessage;
-    final message = _prepareMessage(ctx, 'sayHelloWith', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'sayHelloWith', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = sayHelloWith_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -321,11 +321,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   Future<String> _whatDoYouSay(frugal.FContext ctx, String messageArgs) async {
     final args = whatDoYouSay_args();
     args.messageArgs = messageArgs;
-    final message = _prepareMessage(ctx, 'whatDoYouSay', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'whatDoYouSay', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = whatDoYouSay_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -342,11 +342,11 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
   Future<String> _sayAgain(frugal.FContext ctx, String messageResult) async {
     final args = sayAgain_args();
     args.messageResult = messageResult;
-    final message = _prepareMessage(ctx, 'sayAgain', args, thrift.TMessageType.CALL);
+    final message = frugal.prepareMessage(ctx, 'sayAgain', args, thrift.TMessageType.CALL, _protocolFactory, _transport.requestSizeLimit);
     var response = await _transport.request(ctx, message);
 
     final result = sayAgain_result();
-    _processReply(ctx, result, response);
+    frugal.processReply(ctx, result, response, _protocolFactory);
     if (result.isSetSuccess()) {
       return result.success;
     }
@@ -354,34 +354,6 @@ class FFooClient extends t_actual_base_dart.FBaseFooClient with disposable.Dispo
     throw thrift.TApplicationError(
       frugal.FrugalTApplicationErrorType.MISSING_RESULT, 'sayAgain failed: unknown result'
     );
-  }
-
-  Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
-    final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    final oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage(method, kind, 0));
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    return memoryBuffer.writeBytes;
-  }
-
-  void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
-    final iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    final msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      final error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    result.read(iprot);
-    iprot.readMessageEnd();
   }
 }
 

--- a/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
+++ b/test/expected/dart/vendor_namespace/f_vendored_base_service.dart
@@ -46,34 +46,5 @@ class FVendoredBaseClient extends disposable.Disposable implements FVendoredBase
     }
     return null;
   }
-
-  
-Uint8List _prepareMessage(frugal.FContext ctx, String method, thrift.TBase args, int kind) {
-    final memoryBuffer = frugal.TMemoryOutputBuffer(_transport.requestSizeLimit);
-    final oprot = _protocolFactory.getProtocol(memoryBuffer);
-    oprot.writeRequestHeader(ctx);
-    oprot.writeMessageBegin(thrift.TMessage(method, kind, 0));
-    args.write(oprot);
-    oprot.writeMessageEnd();
-    return memoryBuffer.writeBytes;
-  }
-  
-void _processReply(frugal.FContext ctx, thrift.TBase result, thrift.TTransport response) {
-    final iprot = _protocolFactory.getProtocol(response);
-    iprot.readResponseHeader(ctx);
-    final msg = iprot.readMessageBegin();
-    if (msg.type == thrift.TMessageType.EXCEPTION) {
-      final error = thrift.TApplicationError.read(iprot);
-      iprot.readMessageEnd();
-      if (error.type == frugal.FrugalTTransportErrorType.REQUEST_TOO_LARGE) {
-        throw thrift.TTransportError(
-            frugal.FrugalTTransportErrorType.RESPONSE_TOO_LARGE, error.message);
-      }
-      throw error;
-    }
-
-    result.read(iprot);
-    iprot.readMessageEnd();
-  }
 }
 


### PR DESCRIPTION
### Story:
The dart generated code is very verbose, more so than the go version. In go, prepareMessage and processReply are shared and generic. Update the dart generation to reflect that behavior. 

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
Pull repeated code out of the dart functions and into a shared member. Reduce the total file size of each service provider. 

### How To Test:
I ran this against DPC here to verify the behavior against many services. https://github.com/Workiva/doc_plat_client/pull/12635.

With the latest changes, this is less straight forward and requires the dart dep to be upgraded before you can use it. As a result the PR no longer passes CI. 

### My Test Results:
This reduced the total line count in DPC by ~4000 lines and reduced the generated js size. I would expect the same to apply on a grander scale to all of workiva's dart code. 

#### Reviewers:
@Workiva/product2