### PR TITLE
Add support for java thread pool workers

### DIFF
--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.workiva</groupId>
     <artifactId>frugal</artifactId>
-    <version>3.15.1-SNAPSHOT</version>
+    <version>3.15.1</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.workiva</groupId>
     <artifactId>frugal</artifactId>
-    <version>3.15.1</version>
+    <version>3.15.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FNatsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FNatsSubscriberTransport.java
@@ -109,10 +109,14 @@ public class FNatsSubscriberTransport implements FSubscriberTransport {
         /**
          * Set the number of concurrent workers to use when consuming messages. By default,
          * message are handled one at a time on a single thread.
-         * @param count The number of concurrent workers for consuming messages.
+         * @param count The number of concurrent workers for consuming messages. Must be >= 1.
          * @return The existing Factory
+         * @throws IllegalArgumentException if count < 1
          */
         public Factory withWorkerCount(int count) {
+            if( count < 1) {
+                throw new IllegalArgumentException("Worker count must be 1 or greater, but was " + count);
+            }
             this.workerPool = Executors.newFixedThreadPool(count);
             return this;
         }

--- a/lib/java/src/main/java/com/workiva/frugal/transport/FNatsSubscriberTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/FNatsSubscriberTransport.java
@@ -109,14 +109,10 @@ public class FNatsSubscriberTransport implements FSubscriberTransport {
         /**
          * Set the number of concurrent workers to use when consuming messages. By default,
          * message are handled one at a time on a single thread.
-         * @param count The number of concurrent workers for consuming messages. Must be >= 1.
+         * @param count The number of concurrent workers for consuming messages.
          * @return The existing Factory
-         * @throws IllegalArgumentException if count < 1
          */
         public Factory withWorkerCount(int count) {
-            if( count < 1) {
-                throw new IllegalArgumentException("Worker count must be 1 or greater, but was " + count);
-            }
             this.workerPool = Executors.newFixedThreadPool(count);
             return this;
         }

--- a/lib/java/src/main/java/com/workiva/frugal/util/DirectExecutor.java
+++ b/lib/java/src/main/java/com/workiva/frugal/util/DirectExecutor.java
@@ -1,0 +1,11 @@
+package com.workiva.frugal.util;
+
+import java.util.concurrent.Executor;
+
+public class DirectExecutor implements Executor {
+
+  @Override
+  public void execute(Runnable command) {
+    command.run();
+  }
+}

--- a/lib/java/src/test/java/com/workiva/frugal/transport/FNatsSubscriberTransportTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/transport/FNatsSubscriberTransportTest.java
@@ -247,10 +247,5 @@ public class FNatsSubscriberTransportTest {
         transport.unsubscribe();
         assertFalse(transport.isSubscribed());
     }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testFactoryWithCountLessThan1() {
-        new FNatsSubscriberTransport.Factory(conn).withWorkerCount(0);
-    }
 }
 

--- a/lib/java/src/test/java/com/workiva/frugal/transport/FNatsSubscriberTransportTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/transport/FNatsSubscriberTransportTest.java
@@ -247,5 +247,10 @@ public class FNatsSubscriberTransportTest {
         transport.unsubscribe();
         assertFalse(transport.isSubscribed());
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFactoryWithCountLessThan1() {
+        new FNatsSubscriberTransport.Factory(conn).withWorkerCount(0);
+    }
 }
 


### PR DESCRIPTION
Add support for java thread pool workers to help prevent messages from backing up in nats

### Story:
Adding support for java concurrent executors on the Nats subscribers.  This support is added to help prevent issues with nats topics getting backed up and causing exceptions when a handler execution is slow.

The default uses a single processing thread for all messages, same as before this change.

### Acceptance Criteria:
- [ ] Code has been tested and results documented
- [x] Unit tests have been updated
- [x] Updates to documentation if necessary
- [x] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master


#### Reviewers:
@Workiva/service-platform
