### PR TITLE
TEST: frugal nullsafe PR

### DIFF
--- a/compiler/testdata/expected/dart.int64/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart.int64/include_vendor/pubspec.yaml
@@ -24,3 +24,10 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.10
   w_common: '>=2.0.0 <4.0.0'
+
+dependency_overrides:
+  frugal:
+    git:
+      url: git@github.com:Workiva/frugal.git
+      ref: FEDX-142
+      path: lib/dart

--- a/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart.nullunset/include_vendor/pubspec.yaml
@@ -24,3 +24,10 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.10
   w_common: '>=2.0.0 <4.0.0'
+
+dependency_overrides:
+  frugal:
+    git:
+      url: git@github.com:Workiva/frugal.git
+      ref: FEDX-142
+      path: lib/dart

--- a/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
+++ b/compiler/testdata/expected/dart/include_vendor/pubspec.yaml
@@ -24,3 +24,10 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.14
   w_common: '>=2.0.0 <4.0.0'
+
+dependency_overrides:
+  frugal:
+    git:
+      url: git@github.com:Workiva/frugal.git
+      ref: FEDX-142
+      path: lib/dart

--- a/examples/dart/gen-dart/v1_music/pubspec.yaml
+++ b/examples/dart/gen-dart/v1_music/pubspec.yaml
@@ -17,3 +17,10 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.14
   w_common: '>=2.0.0 <4.0.0'
+
+dependency_overrides:
+  frugal:
+    git:
+      url: git@github.com:Workiva/frugal.git
+      ref: FEDX-142
+      path: lib/dart

--- a/examples/dart/pubspec.yaml
+++ b/examples/dart/pubspec.yaml
@@ -19,3 +19,10 @@ environment:
   sdk: ^2.11.0
 name: client_example
 version: 0.0.1
+
+dependency_overrides:
+  frugal:
+    git:
+      url: git@github.com:Workiva/frugal.git
+      ref: FEDX-142
+      path: lib/dart

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -24,3 +24,10 @@ homepage: https://github.com/Workiva/frugal/lib/dart
 name: frugal
 publish_to: https://pub.workiva.org
 version: 3.16.25
+
+dependency_overrides:
+  frugal:
+    git:
+      url: git@github.com:Workiva/frugal.git
+      ref: FEDX-142
+      path: lib/dart

--- a/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
+++ b/test/integration/dart/gen-dart/frugal_test/pubspec.yaml
@@ -17,3 +17,10 @@ dependencies:
       url: https://pub.workiva.org
     version: ^0.0.14
   w_common: '>=2.0.0 <4.0.0'
+
+dependency_overrides:
+  frugal:
+    git:
+      url: git@github.com:Workiva/frugal.git
+      ref: FEDX-142
+      path: lib/dart

--- a/test/integration/dart/test_client/pubspec.yaml
+++ b/test/integration/dart/test_client/pubspec.yaml
@@ -9,7 +9,8 @@ dev_dependencies:
   test: ^1.15.7
 dependency_overrides:
   frugal:
-    path:  ../../../../lib/dart
-
-environment:
+    git:
+      url: git@github.com:Workiva/frugal.git
+      ref: FEDX-142
+      path: lib/dartenvironment:
   sdk: '>=2.11.0 <3.0.0'


### PR DESCRIPTION
DO NOT MERGE. This PR adds a dependency override to frugal https://github.com/Workiva/frugal/pull/2276 to test whether this repo is compatible with it.
For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/test_frugal_nullsafe`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/test_frugal_nullsafe)