### PR TITLE
SPLAT-1140 Dart: Don't complete already-completed completers

### DIFF
--- a/lib/dart/lib/src/frugal/transport/f_async_transport.dart
+++ b/lib/dart/lib/src/frugal/transport/f_async_transport.dart
@@ -87,21 +87,21 @@ abstract class FAsyncTransport extends FTransport {
     try {
       opId = int.parse(headers[_opidHeader]);
     } catch (e) {
-      _log.warning("frugal: invalid protocol frame: op id not a uint64", e);
+      _log.severe("frugal: invalid protocol frame: op id not a uint64", e);
       return;
     }
 
     Completer<Uint8List> handler = _handlers[opId];
     if (handler == null) {
-      _log.warning("frugal: no handler found for message, dropping message");
+      _log.severe("frugal: no handler found for message, dropping message");
       return;
     }
 
     if (handler.isCompleted) {
-      _log.warning(
+      _log.severe(
           "frugal: handler already called for message, dropping message");
-    } else {
-      handler.complete(frame);
+      return;
     }
+    handler.complete(frame);
   }
 }

--- a/lib/dart/lib/src/frugal/transport/f_async_transport.dart
+++ b/lib/dart/lib/src/frugal/transport/f_async_transport.dart
@@ -100,7 +100,8 @@ abstract class FAsyncTransport extends FTransport {
     if (handler.isCompleted) {
       _log.warning(
           "frugal: handler already called for message, dropping message");
+    } else {
+      handler.complete(frame);
     }
-    handler.complete(frame);
   }
 }


### PR DESCRIPTION
Doing so just leads to an unhandled exception

### Story:
As a consumer, we see these sometimes:
```
   exception: { [-]
     message: Uncaught exception during experience runtime
     stacktrace: org-dartlang-sdk:                                                                                                                                  _AsyncCompleter.complete
https://cdn-prod.wdesk.com/wdesk/packages/frugal/src/frugal/transport/f_async_transport.dart 104:5                                                 FAsyncTransport.handleResponse
https://cdn-prod.wdesk.com/wdesk/packages/messaging_sdk/src/internal/transport/f_nats_transport.dart 150:13                                        FNatsTransport._open.<anonymous function>
org-dartlang-sdk:                                                                                                                                  invokeClosure
eyJhdHRhY2htZW50X2lkIjozOTg4MTYxLCJwcm9kdWNlcl93dXJsIjoid3VybDovL3NoZWV0cy52MC8wOnNoZWV0c19hYTk3ODg1YzY5Mzg0MzNiYTkwMmNmMGQ2YzViNGRlNiJ9 16:23900  MutationObserver.nrWrapper

     type: Bad state: Future already completed
   }
   level: error
   message: Uncaught exception during experience runtime
   name: wdesk_sdk.markup.experience_uncaught
```

We don't want unhandled exceptions, especially when there's already warning logged.

### Acceptance Criteria:
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
TODO

### My Test Results:
TODO

#### Reviewers:
@Workiva/service-platform
