### PR TITLE
Updgrade thrift to 0.14.2 to avoid cve

### DIFF
--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.13.0</version>
+            <version>0.14.2</version>
         </dependency>
         <dependency>
             <groupId>io.nats</groupId>

--- a/lib/java/src/main/java/com/workiva/frugal/protocol/FProtocol.java
+++ b/lib/java/src/main/java/com/workiva/frugal/protocol/FProtocol.java
@@ -122,6 +122,11 @@ public class FProtocol extends TProtocol {
     }
 
     @Override
+    public int getMinSerializedSize(byte type) throws TException {
+        return wrapped.getMinSerializedSize(type);
+    }
+
+    @Override
     public void writeMessageBegin(TMessage tMessage) throws TException {
         wrapped.writeMessageBegin(tMessage);
     }

--- a/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FNatsServer.java
@@ -24,6 +24,7 @@ import io.nats.client.MessageHandler;
 import org.apache.thrift.TException;
 import org.apache.thrift.transport.TMemoryInputTransport;
 import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -402,11 +403,12 @@ public class FNatsServer implements FServer {
             eventHandler.onRequestStarted(ephemeralProperties);
 
             try {
-                // Read and process frame (exclude first 4 bytes which represent frame size).
-                TTransport input = new TMemoryInputTransport(frameBytes, 4, frameBytes.length);
-                TMemoryOutputBuffer output = new TMemoryOutputBuffer(NATS_MAX_MESSAGE_SIZE);
-
+                TMemoryOutputBuffer output = null;
                 try {
+                    // Read and process frame (exclude first 4 bytes which represent frame size).
+                    TTransport input = new TMemoryInputTransport(frameBytes, 4, frameBytes.length);
+                    output = new TMemoryOutputBuffer(NATS_MAX_MESSAGE_SIZE);
+
                     FProtocol inputProto = inputProtoFactory.getProtocol(input);
                     inputProto.setEphemeralProperties(ephemeralProperties);
                     FProtocol outputProto = outputProtoFactory.getProtocol(output);
@@ -416,8 +418,10 @@ public class FNatsServer implements FServer {
                     return;
                 } catch (RuntimeException e) {
                     try {
-                        conn.publish(reply, output.getWriteBytes());
-                        conn.flush(Duration.ofSeconds(60));
+                        if(output != null) {
+                            conn.publish(reply, output.getWriteBytes());
+                            conn.flush(Duration.ofSeconds(60));
+                        }
                     } catch (Exception ignored) {
                     }
                     return;

--- a/lib/java/src/main/java/com/workiva/frugal/server/FSimpleServer.java
+++ b/lib/java/src/main/java/com/workiva/frugal/server/FSimpleServer.java
@@ -17,10 +17,10 @@ import com.workiva.frugal.processor.FProcessor;
 import com.workiva.frugal.protocol.FProtocol;
 import com.workiva.frugal.protocol.FProtocolFactory;
 import org.apache.thrift.TException;
-import org.apache.thrift.transport.TFramedTransport;
 import org.apache.thrift.transport.TServerTransport;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+import org.apache.thrift.transport.layered.TFramedTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/lib/java/src/main/java/com/workiva/frugal/transport/TFramedTransport.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/TFramedTransport.java
@@ -15,6 +15,7 @@ package com.workiva.frugal.transport;
 
 import com.workiva.frugal.util.ProtocolUtils;
 import org.apache.thrift.TByteArrayOutputStream;
+import org.apache.thrift.TConfiguration;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.transport.TTransportFactory;
@@ -123,5 +124,20 @@ class TFramedTransport extends TTransport {
         transport.write(writei32buf, 0, 4);
         transport.write(buf, 0, len);
         transport.flush();
+    }
+
+    @Override
+    public TConfiguration getConfiguration() {
+        return transport.getConfiguration();
+    }
+
+    @Override
+    public void updateKnownMessageSize(long size) throws TTransportException {
+        transport.updateKnownMessageSize(size);
+    }
+
+    @Override
+    public void checkReadBytesAvailable(long numBytes) throws TTransportException {
+        transport.checkReadBytesAvailable(numBytes);
     }
 }

--- a/lib/java/src/main/java/com/workiva/frugal/transport/TMemoryOutputBuffer.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/TMemoryOutputBuffer.java
@@ -28,16 +28,17 @@ import java.io.ByteArrayOutputStream;
  * The size of this buffer is optionally limited. If limited, writes which cause the buffer to exceed
  * its size limit throw an TTransportException with code TTransportExceptionType.REQUEST_TOO_LARGE.
  */
-public class TMemoryOutputBuffer extends TEndpointTransport {
+public class TMemoryOutputBuffer extends TTransport {
 
     private ByteArrayOutputStream buffer;
     private final int limit;
     private final byte[] emptyFrameSize = new byte[4];
+    private static final TConfiguration configuration = new TConfiguration();
 
     /**
      * Create an TMemoryOutputBuffer with no buffer size limit.
      */
-    public TMemoryOutputBuffer() throws TTransportException {
+    public TMemoryOutputBuffer() {
         this(0);
     }
 
@@ -47,11 +48,9 @@ public class TMemoryOutputBuffer extends TEndpointTransport {
      * @param size the size limit of the buffer. Note: If <code>size</code> is non-positive,
      *             no limit will be enforced on the buffer.
      */
-    public TMemoryOutputBuffer(int size) throws TTransportException {
-        super(new TConfiguration());
+    public TMemoryOutputBuffer(int size) {
         buffer = new ByteArrayOutputStream(size);
         limit = size;
-        updateKnownMessageSize(size);
         init();
     }
 
@@ -91,6 +90,23 @@ public class TMemoryOutputBuffer extends TEndpointTransport {
                     TTransportExceptionType.REQUEST_TOO_LARGE, String.format("Buffer size reached (%d)", limit));
         }
         buffer.write(buf, off, len);
+    }
+
+    @Override
+    public TConfiguration getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public void updateKnownMessageSize(long size) {
+        throw new UnsupportedOperationException(
+            "This method is not supported for an out only transport");
+    }
+
+    @Override
+    public void checkReadBytesAvailable(long numBytes) {
+        throw new UnsupportedOperationException(
+            "This method is not supported for an out only transport");
     }
 
     /**

--- a/lib/java/src/main/java/com/workiva/frugal/transport/TMemoryOutputBuffer.java
+++ b/lib/java/src/main/java/com/workiva/frugal/transport/TMemoryOutputBuffer.java
@@ -15,6 +15,9 @@ package com.workiva.frugal.transport;
 
 import com.workiva.frugal.exception.TTransportExceptionType;
 import com.workiva.frugal.util.ProtocolUtils;
+
+import org.apache.thrift.TConfiguration;
+import org.apache.thrift.transport.TEndpointTransport;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 
@@ -25,7 +28,7 @@ import java.io.ByteArrayOutputStream;
  * The size of this buffer is optionally limited. If limited, writes which cause the buffer to exceed
  * its size limit throw an TTransportException with code TTransportExceptionType.REQUEST_TOO_LARGE.
  */
-public class TMemoryOutputBuffer extends TTransport {
+public class TMemoryOutputBuffer extends TEndpointTransport {
 
     private ByteArrayOutputStream buffer;
     private final int limit;
@@ -34,7 +37,7 @@ public class TMemoryOutputBuffer extends TTransport {
     /**
      * Create an TMemoryOutputBuffer with no buffer size limit.
      */
-    public TMemoryOutputBuffer() {
+    public TMemoryOutputBuffer() throws TTransportException {
         this(0);
     }
 
@@ -44,9 +47,11 @@ public class TMemoryOutputBuffer extends TTransport {
      * @param size the size limit of the buffer. Note: If <code>size</code> is non-positive,
      *             no limit will be enforced on the buffer.
      */
-    public TMemoryOutputBuffer(int size) {
-        buffer = new ByteArrayOutputStream();
+    public TMemoryOutputBuffer(int size) throws TTransportException {
+        super(new TConfiguration());
+        buffer = new ByteArrayOutputStream(size);
         limit = size;
+        updateKnownMessageSize(size);
         init();
     }
 

--- a/lib/java/src/test/java/com/workiva/frugal/transport/TMemoryOutputBufferTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/transport/TMemoryOutputBufferTest.java
@@ -20,7 +20,7 @@ public class TMemoryOutputBufferTest {
     private byte[] emptyFrameSize = new byte[4];
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         buffer = new TMemoryOutputBuffer(10);
     }
 

--- a/lib/java/src/test/java/com/workiva/frugal/transport/TMemoryOutputBufferTest.java
+++ b/lib/java/src/test/java/com/workiva/frugal/transport/TMemoryOutputBufferTest.java
@@ -20,7 +20,7 @@ public class TMemoryOutputBufferTest {
     private byte[] emptyFrameSize = new byte[4];
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         buffer = new TMemoryOutputBuffer(10);
     }
 

--- a/test/integration/java/frugal-integration-test/pom.xml
+++ b/test/integration/java/frugal-integration-test/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.13.0</version>
+            <version>0.14.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
### Story:
There were some change to some of the Thrift Interfaces to add some additional method. 

* FProtocol is mostly a straight pass through to TProtocol
* TFramedTransport is a straight pass through to TTransport
* TMemoryOutputBuffer on the other hand was rebased to TEndpointTransport to support the default implementations of the missing abstract methods on TTransport, this also caused some exception handle propagation to FNatsServer


### Acceptance Criteria:
- [x] Code has been tested and results documented
- [x] Unit tests have been updated
- [x] Updates to documentation if necessary
- [x] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

#### Reviewers:
@Workiva/service-platform