### PR TITLE
Add split mock versions, move py2 reqs file

### DIFF
--- a/lib/python/Makefile
+++ b/lib/python/Makefile
@@ -20,7 +20,7 @@ distclean: clean
 	rm -rf $(LIBS_DIR)
 
 deps-py2:
-	$(PIP) install -Ur requirements_python_2.txt
+	$(PIP) install -Ur py2_reqs/requirements_python_2.txt
 
 deps-py3:
 	$(PIP) install -Ur requirements_python_3.txt

--- a/lib/python/py2_reqs/requirements_python_2.txt
+++ b/lib/python/py2_reqs/requirements_python_2.txt
@@ -1,4 +1,4 @@
 coverage==5.6b1
 mock==3.0.5
 
--r requirements_dev_common.txt
+-r ../requirements_dev_common.txt

--- a/lib/python/py2_reqs/requirements_python_2.txt
+++ b/lib/python/py2_reqs/requirements_python_2.txt
@@ -1,3 +1,4 @@
 coverage==5.6b1
+mock==3.0.5
 
 -r requirements_dev_common.txt

--- a/lib/python/requirements_dev_common.txt
+++ b/lib/python/requirements_dev_common.txt
@@ -1,7 +1,6 @@
 nose==1.3.7
 nose-exclude==0.5.0
 rednose==1.3.0
-mock==3.0.5
 flake8==3.9.2
 
 -r requirements.txt

--- a/lib/python/requirements_python_3.txt
+++ b/lib/python/requirements_python_3.txt
@@ -1,3 +1,4 @@
-coverage==7.0.0
+coverage==7.0.1
+mock==5.0.0
 
 -r requirements_dev_common.txt


### PR DESCRIPTION
### Story:
Python 2 compatibility surfacing in newer versions of packages. Add split supported mock version, move req file for python 2 to directory to avoid dependabot bumps.

### Acceptance Criteria:
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

#### Reviewers:
@Workiva/service-platform @ivanvandessel-wk 
