### PR TITLE
dart: Add FGeneratedArgsResultBase

### DIFF
--- a/lib/dart/lib/frugal.dart
+++ b/lib/dart/lib/frugal.dart
@@ -42,4 +42,5 @@ export 'src/frugal.dart'
         TMemoryOutputBuffer,
         TMemoryTransport,
         debugMiddleware;
+export 'src/frugal/f_generated.dart' show FGeneratedArgsResultBase;
 export 'src/frugal/f_packers.dart' show prepareMessage, processReply;

--- a/lib/dart/lib/src/frugal/f_generated.dart
+++ b/lib/dart/lib/src/frugal/f_generated.dart
@@ -1,0 +1,19 @@
+import 'package:thrift/thrift.dart';
+
+// Base class for use by generated args and result classes.
+class FGeneratedArgsResultBase extends TBase {
+  @override
+  dynamic getFieldValue(int fieldID) => throw UnsupportedError('');
+
+  @override
+  void setFieldValue(int fieldID, Object value) => throw UnsupportedError('');
+
+  @override
+  bool isSet(int fieldID) => throw UnsupportedError('');
+
+  @override
+  void read(TProtocol iprot) => throw UnsupportedError('');
+
+  @override
+  void write(TProtocol oprot) => throw UnsupportedError('');
+}


### PR DESCRIPTION
### Story:
Generated code for Dart is larger than desired.

This is the first commit of [this work-in-progress branch](https://github.com/Workiva/frugal/compare/develop...brettkail-wk:frugal:dart_smaller).  The final commit there states:
```
The _args/_result structs are only used internally by the generated
client methods, so those structs don't need the full generality of
generated structs, so:
1.  use use_null_for_unset, which produces smaller code
2.  omit methods that not used by the generated client methods
```
The intent of this PR is to merge+release this base class to simplify deployment.

### Acceptance Criteria:
- [x] Code has been tested and results documented
- [x] Unit tests have been updated
- ~~[ ] Updates to documentation if necessary~~
- ~~[ ] Verify and document changes to any other Messaging components~~
- [x] Pull request made against the 'develop' branch, not master

### Design Notes:
 builds on this commit by modifying 

### How To Test:
CI only (new/unused API only).

### My Test Results:
I manually tested the work-in-progress against a large internal application that currently produces ~270KLOC of Dart, and  the branch reduces that to ~220KLOC.

#### Reviewers:
@Workiva/service-platform
@robbecker-wf @kevinsookocheff-wf 