### PR TITLE
Allow newer build dependencies

### DIFF
--- a/examples/dart/pubspec.yaml
+++ b/examples/dart/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     path: gen-dart/v1_music
 dev_dependencies:
   build_runner: '>=1.6.2 <3.0.0'
-  build_web_compilers: '>=1.2.0 <3.0.0'
+  build_web_compilers: '>=1.2.0 <4.0.0'
 environment:
   sdk: ^2.11.0
 name: client_example


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This PR gets us closer to unblocking analyzer 2+ by allowing these new versions
once we upgrade built_redux, over_react, and handle json_serializable.

It raises the maximum for these packages:
- build_web_compilers
- build_test
- build_runner

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/newer_build_dev_deps`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/newer_build_dev_deps)