### PR TITLE
Test compatibility with w_module 3 and w_transport 5

### DIFF
--- a/compiler/testdata/expected/dart.int64/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart.int64/include_vendor/pubspec.yaml
@@ -24,3 +24,7 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.10
   w_common: '>=2.0.0 <4.0.0'
+
+dependency_overrides:
+  w_module: ^3.0.0
+  w_transport: ^5.0.0

--- a/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
@@ -24,3 +24,7 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.10
   w_common: '>=2.0.0 <4.0.0'
+
+dependency_overrides:
+  w_module: ^3.0.0
+  w_transport: ^5.0.0

--- a/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
@@ -24,3 +24,7 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.14
   w_common: '>=2.0.0 <4.0.0'
+
+dependency_overrides:
+  w_module: ^3.0.0
+  w_transport: ^5.0.0

--- a/examples/dart/gen-dart/v1_music/pubspec.yaml
+++ b/examples/dart/gen-dart/v1_music/pubspec.yaml
@@ -17,3 +17,7 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.14
   w_common: '>=2.0.0 <4.0.0'
+
+dependency_overrides:
+  w_module: ^3.0.0
+  w_transport: ^5.0.0

--- a/examples/dart/pubspec.yaml
+++ b/examples/dart/pubspec.yaml
@@ -19,3 +19,7 @@ environment:
   sdk: ^2.11.0
 name: client_example
 version: 0.0.1
+
+dependency_overrides:
+  w_module: ^3.0.0
+  w_transport: ^5.0.0

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -27,4 +27,7 @@ version: 3.16.24
 
 dependency_overrides:
   w_module: ^3.0.0
-  w_transport: ^5.0.0
+  w_transport: 
+    git:
+      url: git@github.com:Workiva/w_transport.git
+      ref: tweak_collection_dep

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -24,3 +24,7 @@ homepage: https://github.com/Workiva/frugal/lib/dart
 name: frugal
 publish_to: https://pub.workiva.org
 version: 3.16.24
+
+dependency_overrides:
+  w_module: ^3.0.0
+  w_transport: ^5.0.0

--- a/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
+++ b/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
@@ -17,3 +17,7 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.14
   w_common: '>=2.0.0 <4.0.0'
+
+dependency_overrides:
+  w_module: ^3.0.0
+  w_transport: ^5.0.0

--- a/test/integration/dart/test_client/pubspec.yaml
+++ b/test/integration/dart/test_client/pubspec.yaml
@@ -11,5 +11,7 @@ dependency_overrides:
   frugal:
     path:  ../../../../lib/dart
 
+  w_module: ^3.0.0
+  w_transport: ^5.0.0
 environment:
   sdk: '>=2.11.0 <3.0.0'


### PR DESCRIPTION
DO NOT MERGE. This PR adds a dependency override to test whether this repo is compatible with w_module 3 and w_transport 5
For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/test_wmodule_wtransport`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test_wmodule_wtransport)