### PR TITLE
Add comments to unblock Dart 2.12

### DIFF
--- a/examples/dart/web/client.dart
+++ b/examples/dart/web/client.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:async';
 import 'dart:html';
 

--- a/lib/dart/test/f_context_test.dart
+++ b/lib/dart/test/f_context_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import "package:frugal/frugal.dart";
 import "package:test/test.dart";
 

--- a/lib/dart/test/f_middleware_test.dart
+++ b/lib/dart/test/f_middleware_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import "dart:async";
 
 import "package:frugal/frugal.dart";

--- a/lib/dart/test/internal/f_byte_buffer_test.dart
+++ b/lib/dart/test/internal/f_byte_buffer_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import "dart:typed_data";
 import "package:test/test.dart";
 

--- a/lib/dart/test/internal/f_obj_to_json_test.dart
+++ b/lib/dart/test/internal/f_obj_to_json_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import "package:test/test.dart";
 import "package:thrift/thrift.dart";
 

--- a/lib/dart/test/internal/headers_test.dart
+++ b/lib/dart/test/internal/headers_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import "dart:typed_data";
 import "package:test/test.dart";
 import "package:thrift/thrift.dart";

--- a/lib/dart/test/protocol/f_protocol_test.dart
+++ b/lib/dart/test/protocol/f_protocol_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import "package:test/test.dart";
 import "package:frugal/frugal.dart";
 import "package:thrift/thrift.dart";

--- a/lib/dart/test/transport/base_f_transport_monitor_test.dart
+++ b/lib/dart/test/transport/base_f_transport_monitor_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import "dart:async";
 import "package:test/test.dart";
 import "package:frugal/frugal.dart";

--- a/lib/dart/test/transport/f_adapter_transport_test.dart
+++ b/lib/dart/test/transport/f_adapter_transport_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 

--- a/lib/dart/test/transport/f_http_transport_test.dart
+++ b/lib/dart/test/transport/f_http_transport_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data' show Uint8List;

--- a/lib/dart/test/transport/f_transport_test.dart
+++ b/lib/dart/test/transport/f_transport_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 

--- a/test/integration/dart/test_client/bin/main.dart
+++ b/test/integration/dart/test_client/bin/main.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 /// Licensed to the Apache Software Foundation (ASF) under one
 /// or more contributor license agreements. See the NOTICE file
 /// distributed with this work for additional information


### PR DESCRIPTION
Adds null safety opt-out comments to Dart entry points to prepare for Dart 2.12+
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/add_dart2_9_comments`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/add_dart2_9_comments)