### PR TITLE
SPLAT-4559: Pin importlib-metadata==4.13.0

### DIFF
--- a/scripts/smithy/smithy_python.sh
+++ b/scripts/smithy/smithy_python.sh
@@ -18,7 +18,7 @@ deactivate
 
 virtualenv -p /usr/bin/python3 /tmp/frugal-py3
 source /tmp/frugal-py3/bin/activate
-pip install -U pip setuptools==39.0.1
+pip install -U pip setuptools==39.0.1 importlib-metadata==4.13.0
 cd $FRUGAL_HOME/lib/python
 make deps-asyncio
 make xunit-py3


### PR DESCRIPTION
# [SPLAT-4559](https://jira.atl.workiva.net/browse/SPLAT-4559)
![Issue Status](https://h.inf-dev.workiva.org/s/wk-backend/jira/status/SPLAT-4559)

### Story:
importlib-metadata 5.0.0 deprecated EntryPoints (https://exerror.com/entrypoints-object-has-no-attribute-get/#:~:text=facing%20this%20error.-,To%20Fix%20'EntryPoints'%20object%20has%20no%20attribute%20'get',Your%20error%20will%20be%20solved.)

Pinning supported version for now.

### Acceptance Criteria:
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
N/A

### How To Test:
CI Passes

### My Test Results:
N/A

#### Reviewers:
@Workiva/service-platform
