### PR TITLE
w_common v3 rollout - 1 of 2 raise max

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -198,7 +198,7 @@ func (g *Generator) addToPubspec(dir string) error {
 			Hosted:  hostedDep{Name: "thrift", URL: "https://pub.workiva.org"},
 			Version: "^0.0.10",
 		},
-		"w_common": "'>=2.0.0 <4.0.0'",
+		"w_common": ">=2.0.0 <4.0.0",
 	}
 
 	if g.Frugal.ContainsFrugalDefinitions() {

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -198,7 +198,7 @@ func (g *Generator) addToPubspec(dir string) error {
 			Hosted:  hostedDep{Name: "thrift", URL: "https://pub.workiva.org"},
 			Version: "^0.0.10",
 		},
-		"w_common": "^2.0.0",
+		"w_common": "'>=2.0.0 <4.0.0'",
 	}
 
 	if g.Frugal.ContainsFrugalDefinitions() {

--- a/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
@@ -23,4 +23,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.10
-  w_common: ^2.0.0
+  w_common: '>=2.0.0 <4.0.0'

--- a/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
@@ -23,4 +23,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.10
-  w_common: ^2.0.0
+  w_common: '>=2.0.0 <4.0.0'

--- a/examples/dart/gen-dart/v1_music/pubspec.yaml
+++ b/examples/dart/gen-dart/v1_music/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.10
-  w_common: ^2.0.0
+  w_common: '>=2.0.0 <4.0.0'

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.10
   uuid: '>=0.5.0 <4.0.0'
-  w_common: ^2.0.0
+  w_common: '>=2.0.0 <4.0.0'
   w_transport: ^4.0.0
 description: A frugal client for Dart
 dev_dependencies:

--- a/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
+++ b/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
       name: thrift
       url: https://pub.workiva.org
     version: ^0.0.10
-  w_common: ^2.0.0
+  w_common: '>=2.0.0 <4.0.0'


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies!

This update will allow the nullsafe versions of w_common 3x 
by raising the max to < 4.0.0

For more info, visit `#lang-dart` in Slack.

[_Created by Sourcegraph batch change `Workiva/w_common_v3`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/w_common_v3)