### PR TITLE
Update the on-promotion trigger to on-tag in skynet.yaml.

### DIFF
--- a/skynet.yaml
+++ b/skynet.yaml
@@ -3,7 +3,7 @@ name: cross-local
 size: large
 
 run:  # local tests only, never run in Skynet
-  on-promotion: false
+  on-tag: false
   on-pull-request: false
 
 contact: messaging@workiva.com


### PR DESCRIPTION
https://jira.atl.workiva.net/browse/CID-1062

The [skynet.yaml specification](https://github.com/Workiva/skynet/blob/master/docs/skynet/getting-started/skynet-yaml.md#during-a-production-release) includes a concept
named on-promotion that originates from a process that the now shut down service Shipyard managed.
Since that shut down, Workiva has shifted to performing actions on tags and the newer on-tag field was added to reflect that.
The behavior of the tests are identical when using on-promotion and on-tag today.

[CID](https://github.com/Workiva/cid) will no longer support the deprecated on-promotion trigger, so repositories
will need to have it replaced before the eventual transition.

Please reach out to `#support-test` or `#support-cid` with any questions.

[_Created by Sourcegraph batch change `Workiva/replace_on-promotion_trigger`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/replace_on-promotion_trigger)