### PR TITLE
w_common v2 rollout - 2 of 2 raise min

### DIFF
--- a/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
@@ -23,4 +23,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.10
-  w_common: '>=1.20.2 <3.0.0'
+  w_common: '^2.0.0'

--- a/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
@@ -23,4 +23,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.10
-  w_common: '>=1.20.2 <3.0.0'
+  w_common: '^2.0.0'

--- a/examples/dart/gen-dart/v1_music/pubspec.yaml
+++ b/examples/dart/gen-dart/v1_music/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.10
-  w_common: '>=1.20.2 <3.0.0'
+  w_common: '^2.0.0'

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.10
   uuid: '>=0.5.0 <4.0.0'
-  w_common: '>=1.20.1 <3.0.0'
+  w_common: '^2.0.0'
   w_transport: ^4.0.0
 description: A frugal client for Dart
 dev_dependencies:

--- a/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
+++ b/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.10
-  w_common: '>=1.20.2 <3.0.0'
+  w_common: '^2.0.0'


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This update will require w_common 2x by raising the min to ^2.0.0
All consumers have already been updated to allow w_common 2 in the
step 1 batch, so this PR should be a no-op.

For more info, reach out to `#support-frontend-architecture` on Slack.

[_Created by Sourcegraph batch change `Workiva/w_common_v2_raise_min`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/w_common_v2_raise_min)