### PR TITLE
Raise w_transport max to <5.0.0

### DIFF
--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
     version: ^0.0.10
   uuid: '>=0.5.0 <2.0.0'
   w_common: ^1.20.1
-  w_transport: ^3.2.8
+  w_transport: '>=3.2.8 <5.0.0'
 description: A frugal client for Dart
 dev_dependencies:
   dart_dev: ^3.0.0


### PR DESCRIPTION
Client Platform is updating dependencies. More info: 
This PR raises the max version allowed for w_transport to <5.0.0
```
  pubspec_codemod raise-max w_transport 5.0.0 --recursive
  pubspec_codemod raise-min messaging_sdk 3.17.0 --recursive
  pubspec_codemod raise-min wdesk_sdk 2.303.71 --recursive
```
For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/w_transport_v4_raise_max`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/w_transport_v4_raise_max)