### PR TITLE
Prepare for dart_dev v4.0.0

### DIFF
--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   w_transport: ^4.0.0
 description: A frugal client for Dart
 dev_dependencies:
-  dart_dev: ^3.0.0
+  dart_dev: '>=3.0.0 <5.0.0'
   dart_style: '>=1.3.1 <3.0.0'
   meta: ^1.6.0
   mockito: ^5.0.0


### PR DESCRIPTION
This PR widens the allowable version ranges of dart_dev so that all repos at Workiva can consume dart_dev 4.0.0 without updating all repositories in lock step.
For more info, reach out to Timothy Steward or `#link23-state-of-the-dart-jam` on Slack.

[_Created by Sourcegraph batch change `Workiva/dart_dev_widen_ranges_v4`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_dev_widen_ranges_v4)