### PR TITLE
Test w_transport v4

### DIFF
--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -21,3 +21,9 @@ homepage: https://github.com/Workiva/frugal/lib/dart
 name: frugal
 publish_to: https://pub.workiva.org
 version: 3.14.10
+
+dependency_overrides:
+  w_transport:
+    git:
+      url: https://github.com/Workiva/w_transport.git
+      ref: v4


### PR DESCRIPTION
DO NOT MERGE. This PR adds a dependency override to the w_transport v4 branch to test whether this repo is compatible with it.
For more info, reach out to `#support-client-plat` on Slack.