### PR TITLE
Revert dependabot changes due to public repo

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,10 +1,4 @@
 version: 2
-registries:
-  maven-repository-workivaeast-jfrog-io-workivaeast-maven-prod:
-    type: maven-repository
-    url: https://workivaeast.jfrog.io/workivaeast/maven-prod
-    username: dependabot
-    password: "${{secrets.MAVEN_REPOSITORY_WORKIVAEAST_JFROG_IO_WORKIVAEAST_MAVEN_PROD_PASSWORD}}"
 updates:
   - package-ecosystem: "gomod"
     directory: "/lib/go"
@@ -25,8 +19,6 @@ updates:
     commit-message:
       prefix: "go-tool: "
   - package-ecosystem: "maven"
-    registries:
-    - maven-repository-workivaeast-jfrog-io-workivaeast-maven-prod
     ignore:
       # Ignore all semver major upgrades
       - dependency-name: "*"
@@ -40,8 +32,6 @@ updates:
     commit-message:
       prefix: "java-lib: "
   - package-ecosystem: "maven"
-    registries:
-    - maven-repository-workivaeast-jfrog-io-workivaeast-maven-prod
     ignore:
       # Ignore all semver major upgrades
       - dependency-name: "*"
@@ -67,8 +57,6 @@ updates:
     commit-message:
       prefix: "go-exam: "
   - package-ecosystem: "maven"
-    registries:
-    - maven-repository-workivaeast-jfrog-io-workivaeast-maven-prod
     ignore:
       # Ignore all semver major upgrades
       - dependency-name: "*"


### PR DESCRIPTION
### Story:
Reset dependabot.yml back since frugal is private repo and cannot access internal secrets.

#### Reviewers:
@Workiva/service-platform
