### PR TITLE
skip broken version for jnats

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -37,7 +37,7 @@ updates:
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "io.nats:jnats"
-        // Issue fixed in https://github.com/nats-io/nats.java/pull/874
+        # Issue fixed in https://github.com/nats-io/nats.java/pull/874
         versions: ["2.16.9"]
     directory: "/examples/java"
     schedule:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -36,6 +36,8 @@ updates:
       # Ignore all semver major upgrades
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
+      - dependency-name: "io.nats:jnats"
+        versions: ["2.16.9"]
     directory: "/examples/java"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -37,6 +37,7 @@ updates:
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "io.nats:jnats"
+        // Issue fixed in https://github.com/nats-io/nats.java/pull/874
         versions: ["2.16.9"]
     directory: "/examples/java"
     schedule:


### PR DESCRIPTION
Java lib consumption is broken for 3.16.16 due to a jnats issue.

The upstream fix is in https://github.com/nats-io/nats.java/pull/874 but not released yet. Tell dependabot to skip this version.