### PR TITLE
w_common v2 rollout - 1 of 2 raise max

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -198,7 +198,7 @@ func (g *Generator) addToPubspec(dir string) error {
 			Hosted:  hostedDep{Name: "thrift", URL: "https://pub.workiva.org"},
 			Version: "^0.0.10",
 		},
-		"w_common": "^1.20.2",
+		"w_common": ">=1.20.2 <3.0.0",
 	}
 
 	if g.Frugal.ContainsFrugalDefinitions() {

--- a/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
@@ -23,4 +23,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.10
-  w_common: ^1.20.2
+  w_common: '>=1.20.2 <3.0.0'

--- a/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
@@ -23,4 +23,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.10
-  w_common: ^1.20.2
+  w_common: '>=1.20.2 <3.0.0'

--- a/examples/dart/gen-dart/v1_music/pubspec.yaml
+++ b/examples/dart/gen-dart/v1_music/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.10
-  w_common: ^1.20.2
+  w_common: '>=1.20.2 <3.0.0'

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.10
   uuid: '>=0.5.0 <4.0.0'
-  w_common: ^1.20.1
+  w_common: '>=1.20.1 <3.0.0'
   w_transport: ^4.0.0
 description: A frugal client for Dart
 dev_dependencies:

--- a/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
+++ b/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.10
-  w_common: ^1.20.2
+  w_common: '>=1.20.2 <3.0.0'


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This update will allow w_common 2x by raising the max to < 3.0.0
It also raises the minimum of a few packages that addressed w_common
v2 breaking changes. In order to be compatible with w_common v2, we
need at least these versions.
  dart_dev_workiva 1.5.9
  wdesk_sdk 3.7.8
  w_router 1.1.15
  w_flux 2.10.21
  w_module 2.0.30
  bigsky_rest_files 1.33.10

In addition, sass compilation was moved out of w_common into a 
w_common_tools package, so if it detects that the repo might need it, 
it might add a dependency on w_common_tools.

Lastly, app/pubspec.lock files may have needed to be updated to get 
those minimum versions of packages

For more info, reach out to `#support-frontend-architecture` on Slack.

[_Created by Sourcegraph batch change `Workiva/w_common_v2`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/w_common_v2)