### PR TITLE
Raise Max Versions

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -193,7 +193,7 @@ func (g *Generator) addToPubspec(dir string) error {
 
 	deps := map[interface{}]interface{}{
 		"collection": "^1.14.12",
-		"logging":    "^0.11.2",
+		"logging":    ">=0.11.2 <2.0.0",
 		"thrift": dep{
 			Hosted:  hostedDep{Name: "thrift", URL: "https://pub.workiva.org"},
 			Version: "^0.0.10",
@@ -1106,7 +1106,7 @@ func (g *Generator) generateWrite(s *parser.Struct) string {
 func (g *Generator) generateWriteFieldRec(field *parser.Field, first bool, ind string) string {
 	contents := ""
 
-	contents += ignoreDeprecationWarningIfNeeded(tabtab + ind, field.Annotations)
+	contents += ignoreDeprecationWarningIfNeeded(tabtab+ind, field.Annotations)
 
 	fName := toFieldName(field.Name)
 	thisPrefix := ""
@@ -1833,7 +1833,7 @@ func (g *Generator) generateClient(service *parser.Service) string {
 	contents += tabtab + "}\n"
 	contents += tabtab + "return null;\n"
 	contents += tab + "}\n"
-	
+
 	for _, method := range service.Methods {
 		contents += "\n"
 		contents += g.generateClientMethod(service, method)
@@ -1888,7 +1888,7 @@ func (g *Generator) generateClientMethod(service *parser.Service, method *parser
 	}
 
 	contents += fmt.Sprintf(indent+"final message = frugal.prepareMessage(ctx, '%s', args, thrift.TMessageType.%s, _protocolFactory, _transport.requestSizeLimit);\n",
-	nameLower, msgType)
+		nameLower, msgType)
 
 	if method.Oneway {
 		contents += indent + "await _transport.oneway(ctx, message);\n"

--- a/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
       name: frugal
       url: https://pub.workiva.org
     version: ^3.9.7
-  logging: ^0.11.2
+  logging: '>=0.11.2 <2.0.0'
   some_vendored_place:
     hosted:
       name: some_vendored_place

--- a/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
       name: frugal
       url: https://pub.workiva.org
     version: ^3.14.11
-  logging: ^0.11.2
+  logging: '>=0.11.2 <2.0.0'
   some_vendored_place:
     hosted:
       name: some_vendored_place

--- a/examples/dart/gen-dart/v1_music/pubspec.yaml
+++ b/examples/dart/gen-dart/v1_music/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
       name: frugal
       url: https://pub.workiva.org
     version: ^3.14.11
-  logging: ^0.11.2
+  logging: '>=0.11.2 <2.0.0'
   thrift:
     hosted:
       name: thrift

--- a/examples/dart/pubspec.yaml
+++ b/examples/dart/pubspec.yaml
@@ -4,7 +4,7 @@ dependencies:
       name: frugal
       url: https://pub.workiva.org
     version: ^3.14.11
-  logging: ^0.11.2
+  logging: '>=0.11.2 <2.0.0'
   thrift:
     hosted:
       name: thrift
@@ -13,7 +13,7 @@ dependencies:
   v1_music:
     path: gen-dart/v1_music
 dev_dependencies:
-  build_runner: '>=1.6.2 <2.0.0'
+  build_runner: '>=1.6.2 <3.0.0'
   build_web_compilers: '>=1.2.0 <3.0.0'
 environment:
   sdk: ^2.11.0

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 dependencies:
-  logging: ^0.11.2
+  logging: '>=0.11.2 <2.0.0'
   thrift:
     hosted:
       name: thrift

--- a/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
+++ b/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
       name: frugal
       url: https://pub.workiva.org
     version: ^3.14.11
-  logging: ^0.11.2
+  logging: '>=0.11.2 <2.0.0'
   thrift:
     hosted:
       name: thrift


### PR DESCRIPTION
Summary
---
Client Platform is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This batch raises the max versions allowed for the following
dependencies:
  - args <3.0.0
  - build <3.0.0
  - build_config <2.0.0
  - build_runner <3.0.0
  - checked_yaml <3.0.0
  - logging <2.0.0
  - pub_semver <3.0.0
  - pubspec_parse <2.0.0
  - uri <2.0.0

For more info, reach out to `#support-client-plat` on Slack.

[_Created by Sourcegraph batch change `Workiva/raise_max_versions`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/raise_max_versions)