### PR TITLE
update to ignore dependabot updates for python2 library dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -79,6 +79,12 @@ updates:
     directory: "/lib/python"
     schedule:
       interval: "weekly"
+     ignore:
+      # ignore all updates for version python2 libraries
+      - dependency-name: "coverage"
+        versions: [ "5.6b1", "5.5b1" ]
+      - dependency-name: "mock"
+        versions: [ "3.0.5", "3.0.0"]
     target-branch: "develop"
     reviewers:
       - "Workiva/service-platform"


### PR DESCRIPTION
### Story:
Get dependabot to ignore updating dependencies for python2 libraries that can not be moved forward

### Acceptance Criteria:
- [x] Verify Testing on skynet passed
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
python2 dependent libraries can not be updated like python3 can so we split them out and I am ignoring those versions in dependabot yaml file

### How To Test:
tests in skynet pass

#### Reviewers:
@Workiva/service-platform
