### PR TITLE
SPLAT-2065: Pin aiohttp to <3.8.0

### DIFF
--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -29,7 +29,7 @@ setup(
     extras_require={
         'tornado': ['nats-client==0.8.4'],
         'asyncio': [
-            'aiohttp>=3.0.9,<4',
+            'aiohttp>=3.0.9,<3.8.0',
             'aiostomp==1.6.2',
             'asyncio-nats-client>=0.11.4,<1',
             'async-timeout>=2.0.1,<4',


### PR DESCRIPTION
# [SPLAT-2065](https://jira.atl.workiva.net/browse/SPLAT-2065)
![Issue Status](http://bender.workiva.org:9000/Bender/status/SPLAT-2065)

### Story:
New version of aiohttp imcompatible with current dependency setup.

### How To Test:
- [x] CI Passes again

### My Test Results:
- [x] CI Passed for me: https://github.com/Workiva/frugal/pull/1723

#### Reviewers:
@Workiva/service-platform
