### PR TITLE
Revert "java-lib: bump jnats from 2.16.8 to 2.16.9 in /lib/java"

### DIFF
--- a/lib/java/pom.xml
+++ b/lib/java/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>io.nats</groupId>
             <artifactId>jnats</artifactId>
-            <version>2.16.9</version>
+            <version>2.16.8</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Reverts Workiva/frugal#2148

There was an issue in jnats which is fixed in this PR that has yet to be released:

https://github.com/nats-io/nats.java/pull/874