### PR TITLE
Remove gson dependency

### DIFF
--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -75,11 +75,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.9.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>

--- a/test/integration/java/frugal-integration-test/pom.xml
+++ b/test/integration/java/frugal-integration-test/pom.xml
@@ -32,11 +32,6 @@
             <version>2.16.1</version>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.9.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
             <version>0.14.2</version>


### PR DESCRIPTION
### Story:
We had a few people with projects that included frugal only as a secondary dependency complain that their builds were failing due to gson being a tertiary dependency, but it seems we aren't actually using it anywhere. 

Removing.

#### Reviewers:
@Workiva/service-platform
