### PR TITLE
Rollout w_transport 5, w_module 3

### DIFF
--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
     version: ^0.0.10
   uuid: '>=0.5.0 <4.0.0'
   w_common: '>=2.0.0 <4.0.0'
-  w_transport: ^4.0.0
+  w_transport: '>=4.0.0 <6.0.0'
 dependency_validator:
   ignore:
   - mockito


### PR DESCRIPTION
This PR raises the max range in pubspec.yaml(s) to allow resolving to the new major releases w_module 3 and w_transport 5 This is batch 1, batch 2 will raise the minimums.
For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/rollout_transport_module_1`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/rollout_transport_module_1)