### PR TITLE
java: Deprecate FServlet

### DIFF
--- a/lib/java/src/main/java/com/workiva/frugal/server/FServlet.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FServlet.java
@@ -40,7 +40,12 @@ import java.util.concurrent.ExecutorService;
  * exceeds the payload limit specified by the client.
  * <p>
  * Both the request and response are base64 encoded.
+ *
+ * @deprecated The {@code javax.servlet} package has been superseded by the
+ * {@code jakarta.servlet} package.
+ * Use {@code com.workiva.frugal.server.FJakartaServlet}.
  */
+@Deprecated
 @SuppressWarnings("serial")
 public class FServlet extends HttpServlet {
     private static final Logger LOGGER = LoggerFactory.getLogger(FServlet.class);

--- a/lib/java/src/test/java/com/workiva/frugal/server/FServletTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/server/FServletTest.java
@@ -46,6 +46,7 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 /**
  * Tests for {@link FServlet}.
  */
+@SuppressWarnings("deprecation")
 public class FServletTest {
 
     private static class ProxyServletInputStream extends ServletInputStream {


### PR DESCRIPTION
### Story:
Jakarta EE has [renamed](https://eclipse-foundation.blog/2020/12/08/jakarta-ee-9-delivers-the-big-bang/) all packages to `jakarta.`.  #1410 added `FJakartaServlet` as a replacement.  We would like to remove `FServlet` in the future, so start warning developers that `FServlet` is going away.

### How To Test:
N/A.  Deprecation only.

#### Reviewers:
@Workiva/service-platform
