### PR TITLE
Fix async go compiler to use correct argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ unit_tests_py3.xml
 
 # Cross-compiled code
 pkg/
+
+# macos
+.DS_Store

--- a/compiler/generator/golang/generator.go
+++ b/compiler/generator/golang/generator.go
@@ -1975,7 +1975,7 @@ func (g *Generator) generateHandlerArgs(method *parser.Method) string {
 	return args
 }
 func (g *Generator) generateCallArgs(method *parser.Method) string {
-	args := "ctx"
+	args := "fctx"
 	for _, arg := range method.Arguments {
 		args += ", " + strings.ToLower(arg.Name)
 	}

--- a/compiler/testdata/expected/go/variety_async/f_foo_service.txt
+++ b/compiler/testdata/expected/go/variety_async/f_foo_service.txt
@@ -103,7 +103,7 @@ func (f *FFooClient) ping(fctx frugal.FContext) (err error) {
 func (f *FFooClient) PingAsync(fctx frugal.FContext) (err <-chan error) {
 	errC := make(chan error, 1)
 	go func() {
-		errC <- f.Ping(ctx)
+		errC <- f.Ping(fctx)
 	}()
 	return errC
 }
@@ -151,7 +151,7 @@ func (f *FFooClient) BlahAsync(fctx frugal.FContext, num int32, str string, even
 	errC := make(chan error, 1)
 	resultC := make(chan int64, 1)
 	go func() {
-		result, err := f.Blah(ctx, num, str, event)
+		result, err := f.Blah(fctx, num, str, event)
 		if err != nil {
 			errC <- err
 		} else {
@@ -185,7 +185,7 @@ func (f *FFooClient) oneWay(fctx frugal.FContext, id ID, req Request) (err error
 func (f *FFooClient) OneWayAsync(fctx frugal.FContext, id ID, req Request) (err <-chan error) {
 	errC := make(chan error, 1)
 	go func() {
-		errC <- f.OneWay(ctx, id, req)
+		errC <- f.OneWay(fctx, id, req)
 	}()
 	return errC
 }
@@ -226,7 +226,7 @@ func (f *FFooClient) BinMethodAsync(fctx frugal.FContext, bin []byte, str string
 	errC := make(chan error, 1)
 	resultC := make(chan []byte, 1)
 	go func() {
-		result, err := f.BinMethod(ctx, bin, str)
+		result, err := f.BinMethod(fctx, bin, str)
 		if err != nil {
 			errC <- err
 		} else {
@@ -269,7 +269,7 @@ func (f *FFooClient) ParamModifiersAsync(fctx frugal.FContext, opt_num int32, de
 	errC := make(chan error, 1)
 	resultC := make(chan int64, 1)
 	go func() {
-		result, err := f.ParamModifiers(ctx, opt_num, default_num, req_num)
+		result, err := f.ParamModifiers(fctx, opt_num, default_num, req_num)
 		if err != nil {
 			errC <- err
 		} else {
@@ -311,7 +311,7 @@ func (f *FFooClient) UnderlyingTypesTestAsync(fctx frugal.FContext, list_type []
 	errC := make(chan error, 1)
 	resultC := make(chan []ID, 1)
 	go func() {
-		result, err := f.UnderlyingTypesTest(ctx, list_type, set_type)
+		result, err := f.UnderlyingTypesTest(fctx, list_type, set_type)
 		if err != nil {
 			errC <- err
 		} else {
@@ -350,7 +350,7 @@ func (f *FFooClient) GetThingAsync(fctx frugal.FContext) (r <-chan *validStructs
 	errC := make(chan error, 1)
 	resultC := make(chan *validStructs.Thing, 1)
 	go func() {
-		result, err := f.GetThing(ctx)
+		result, err := f.GetThing(fctx)
 		if err != nil {
 			errC <- err
 		} else {
@@ -389,7 +389,7 @@ func (f *FFooClient) GetMyIntAsync(fctx frugal.FContext) (r <-chan ValidTypes.My
 	errC := make(chan error, 1)
 	resultC := make(chan ValidTypes.MyInt, 1)
 	go func() {
-		result, err := f.GetMyInt(ctx)
+		result, err := f.GetMyInt(fctx)
 		if err != nil {
 			errC <- err
 		} else {
@@ -430,7 +430,7 @@ func (f *FFooClient) UseSubdirStructAsync(fctx frugal.FContext, a *subdir_includ
 	errC := make(chan error, 1)
 	resultC := make(chan *subdir_include.A, 1)
 	go func() {
-		result, err := f.UseSubdirStruct(ctx, a)
+		result, err := f.UseSubdirStruct(fctx, a)
 		if err != nil {
 			errC <- err
 		} else {
@@ -471,7 +471,7 @@ func (f *FFooClient) SayHelloWithAsync(fctx frugal.FContext, newmessage string) 
 	errC := make(chan error, 1)
 	resultC := make(chan string, 1)
 	go func() {
-		result, err := f.SayHelloWith(ctx, newmessage)
+		result, err := f.SayHelloWith(fctx, newmessage)
 		if err != nil {
 			errC <- err
 		} else {
@@ -512,7 +512,7 @@ func (f *FFooClient) WhatDoYouSayAsync(fctx frugal.FContext, messageargs string)
 	errC := make(chan error, 1)
 	resultC := make(chan string, 1)
 	go func() {
-		result, err := f.WhatDoYouSay(ctx, messageargs)
+		result, err := f.WhatDoYouSay(fctx, messageargs)
 		if err != nil {
 			errC <- err
 		} else {
@@ -553,7 +553,7 @@ func (f *FFooClient) SayAgainAsync(fctx frugal.FContext, messageresult string) (
 	errC := make(chan error, 1)
 	resultC := make(chan string, 1)
 	go func() {
-		result, err := f.SayAgain(ctx, messageresult)
+		result, err := f.SayAgain(fctx, messageresult)
 		if err != nil {
 			errC <- err
 		} else {


### PR DESCRIPTION
### Story:

Compiling the music store example using the async go generator results in an `undeclared name: ctx` error:

```
func (f *FStoreClient) BuyAlbumAsync(fctx frugal.FContext, asin string, acct string) (r <-chan *Album, err <-chan error) {
	errC := make(chan error, 1)
	resultC := make(chan *Album, 1)
	go func() {
		result, err := f.BuyAlbum(ctx, asin, acct)  // undeclared name: ctx
```

Addresses issue https://github.com/Workiva/frugal/issues/1536

### Acceptance Criteria:

- [x] Code has been tested and results documented
- [x] Unit tests have been updated
- [x] Updates to documentation if necessary
- [x] Verify and document changes to any other Messaging components
- [x] Pull request made against the 'develop' branch, not master

#### Reviewers:
@Workiva/service-platform
