### PR TITLE
MEX-1042 broken builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.15 as build
 
-RUN yum update -y && \
-    yum upgrade -y && \
-    yum clean all && \
-    rm -rf /var/cache/yum
-
 ARG GIT_BRANCH
 ARG GIT_MERGE_BRANCH
 ARG GIT_SSH_KEY


### PR DESCRIPTION
The yum update was failing. We don't need this, since it's already called in the base image over at messaging-docker-images successfully so we should already be updated.

@Workiva/service-platform
