### PR TITLE
TESTING: Consume messaging-docker-images 0.1.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.8 as build
+FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.9 as build
 
 RUN yum update -y && \
     yum upgrade -y && \

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -8,7 +8,7 @@ run:  # local tests only, never run in Skynet
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.8
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.9
 
 env:
   - IN_SKYNET_CLI=true
@@ -41,7 +41,7 @@ requires:
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.8
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.9
 env:
   - PYTHONIOENCODING=utf-8
 


### PR DESCRIPTION
This is a test pull request triggered from w-rmconsole and is not intended for merge.
Consume [messaging-docker-images 0.1.9](https://github.com/Workiva/messaging-docker-images/releases/tag/0.1.9)

Pull Requests included in release:
* Patch changes:
	* [updated go to 1.17.4](https://github.com/Workiva/messaging-docker-images/pull/71)

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5198026715955200/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5198026715955200/?pull_number=1775&repo_name=Workiva%2Ffrugal)