### PR TITLE
java: Fix spurious IllegalArgumentException with NATS 2.2.0 and no responders

### DIFF
--- a/lib/dart/lib/src/frugal/f_error.dart
+++ b/lib/dart/lib/src/frugal/f_error.dart
@@ -81,4 +81,8 @@ class FrugalTTransportErrorType extends TTransportErrorType {
 
   /// Indicates the request failed because the transport was disconnected.
   static const int DISCONNECTED = 102;
+
+  /// Indicates the request failed because the service host, subject, etc. was
+  /// not found.
+  static const int SERVICE_NOT_AVAILABLE = 103;
 }

--- a/lib/go/errors.go
+++ b/lib/go/errors.go
@@ -38,6 +38,10 @@ const (
 	// TRANSPORT_EXCEPTION_DISCONNECTED is a TTransportException error type
 	// indicating the transport was disconnected
 	TRANSPORT_EXCEPTION_DISCONNECTED = 102
+
+	// TRANSPORT_EXCEPTION_SERVICE_NOT_AVAILABLE is a TTransportException
+	// error type indicating the service host, subject, etc. was not found.
+	TRANSPORT_EXCEPTION_SERVICE_NOT_AVAILABLE = 103
 )
 
 // TApplicationException types used in frugal instantiated

--- a/lib/java/src/main/java/com/workiva/frugal/exception/TTransportExceptionType.java
+++ b/lib/java/src/main/java/com/workiva/frugal/exception/TTransportExceptionType.java
@@ -44,4 +44,9 @@ public class TTransportExceptionType {
      * TTransportException code that indicates the transport was disconnected.
      */
     public static final int DISCONNECTED = 102;
+
+    /**
+     * TTransportException code that indicates the service host, subject, etc. was not found.
+     */
+    public static final int SERVICE_NOT_AVAILABLE = 103;
 }

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FAsyncTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FAsyncTransport.java
@@ -37,6 +37,8 @@ import java.util.concurrent.TimeUnit;
 public abstract class FAsyncTransport extends FTransport {
 
     protected static final byte[] POISON_PILL = new byte[0];
+    // Visible for testing
+    static final byte[] SERVICE_NOT_AVAILABLE = new byte[0];
 
     protected Map<Long, BlockingQueue<byte[]>> queueMap = new HashMap<>();
 
@@ -87,15 +89,16 @@ public abstract class FAsyncTransport extends FTransport {
         preflightRequestCheck(payload.length);
 
         BlockingQueue<byte[]> queue = new ArrayBlockingQueue<>(1);
+        long opId = getOpId(context);
         synchronized (this) {
-            if (queueMap.containsKey(getOpId(context))) {
+            if (queueMap.containsKey(opId)) {
                 throw new TTransportException("request already in flight for context");
             }
-            queueMap.put(getOpId(context), queue);
+            queueMap.put(opId, queue);
         }
 
         try {
-            flush(payload);
+            flushOp(opId, payload);
 
             byte[] response;
             try {
@@ -108,6 +111,11 @@ public abstract class FAsyncTransport extends FTransport {
                 throw new TTransportException(TTransportExceptionType.TIMED_OUT, "request: timed out");
             }
 
+            if (response == SERVICE_NOT_AVAILABLE) {
+                throw new TTransportException(TTransportExceptionType.SERVICE_NOT_AVAILABLE,
+                        "request: service not available");
+            }
+
             if (response == POISON_PILL) {
                 throw new TTransportException(TTransportExceptionType.NOT_OPEN,
                         "request: transport closed, request canceled");
@@ -116,18 +124,29 @@ public abstract class FAsyncTransport extends FTransport {
             return new TMemoryInputTransport(response);
         } finally {
             synchronized (this) {
-                queueMap.remove(getOpId(context));
+                queueMap.remove(opId);
             }
         }
     }
 
     /**
-     * Flush the payload to the server. Implementations must not block and must be thread-safe.
+     * Flush a oneway or request payload to the server.
+     * Implementations must not block and must be thread-safe.
+     * This method is not called for requests if {@link #flushOp} is overridden.
      *
      * @param payload framed frugal bytes
      * @throws TTransportException if flushing the transport fails.
+     * @see #flushOp
      */
     protected abstract void flush(byte[] payload) throws TTransportException;
+
+    /**
+     * Flush a request payload to the server.
+     * By default, this method calls {@link #flush}.
+     */
+    protected void flushOp(long opId, byte[] payload) throws TTransportException {
+        flush(payload);
+    }
 
     /**
      * Handles a frugal frame response (NOTE: this frame must NOT include the frame size).
@@ -147,6 +166,21 @@ public abstract class FAsyncTransport extends FTransport {
             throw new TProtocolException("invalid protocol frame: op id not a uint64", e);
         }
 
+        handleOpResponse(opId, frame);
+    }
+
+    /**
+     * Handles a frugal response for
+     * {@link TTransportExceptionType#SERVICE_NOT_AVAILABLE}.
+     */
+    protected void handleServiceNotAvailable(long opId) throws TException {
+        handleOpResponse(opId, SERVICE_NOT_AVAILABLE);
+    }
+
+    /**
+     * Handles a frugal frame response for a specific op.
+     */
+    private void handleOpResponse(long opId, byte[] frame) throws TException {
         BlockingQueue<byte[]> queue;
         synchronized (this) {
             queue = queueMap.get(opId);

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FHttpTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FHttpTransport.java
@@ -39,7 +39,9 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.ConnectException;
 import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.Objects;
 
@@ -287,6 +289,12 @@ public class FHttpTransport extends FTransport {
         CloseableHttpResponse response;
         try {
             response = httpClient.execute(request);
+        } catch (UnknownHostException e) {
+            throw new TTransportException(TTransportExceptionType.SERVICE_NOT_AVAILABLE,
+                    "http request unknown host: " + e.getMessage(), e);
+        } catch (ConnectException e) {
+            throw new TTransportException(TTransportExceptionType.SERVICE_NOT_AVAILABLE,
+                    "http request connect exception: " + e.getMessage(), e);
         } catch (ConnectTimeoutException e) {
             throw new TTransportException(TTransportExceptionType.TIMED_OUT,
                     "http request connection timed out: " + e.getMessage(), e);

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FNatsTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FNatsTransport.java
@@ -139,8 +139,12 @@ public class FNatsTransport extends FAsyncTransport {
     protected class Handler implements MessageHandler {
         public void onMessage(Message message) {
             try {
-                byte[] frame = message.getData();
-                handleResponse(Arrays.copyOfRange(frame, 4, frame.length));
+                if (message.isStatusMessage()) {
+                    LOGGER.debug("Received status message: {}", message);
+                } else {
+                    byte[] frame = message.getData();
+                    handleResponse(Arrays.copyOfRange(frame, 4, frame.length));
+                }
             } catch (TException e) {
                 LOGGER.warn("Could not handle frame", e);
             }

--- a/lib/java/src/test/java/com/workiva/frugal/transport/FHttpTransportTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/transport/FHttpTransportTest.java
@@ -28,7 +28,9 @@ import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -355,6 +357,30 @@ public class FHttpTransportTest {
             fail();
         } catch (TTransportException e) {
             assertEquals(e.getType(), TTransportException.UNKNOWN);
+        }
+    }
+
+    @Test
+    public void testSend_requestUnknownHost() throws TTransportException, IOException {
+        byte[] buff = "helloserver".getBytes();
+        when(client.execute(any(HttpPost.class))).thenThrow(new UnknownHostException());
+        try {
+            transport.request(context, buff);
+            fail();
+        } catch (TTransportException e) {
+            assertEquals(e.getType(), TTransportExceptionType.SERVICE_NOT_AVAILABLE);
+        }
+    }
+
+    @Test
+    public void testSend_requestConnectException() throws TTransportException, IOException {
+        byte[] buff = "helloserver".getBytes();
+        when(client.execute(any(HttpPost.class))).thenThrow(new ConnectException());
+        try {
+            transport.request(context, buff);
+            fail();
+        } catch (TTransportException e) {
+            assertEquals(e.getType(), TTransportExceptionType.SERVICE_NOT_AVAILABLE);
         }
     }
 

--- a/lib/python/frugal/exceptions.py
+++ b/lib/python/frugal/exceptions.py
@@ -24,6 +24,7 @@ class TTransportExceptionType(object):
     REQUEST_TOO_LARGE = 100
     RESPONSE_TOO_LARGE = 101
     DISCONNECTED = 102
+    SERVICE_NOT_AVAILABLE = 103
 
 
 class TApplicationExceptionType(object):


### PR DESCRIPTION
### Story:
Commits are intended to be reviewed independently.  See commit messages for details.

I was developing an integration test issue where a Frugal request was being sent to a subject with no responders, and I was receiving the following exception in the logs:
```
java.lang.IllegalArgumentException: 4 > 0
	at java.base/java.util.Arrays.copyOfRange(Arrays.java:4029)
	at com.workiva.frugal.transport.FNatsTransport$Handler.onMessage(FNatsTransport.java:147)
	at io.nats.client.impl.NatsDispatcher.run(NatsDispatcher.java:98)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

After debugging, I discovered that I was running NATS 2.2.0, which includes nats-server PR 1478, which automatically sends a no-data status message with headers if there are no subscribers to a PUB.  nats.java PR 362 parses this and unconditionally delivers a no-data `Message`.

### Acceptance Criteria:
- [x] Code has been tested and results documented
- [x] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
The first commit ignores status messages sent to the inbox since they are not valid Frugal messages.

The remaining commits adds support to immediately fail requests rather than waiting on a timeout if a 503 (NO_RESPONDERS) status message is sent to the Frugal inbox.  Since the message has no additional context, the inbox subscription is changed to a wildcard, and the op id is encoded in the reply subject.  In theory, the same approach could be used to remove the [transport response header decoding](https://github.com/Workiva/frugal/blob/eb8279149329b68bc5156b41e16e204ef6614afb/lib/java/src/main/java/com/workiva/frugal/transport/FAsyncTransport.java#L140-L141), which is somewhat expensive just to find the op id, but I chose to keep this PR simple for now.

I don't have a convenient setup for testing Go, Dart, or Python, so I have not checked whether status messages similarly cause issues for those languages, and I have not attempted to short-circuit the 

### How To Test:
Set up a client/server using NATS 2.1.9 and NATS 2.2.0, and send oneway/request to subjects with and without subscribers.

### My Test Results:
I tested the changes with an internal service that makes NATS requests and verified both the success and failure paths.

As part of the testing, I also had two servers sending requests to eachother, one with these updates and one without, so there should not be any interoperability problems.

#### Reviewers:
@Workiva/service-platform
FYI @scottmartin-wk 