### PR TITLE
Widen Dependency Ranges Blocking Dart 2.13

### DIFF
--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -17,7 +17,7 @@ dev_dependencies:
   dart_dev: ^3.0.0
   dart_style: ^1.3.1
   mockito: ^4.1.1
-  test: ^1.9.1
+  test: ^1.15.7
 environment:
   sdk: '>=2.4.1 <3.0.0'
 homepage: https://github.com/Workiva/frugal/lib/dart

--- a/test/integration/dart/test_client/pubspec.yaml
+++ b/test/integration/dart/test_client/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
   frugal_test:
     path: ../gen-dart/frugal_test
 dev_dependencies:
-  test: "^1.3.0"
+  test: ^1.15.7
 dependency_overrides:
   frugal:
     path:  ../../../../lib/dart

--- a/test/integration/dart/test_client/pubspec.yaml
+++ b/test/integration/dart/test_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: frugal_test_client
 dependencies:
-  http: ^0.11.0
+  http: ^0.12.0
   frugal:
     path:  ../../../../lib/dart
   frugal_test:


### PR DESCRIPTION
## Motivation
In order for projects to be compatible with Dart 2.13, there are dependencies that need to have their ranges widened. 
For a list of dependencies expected to be changed, see the dependencies section of the Dart 2.12+ [wiki page](https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832).

Another necessary change is the removal of `build_vm_compilers`. If this is the case, additional clean up may need to be done, such as removing the associated config from `build.yaml` or updating how tests are run. A member of Client Platform will be following up with PRs that have CI failures to resolve any issues or perform necessary clean up.

For any questions or concerns, don't hesitate to reach us in the #support-client-plat Slack channel!

## Changes
- Update specific dependencies to be compatible with Dart 2.13.
- Remove `build_vm_compilers` if it was present

## QA
- CI passes

[_Created by Sourcegraph batch change `Workiva/dart_213_dependency_range_widen`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/dart_213_dependency_range_widen)