### PR TITLE
Fix update.py for Go

### DIFF
--- a/scripts/lang/go.py
+++ b/scripts/lang/go.py
@@ -1,6 +1,3 @@
-import os
-import yaml
-
 from lang.base import LanguageBase
 
 
@@ -10,20 +7,9 @@ class Go(LanguageBase):
     """
 
     def update_frugal(self, version, root):
-        """
-        Update the go version. Go versioning is controlled by git tags, so
-        there is nothing to do here.
-        """
-        os.chdir('{0}/examples/go'.format(root))
-
-        with open('glide.yaml') as f:
-            glide_yaml = yaml.safe_load(f.read())
-            for imp in glide_yaml['import']:
-                if imp['package'] == 'github.com/Workiva/frugal':
-                    imp['version'] = version
-
-        with open('glide.yaml', 'w') as f:
-            yaml.dump(glide_yaml, f, default_flow_style=False)
+        # No change necessary
+        pass
 
     def update_expected_tests(self, root):
+        # No change necessary
         pass

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -50,7 +50,9 @@ def update_compiler(version, root):
         f.write(s)
     # Install the binary with the updated version
     os.chdir(root)
-    if subprocess.call(['godep', 'go', 'install']) != 0:
+    if subprocess.call(['go', 'mod', 'download']) != 0:
+        raise Exception('downloading modules failed')
+    if subprocess.call(['go', 'install']) != 0:
         raise Exception('installing frugal binary failed')
 
 


### PR DESCRIPTION
### Story:
update.py script failing do to transition from godep/glide to gomod.

### Acceptance Criteria:
- [ ] At least one InfRe Squad 2 member has reviewed and +1'd
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
N/A

### How To Test:
- Run `python scripts/update.py --version v3.14.0` on this branch and review changes to versions.

### My Test Results:
```
$ python scripts/update.py --version v3.14.0
dict_keys(['dart', 'go', 'java', 'python'])
Updating frugal to version 3.14.0 for dart, go, java, python
Events: scope subscriber generation is not implemented for vanilla Python 2.7. For 2.7, use the Tornado framework (where available) or provide a pull request
Events: scope subscriber generation is not implemented for vanilla Python 2.7. For 2.7, use the Tornado framework (where available) or provide a pull request
PASS
ok  	github.com/Workiva/frugal/test	48.138s
Updating expected tests for dart
Updating expected tests for go
Updating expected tests for java
Updating expected tests for python
```

#### Reviewers:
@Workiva/service-platform 