### PR TITLE
python: Remove dependency upper bound

### DIFF
--- a/lib/python/setup.py
+++ b/lib/python/setup.py
@@ -24,7 +24,7 @@ setup(
     install_requires=[
         'six>=1.10.0,<2',
         'thrift==0.13.0',
-        'requests>=2.12.5,<2.31.0',
+        'requests>=2.12.5,<3',
     ],
     extras_require={
         'tornado': ['nats-client==0.8.4'],


### PR DESCRIPTION
### Story:
I got the following error:
```
ERROR: Cannot install -r requirements.txt (line 3), -r requirements_http.txt (line 4), messaging-sdk and requests==2.31.0 because these package versions have conflicting dependencies.
```
There doesn't seem to be a reason to constrain the upper bound of the `requests` dependency so tightly.

### Acceptance Criteria:

### Design Notes:

### How To Test:

### My Test Results:

#### Reviewers:
@Workiva/service-platform
