### PR TITLE
Revert slf4j v2 upgrade and skip major version upgrades in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,6 +19,10 @@ updates:
     commit-message:
       prefix: "go-tool: "
   - package-ecosystem: "maven"
+    ignore:
+      # Ignore all semver major upgrades
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
     directory: "/lib/java"
     schedule:
       interval: "weekly"
@@ -28,6 +32,10 @@ updates:
     commit-message:
       prefix: "java-lib: "
   - package-ecosystem: "maven"
+    ignore:
+      # Ignore all semver major upgrades
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
     directory: "/examples/java"
     schedule:
       interval: "weekly"
@@ -46,6 +54,10 @@ updates:
     commit-message:
       prefix: "go-exam: "
   - package-ecosystem: "maven"
+    ignore:
+      # Ignore all semver major upgrades
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
     directory: "/test/integration/java/frugal-integration-test"
     schedule:
       interval: "weekly"

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -5,6 +5,11 @@
     <artifactId>examples</artifactId>
     <version>3.16.2</version>
 
+
+    <properties>
+        <slf4j.version>1.7.36</slf4j.version>
+    </properties>
+
     <repositories>
         <repository>
             <id>central</id>
@@ -32,12 +37,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.0</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.0</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>

--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -14,6 +14,7 @@
         <java.version>1.8</java.version>
         <jmh.version>1.35</jmh.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <slf4j.version>1.7.36</slf4j.version>
     </properties>
 
     <licenses>
@@ -81,7 +82,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.0</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -104,7 +105,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.0</version>
+            <version>${slf4j.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/test/integration/java/frugal-integration-test/pom.xml
+++ b/test/integration/java/frugal-integration-test/pom.xml
@@ -9,6 +9,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <slf4j.version>1.7.36</slf4j.version>
     </properties>
 
     <repositories>
@@ -53,7 +54,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.0</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
### Story:
Breaking changes in slf4j v2 broke consumers, e.g. https://github.com/Workiva/markup-service/pull/1009. Revert back to v1 and prevent automated major version bumps by dependabot.

### Acceptance Criteria:
- [x] Code has been tested and results documented
- [NA] Unit tests have been updated
- [NA] Updates to documentation if necessary
- [x] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

### How To Test:
Verify that the version in the build artifacts is 1.7.36 again.

```
[patkujawa@wf16264 Fri Sep  9 11:46:33 MDT 2022] ~/workspace/frugal (revert_slf4j_v2)
❯ mvn dependency:tree -Dincludes=org.slf4j -f lib/java/pom.xml
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO]
[INFO] -------------------------< com.workiva:frugal >-------------------------
[INFO] Building com.workiva:frugal 3.16.2
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ frugal ---
[WARNING] The artifact xml-apis:xml-apis:jar:2.0.2 has been relocated to xml-apis:xml-apis:jar:1.0.b2
[INFO] com.workiva:frugal:jar:3.16.2
[INFO] +- org.slf4j:slf4j-api:jar:1.7.36:compile
[INFO] \- org.slf4j:slf4j-simple:jar:1.7.36:provided
```

#### Reviewers:
@Workiva/service-platform
