### PR TITLE
 FW-626 make frugal docker image usable as for a standalone container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,5 @@ ARG BUILD_ARTIFACTS_TEST_RESULTS=/go/src/github.com/Workiva/frugal/test_results/
 
 FROM scratch
 COPY --from=build /go/src/github.com/Workiva/frugal/frugal /bin/frugal
-COPY --from=build /passwd.minimal /etc/passwd
 
 ENTRYPOINT ["frugal"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,11 +46,8 @@ ARG BUILD_ARTIFACTS_JAVA=/go/src/github.com/Workiva/frugal/frugal-*.jar
 ARG BUILD_ARTIFACTS_PUB=/go/src/github.com/Workiva/frugal/frugal.pub.tgz
 ARG BUILD_ARTIFACTS_TEST_RESULTS=/go/src/github.com/Workiva/frugal/test_results/*
 
-# make a simple etc/passwd file so the scratch image can run as nobody (not root)
-RUN echo "nobody:x:65534:65534:Nobody:/:" > /passwd.minimal
-
 FROM scratch
 COPY --from=build /go/src/github.com/Workiva/frugal/frugal /bin/frugal
 COPY --from=build /passwd.minimal /etc/passwd
-USER nobody
+
 ENTRYPOINT ["frugal"]


### PR DESCRIPTION
### Story:
Trying to use the frugal docker image by mounting in a folder with an IDL file to generate an sdk from, but the nobody permission makes this image pretty cumbersome to actually use. Since this image is for a CLI tool with nothing else on the image and it's not a deployable service, maybe the restrictive nobody user could be removed?

### Acceptance Criteria:
- [ x ] Code has been tested and results documented
- [ x ] Unit tests have been updated
- [ x ] Updates to documentation if necessary
- [ x ] Verify and document changes to any other Messaging components
- [ x ] Pull request made against the 'develop' branch, not master

### How To Test:
using the k8s locust music idl file, I ran the below and it failed
```bash
docker run --rm -it -v ${PWD}/idl:/idl drydock.workiva.net/workiva/frugal:latest-release -gen go:async /idl/music.frugal 
```

running with the user change successfully generates the frugal sdk
```bash
docker run --rm -it -v ${PWD}/idl:/idl drydock.workiva.net/workiva/frugal:adamknox-wf-patch-1-latest -gen go:async /idl/music.frugal 
```
### My Test Results:
```bash
➜  music-service git:(FW-527_update_examples) ✗ docker run --rm -it -v ${PWD}/idl:/idl drydock.workiva.net/workiva/frugal:latest -gen go:async /idl/music.frugal                                                                                                                                                                                                                           (4.215s) 2023-05-19 18:55:52 +0000

Failed to generate /idl/music.frugal:
        mkdir gen-go: permission denied
➜  music-service git:(FW-527_update_examples) ✗ docker run --rm -it -v ${PWD}/idl:/idl drydock.workiva.net/workiva/frugal:adamknox-wf-patch-1-latest -gen go:async /idl/music.frugal                                                                                                                                                                                                       (1.372s) 2023-05-19 18:55:57 +0000

➜  music-service git:(FW-527_update_examples) ✗   
```

#### Reviewers:
@Workiva/service-platform
