### PR TITLE
Consume messaging-docker-images 0.1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.16 as build
+FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.18 as build
 
 ARG GIT_BRANCH
 ARG GIT_MERGE_BRANCH

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -7,7 +7,7 @@ run:  # local tests only, never run in Skynet
   on-pull-request: false
 
 contact: messaging@workiva.com
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.16
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.18
 
 env:
   - IN_SKYNET_CLI=true
@@ -40,7 +40,7 @@ requires:
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.16
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.18
 env:
   - PYTHONIOENCODING=utf-8
 


### PR DESCRIPTION
Consume [messaging-docker-images 0.1.18](https://github.com/Workiva/messaging-docker-images/releases/tag/0.1.18)

Pull Requests included in release:
* Patch changes:
	* [Bump go version to 1.21](https://github.com/Workiva/messaging-docker-images/pull/83)


Requested by: @rm-astro-wf
The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5198026715955200/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5198026715955200/?repo_name=Workiva%2Ffrugal&pull_number=2310)