### PR TITLE
Consume messaging-docker-images 0.1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.15 as build
+FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.16 as build
 
 RUN yum update -y && \
     yum upgrade -y && \

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -7,7 +7,7 @@ run:  # local tests only, never run in Skynet
   on-pull-request: false
 
 contact: messaging@workiva.com
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.15
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.16
 
 env:
   - IN_SKYNET_CLI=true
@@ -40,7 +40,7 @@ requires:
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.15
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.16
 env:
   - PYTHONIOENCODING=utf-8
 


### PR DESCRIPTION
Consume [messaging-docker-images 0.1.16](https://github.com/Workiva/messaging-docker-images/releases/tag/0.1.16)

Pull Requests included in release:
* Patch changes:
	* [SKREAMS-2447: Update Go](https://github.com/Workiva/messaging-docker-images/pull/80)


Requested by: @rm-astro-wf
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5198026715955200/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5198026715955200/?repo_name=Workiva%2Ffrugal&pull_number=2178)