### PR TITLE
Remove deprecated authors field from pubspec.yaml

### DIFF
--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -1,7 +1,3 @@
-authors:
-- Steven Osborne <steven.osborne@workiva.com>
-- Mark Erickson <mark.erickson@workiva.com>
-- Brian Shannan <brian.shannan@workiva.com>
 dependencies:
   logging: ^0.11.2
   thrift:


### PR DESCRIPTION
This PR removes the author field from any `pubspec.yaml` files in this repo,
as the field was deprecated in Dart 2.7 and is no longer needed.

Removing this field will silence the warning that `pub publish` emits, which
has the added benefit of allowing us to use `pub publish --dry-run` as a
quality check during CI.

If you'd like to retain the author information, we recommend adding an
`AUTHORS.md` file in the repo or the package directory.

---

This PR was created automatically from a Sourcegraph batch change.
Please reach out to @evanweible-wf or #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/remove_pubspec_authors`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/remove_pubspec_authors)