### PR TITLE
TEST: Compatibility with pkg:http ^0.13.0

### DIFF
--- a/test/integration/dart/test_client/pubspec.yaml
+++ b/test/integration/dart/test_client/pubspec.yaml
@@ -11,5 +11,6 @@ dependency_overrides:
   frugal:
     path:  ../../../../lib/dart
 
+  http: '>=0.13.0 <0.13.4'
 environment:
   sdk: '>=2.11.0 <3.0.0'


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies!
Read more details at https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

The purpose of this batch is to find packages that depend on the `http`
package and add a dependency override to force resolution to the next major
version (^0.13.0) in order to test for compatibility.

**There is no immediate action required on your part.**

If CI passes, we will consider that verification that the packages in this
repo are compatible with `pkg:http ^0.13.0`. Otherwise, the FEF team will
investigate the CI failure to determine if any action is needed to unblock
this upgrade.

For more info, reach out to `#support-frontend-architecture` on Slack.

[_Created by Sourcegraph batch change `Workiva/test2_http_13`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test2_http_13)