### PR TITLE
Update dart dependencies

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -193,7 +193,7 @@ func (g *Generator) addToPubspec(dir string) error {
 
 	deps := map[interface{}]interface{}{
 		"collection": "^1.14.12",
-		"logging":    ">=0.11.2 <2.0.0",
+		"logging":    "^1.0.0",
 		"thrift": dep{
 			Hosted:  hostedDep{Name: "thrift", URL: "https://pub.workiva.org"},
 			Version: "^0.0.10",

--- a/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
       name: frugal
       url: https://pub.workiva.org
     version: ^3.9.7
-  logging: '>=0.11.2 <2.0.0'
+  logging: ^1.0.0
   some_vendored_place:
     hosted:
       name: some_vendored_place

--- a/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
       name: frugal
       url: https://pub.workiva.org
     version: ^3.16.18
-  logging: '>=0.11.2 <2.0.0'
+  logging: ^1.0.0
   some_vendored_place:
     hosted:
       name: some_vendored_place

--- a/examples/dart/gen-dart/v1_music/pubspec.yaml
+++ b/examples/dart/gen-dart/v1_music/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
       name: frugal
       url: https://pub.workiva.org
     version: ^3.16.18
-  logging: '>=0.11.2 <2.0.0'
+  logging: ^1.0.0
   thrift:
     hosted:
       name: thrift

--- a/examples/dart/pubspec.yaml
+++ b/examples/dart/pubspec.yaml
@@ -4,7 +4,7 @@ dependencies:
       name: frugal
       url: https://pub.workiva.org
     version: ^3.16.18
-  logging: '>=0.11.2 <2.0.0'
+  logging: ^1.0.0
   thrift:
     hosted:
       name: thrift

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 dependencies:
-  logging: '>=0.11.2 <2.0.0'
+  logging: ^1.0.0
   thrift:
     hosted:
       name: thrift

--- a/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
+++ b/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
       name: frugal
       url: https://pub.workiva.org
     version: ^3.16.18
-  logging: '>=0.11.2 <2.0.0'
+  logging: ^1.0.0
   thrift:
     hosted:
       name: thrift


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

```
  # Raise minimums for package versions that we already resolve to
  pubspec_codemod raise-min built_redux 8.0.0 --recursive
  pubspec_codemod raise-min logging 1.0.0 --recursive
  pubspec_codemod raise-min glob 2.0.0 --recursive
  pubspec_codemod raise-min yaml 3.0.0 --recursive
  pubspec_codemod raise-min archive 3.0.0 --recursive
  pubspec_codemod raise-min xml 5.0.0 --recursive

  # allow next versions (io 1 and memoize 3)
  pubspec_codemod raise-max io 2.0.0 --recursive
  pubspec_codemod raise-max memoize 4.0.0 --recursive
   
  # Allow the nullsafe version of intl and color
  pubspec_codemod raise-min intl 0.17.0 --recursive
  pubspec_codemod raise-max intl 0.19.0 --recursive
  pubspec_codemod raise-max color 4.0.0 --recursive
```

A passing CI is sufficient QA (means dependencies resolve and tests run and pass).

For more info, reach out to Rob Becker in `#support-frontend-dx`

[_Created by Sourcegraph batch change `Workiva/update_deps_april_23`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/update_deps_april_23)