### PR TITLE
MEX-124: Frugal - Upgrade async-nats-client to 2.x

### DIFF
--- a/lib/python/frugal/aio/server/nats_server.py
+++ b/lib/python/frugal/aio/server/nats_server.py
@@ -41,13 +41,13 @@ class FNatsServer(FServer):
         self._processor = processor
         self._protocol_factory = protocol_factory
         self._queue = queue
-        self._sub_ids = []
+        self._subs = []
 
     async def serve(self):
         """Subscribe to the server subject and queue."""
-        self._sub_ids = []
+        self._subs = []
         for subject in self._subjects:
-            self._sub_ids.append(await self._nats_client.subscribe_async(
+            self._subs.append(await self._nats_client.subscribe(
                 subject,
                 queue=self._queue,
                 cb=self._on_message_callback,
@@ -56,8 +56,8 @@ class FNatsServer(FServer):
 
     async def stop(self):
         """Unsubscribe from the server subject."""
-        for sid in self._sub_ids:
-            await self._nats_client.unsubscribe(sid)
+        for sub in self._subs:
+            await sub.unsubscribe()
 
     async def _on_message_callback(self, message):
         """The function to be executed when a message is received."""

--- a/lib/python/frugal/aio/transport/nats_scope_transport.py
+++ b/lib/python/frugal/aio/transport/nats_scope_transport.py
@@ -121,7 +121,7 @@ class FNatsSubscriberTransport(FSubscriberTransport):
         self._nats_client = nats_client
         self._queue = queue
         self._is_subscribed = False
-        self._sub_id = None
+        self._subscription = None
 
     async def subscribe(self, topic: str, callback):
         """
@@ -145,7 +145,7 @@ class FNatsSubscriberTransport(FSubscriberTransport):
                 ret = await ret
             return ret
 
-        self._sub_id = await self._nats_client.subscribe_async(
+        self._subscription = await self._nats_client.subscribe(
             'frugal.{0}'.format(topic),
             queue=self._queue,
             cb=nats_callback,
@@ -156,8 +156,8 @@ class FNatsSubscriberTransport(FSubscriberTransport):
         """
         Unsubscribe from the currently subscribed topic.
         """
-        await self._nats_client.unsubscribe(self._sub_id)
-        self._sub_id = None
+        await self._subscription.unsubscribe()
+        self._subscription = None
         self._is_subscribed = False
 
     def is_subscribed(self) -> bool:

--- a/lib/python/requirements_dev_asyncio.txt
+++ b/lib/python/requirements_dev_asyncio.txt
@@ -1,6 +1,6 @@
 aiohttp==3.6.3
 aiostomp==1.6.2
-asyncio-nats-client==0.11.5
+nats-py>=2,<3
 async-timeout>=2.0.1,<4
 
 -r requirements_dev_common.txt

--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -31,7 +31,7 @@ setup(
         'asyncio': [
             'aiohttp>=3.0.9,<3.8.0',
             'aiostomp==1.6.2',
-            'asyncio-nats-client>=0.11.4,<1',
+            'nats-py>=2,<3',
             'async-timeout>=2.0.1,<4',
         ],
         'gae': ['webapp2==2.5.2'],


### PR DESCRIPTION
Story:

For python 3.10 support it was requested that we upgrade from async-nats-client v0.11.5 to nats-py v2.0 or higher
Reviewers:

https://github.com/orgs/Workiva/teams/service-platform