### PR TITLE
Update the deprecated build arg BUILD_ARTIFACTS_ARTIFACTORY to BUILD_ARTIFACTS_JAVA.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ARG BUILD_ARTIFACTS_RELEASE=/go/src/github.com/Workiva/frugal/frugal
 ARG BUILD_ARTIFACTS_AUDIT=/go/src/github.com/Workiva/frugal/python2_pip_deps.txt:/go/src/github.com/Workiva/frugal/python3_pip_deps.txt:/go/src/github.com/Workiva/frugal/lib/go/go.mod:/go/src/github.com/Workiva/frugal/lib/dart/pubspec.lock:/go/src/github.com/Workiva/frugal/lib/java/pom.xml
 ARG BUILD_ARTIFACTS_GO_LIBRARY=/go/src/github.com/Workiva/frugal/goLib.tar.gz
 ARG BUILD_ARTIFACTS_PYPI=/go/src/github.com/Workiva/frugal/frugal-*.tar.gz
-ARG BUILD_ARTIFACTS_ARTIFACTORY=/go/src/github.com/Workiva/frugal/frugal-*.jar
+ARG BUILD_ARTIFACTS_JAVA=/go/src/github.com/Workiva/frugal/frugal-*.jar
 ARG BUILD_ARTIFACTS_PUB=/go/src/github.com/Workiva/frugal/frugal.pub.tgz
 ARG BUILD_ARTIFACTS_TEST_RESULTS=/go/src/github.com/Workiva/frugal/test_results/*
 

--- a/scripts/skynet/cross/setup_java.sh
+++ b/scripts/skynet/cross/setup_java.sh
@@ -5,7 +5,7 @@ set -ex
 export FRUGAL_HOME=$GOPATH/src/github.com/Workiva/frugal
 
 if [ -z "${IN_SKYNET_CLI+yes}" ]; then
-    cp ${SKYNET_APPLICATION_FRUGAL_ARTIFACTORY} ${FRUGAL_HOME}/test/integration/java/frugal-integration-test/frugal.jar
+    cp ${SKYNET_APPLICATION_FRUGAL_JAVA} ${FRUGAL_HOME}/test/integration/java/frugal-integration-test/frugal.jar
 else
     cd ${FRUGAL_HOME}/lib/java
     mvn clean verify -q

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -34,7 +34,7 @@ run:
 
 requires:
   Workiva/frugal:
-    - artifactory
+    - java
     - release
     - pub
     - pypi


### PR DESCRIPTION
https://jira.atl.workiva.net/browse/CID-947

The BUILD_ARTIFACTS_ARTIFACTORY build arg has been deprecated and replaced/made synonymous with BUILD_ARTIFACTS_JAVA as
noted in the workiva-build [user guide](https://github.com/Workiva/workiva-build/blob/master/doc/user_guide.md#artifacts)

[CID](https://github.com/Workiva/cid) will no longer support the deprecated BUILD_ARTIFACTS_ARTIFACTORY, so repositories
will need to have it replaced before the eventual transition.

Please reach out to `#support-cid` or `#support-build` with any questions.

[_Created by Sourcegraph batch change `Workiva/remove_deprecated_build_args`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/remove_deprecated_build_args)