### PR TITLE
Nullsafe generator fixes

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1055,14 +1055,14 @@ func (g *Generator) generateFieldMethods(s *parser.Struct, kind structKind) stri
 	// setFieldValue
 	if kind.export() {
 		contents += tab + "@override\n"
-		contents += tab + "setFieldValue(int fieldID, Object value) {\n"
+		contents += tab + fmt.Sprintf("setFieldValue(int fieldID, Object%s value) {\n", g.nullableOperator)
 		contents += tabtab + "switch (fieldID) {\n"
 		for _, field := range s.Fields {
 			fName := toFieldName(field.Name)
 			contents += fmt.Sprintf(tabtabtab+"case %s:\n", g.generateFieldIdExpr(s, kind, field))
 			if g.useNullForIsSetExpr(kind, field) {
 				contents += ignoreDeprecationWarningIfNeeded(tabtabtabtab, field.Annotations)
-				contents += fmt.Sprintf(tabtabtabtab+"this.%s = value as dynamic;\n", fName)
+				contents += fmt.Sprintf(tabtabtabtab+"this.%s = value as %s;\n", fName, g.getDartTypeFromThriftType(field.Type))
 			} else {
 				contents += tabtabtabtab + "if (value == null) {\n"
 				contents += fmt.Sprintf(tabtabtabtabtab+"unset%s();\n", strings.Title(field.Name))

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1062,13 +1062,13 @@ func (g *Generator) generateFieldMethods(s *parser.Struct, kind structKind) stri
 			contents += fmt.Sprintf(tabtabtab+"case %s:\n", g.generateFieldIdExpr(s, kind, field))
 			if g.useNullForIsSetExpr(kind, field) {
 				contents += ignoreDeprecationWarningIfNeeded(tabtabtabtab, field.Annotations)
-				contents += fmt.Sprintf(tabtabtabtab+"this.%s = value as %s;\n", fName, g.getDartTypeFromThriftType(field.Type))
+				contents += fmt.Sprintf(tabtabtabtab+"this.%s = value as %s%s;\n", fName, g.getDartTypeFromThriftType(field.Type), g.nullableOperator)
 			} else {
 				contents += tabtabtabtab + "if (value == null) {\n"
 				contents += fmt.Sprintf(tabtabtabtabtab+"unset%s();\n", strings.Title(field.Name))
 				contents += tabtabtabtab + "} else {\n"
 				contents += ignoreDeprecationWarningIfNeeded(tabtabtabtabtab, field.Annotations)
-				contents += fmt.Sprintf(tabtabtabtabtab+"this.%s = value as %s;\n", fName, g.getDartTypeFromThriftType(field.Type))
+				contents += fmt.Sprintf(tabtabtabtabtab+"this.%s = value as %s%s;\n", fName, g.getDartTypeFromThriftType(field.Type), g.nullableOperator)
 				contents += tabtabtabtab + "}\n"
 			}
 			contents += tabtabtabtab + "break;\n\n"

--- a/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
@@ -48,7 +48,7 @@ class nested_thing implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case THINGS:
-        this.things = value as dynamic;
+        this.things = value as List<t_actual_base_dart.thing>;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
@@ -74,7 +74,7 @@ class thing implements thrift.TBase {
         break;
 
       case A_STRING:
-        this.a_string = value as dynamic;
+        this.a_string = value as String;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
@@ -111,7 +111,7 @@ class AwesomeException extends Error implements thrift.TBase {
         break;
 
       case REASON:
-        this.reason = value as dynamic;
+        this.reason = value as String;
         break;
 
       case DEPR:

--- a/compiler/testdata/expected/dart.int64/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_event.dart
@@ -110,7 +110,7 @@ class Event implements thrift.TBase {
         break;
 
       case MESSAGE:
-        this.message = value as dynamic;
+        this.message = value as String;
         break;
 
       case YES_NO:

--- a/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
@@ -359,27 +359,27 @@ class EventWrapper implements thrift.TBase {
         break;
 
       case EV:
-        this.ev = value as dynamic;
+        this.ev = value as t_variety.Event;
         break;
 
       case EVENTS:
-        this.events = value as dynamic;
+        this.events = value as List<t_variety.Event>;
         break;
 
       case EVENTS2:
-        this.events2 = value as dynamic;
+        this.events2 = value as Set<t_variety.Event>;
         break;
 
       case EVENTMAP:
-        this.eventMap = value as dynamic;
+        this.eventMap = value as Map<fixnum.Int64, t_variety.Event>;
         break;
 
       case NUMS:
-        this.nums = value as dynamic;
+        this.nums = value as List<List<int>>;
         break;
 
       case ENUMS:
-        this.enums = value as dynamic;
+        this.enums = value as List<int>;
         break;
 
       case ABOOLFIELD:
@@ -391,11 +391,11 @@ class EventWrapper implements thrift.TBase {
         break;
 
       case A_UNION:
-        this.a_union = value as dynamic;
+        this.a_union = value as t_variety.TestingUnions;
         break;
 
       case TYPEDEFOFTYPEDEF:
-        this.typedefOfTypedef = value as dynamic;
+        this.typedefOfTypedef = value as String;
         break;
 
       case DEPR:
@@ -409,24 +409,24 @@ class EventWrapper implements thrift.TBase {
 
       case DEPRBINARY:
         // ignore: deprecated_member_use
-        this.deprBinary = value as dynamic;
+        this.deprBinary = value as Uint8List;
         break;
 
       case DEPRLIST:
         // ignore: deprecated_member_use
-        this.deprList = value as dynamic;
+        this.deprList = value as List<bool>;
         break;
 
       case EVENTSDEFAULT:
-        this.eventsDefault = value as dynamic;
+        this.eventsDefault = value as List<t_variety.Event>;
         break;
 
       case EVENTMAPDEFAULT:
-        this.eventMapDefault = value as dynamic;
+        this.eventMapDefault = value as Map<fixnum.Int64, t_variety.Event>;
         break;
 
       case EVENTSETDEFAULT:
-        this.eventSetDefault = value as dynamic;
+        this.eventSetDefault = value as Set<t_variety.Event>;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
@@ -86,15 +86,15 @@ class FooArgs implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case NEWMESSAGE:
-        this.newMessage = value as dynamic;
+        this.newMessage = value as String;
         break;
 
       case MESSAGEARGS:
-        this.messageArgs = value as dynamic;
+        this.messageArgs = value as String;
         break;
 
       case MESSAGERESULT:
-        this.messageResult = value as dynamic;
+        this.messageResult = value as String;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.int64/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_test_base.dart
@@ -52,7 +52,7 @@ class TestBase implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case BASE_STRUCT:
-        this.base_struct = value as dynamic;
+        this.base_struct = value as t_actual_base_dart.thing;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
@@ -406,11 +406,11 @@ class TestingDefaults implements thrift.TBase {
         break;
 
       case EV1:
-        this.ev1 = value as dynamic;
+        this.ev1 = value as t_variety.Event;
         break;
 
       case EV2:
-        this.ev2 = value as dynamic;
+        this.ev2 = value as t_variety.Event;
         break;
 
       case ID:
@@ -422,15 +422,15 @@ class TestingDefaults implements thrift.TBase {
         break;
 
       case THING:
-        this.thing = value as dynamic;
+        this.thing = value as String;
         break;
 
       case THING2:
-        this.thing2 = value as dynamic;
+        this.thing2 = value as String;
         break;
 
       case LISTFIELD:
-        this.listfield = value as dynamic;
+        this.listfield = value as List<int>;
         break;
 
       case ID3:
@@ -442,35 +442,35 @@ class TestingDefaults implements thrift.TBase {
         break;
 
       case BIN_FIELD:
-        this.bin_field = value as dynamic;
+        this.bin_field = value as Uint8List;
         break;
 
       case BIN_FIELD2:
-        this.bin_field2 = value as dynamic;
+        this.bin_field2 = value as Uint8List;
         break;
 
       case BIN_FIELD3:
-        this.bin_field3 = value as dynamic;
+        this.bin_field3 = value as Uint8List;
         break;
 
       case BIN_FIELD4:
-        this.bin_field4 = value as dynamic;
+        this.bin_field4 = value as Uint8List;
         break;
 
       case LIST2:
-        this.list2 = value as dynamic;
+        this.list2 = value as List<int>;
         break;
 
       case LIST3:
-        this.list3 = value as dynamic;
+        this.list3 = value as List<int>;
         break;
 
       case LIST4:
-        this.list4 = value as dynamic;
+        this.list4 = value as List<int>;
         break;
 
       case A_MAP:
-        this.a_map = value as dynamic;
+        this.a_map = value as Map<String, String>;
         break;
 
       case STATUS:

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
@@ -196,7 +196,7 @@ class TestingUnions implements thrift.TBase {
         break;
 
       case ASTRING:
-        this.aString = value as dynamic;
+        this.aString = value as String;
         break;
 
       case SOMEOTHERTHING:
@@ -216,11 +216,11 @@ class TestingUnions implements thrift.TBase {
         break;
 
       case REQUESTS:
-        this.requests = value as dynamic;
+        this.requests = value as Map<int, String>;
         break;
 
       case BIN_FIELD_IN_UNION:
-        this.bin_field_in_union = value as dynamic;
+        this.bin_field_in_union = value as Uint8List;
         break;
 
       case DEPR:

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_api_exception.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_api_exception.dart
@@ -27,7 +27,7 @@ class api_exception extends Error implements thrift.TBase {
   }
 
   @override
-  setFieldValue(int fieldID, Object value) {
+  setFieldValue(int fieldID, Object? value) {
     switch (fieldID) {
       default:
         throw ArgumentError("Field $fieldID doesn't exist!");

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_nested_thing.dart
@@ -44,10 +44,10 @@ class nested_thing implements thrift.TBase {
   }
 
   @override
-  setFieldValue(int fieldID, Object value) {
+  setFieldValue(int fieldID, Object? value) {
     switch (fieldID) {
       case THINGS:
-        this.things = value as dynamic;
+        this.things = value as List<t_actual_base_dart.thing>?;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
@@ -62,18 +62,18 @@ class thing implements thrift.TBase {
   }
 
   @override
-  setFieldValue(int fieldID, Object value) {
+  setFieldValue(int fieldID, Object? value) {
     switch (fieldID) {
       case AN_ID:
         if (value == null) {
           unsetAn_id();
         } else {
-          this.an_id = value as int;
+          this.an_id = value as int?;
         }
         break;
 
       case A_STRING:
-        this.a_string = value as dynamic;
+        this.a_string = value as String?;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
@@ -99,18 +99,18 @@ class AwesomeException extends Error implements thrift.TBase {
   }
 
   @override
-  setFieldValue(int fieldID, Object value) {
+  setFieldValue(int fieldID, Object? value) {
     switch (fieldID) {
       case ID:
         if (value == null) {
           unsetID();
         } else {
-          this.iD = value as int;
+          this.iD = value as int?;
         }
         break;
 
       case REASON:
-        this.reason = value as dynamic;
+        this.reason = value as String?;
         break;
 
       case DEPR:
@@ -118,7 +118,7 @@ class AwesomeException extends Error implements thrift.TBase {
           unsetDepr();
         } else {
           // ignore: deprecated_member_use
-          this.depr = value as bool;
+          this.depr = value as bool?;
         }
         break;
 

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_event.dart
@@ -98,25 +98,25 @@ class Event implements thrift.TBase {
   }
 
   @override
-  setFieldValue(int fieldID, Object value) {
+  setFieldValue(int fieldID, Object? value) {
     switch (fieldID) {
       case ID:
         if (value == null) {
           unsetID();
         } else {
-          this.iD = value as int;
+          this.iD = value as int?;
         }
         break;
 
       case MESSAGE:
-        this.message = value as dynamic;
+        this.message = value as String?;
         break;
 
       case YES_NO:
         if (value == null) {
           unsetYES_NO();
         } else {
-          this.yES_NO = value as bool;
+          this.yES_NO = value as bool?;
         }
         break;
 

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
@@ -347,54 +347,54 @@ class EventWrapper implements thrift.TBase {
   }
 
   @override
-  setFieldValue(int fieldID, Object value) {
+  setFieldValue(int fieldID, Object? value) {
     switch (fieldID) {
       case ID:
         if (value == null) {
           unsetID();
         } else {
-          this.iD = value as int;
+          this.iD = value as int?;
         }
         break;
 
       case EV:
-        this.ev = value as dynamic;
+        this.ev = value as t_variety.Event?;
         break;
 
       case EVENTS:
-        this.events = value as dynamic;
+        this.events = value as List<t_variety.Event>?;
         break;
 
       case EVENTS2:
-        this.events2 = value as dynamic;
+        this.events2 = value as Set<t_variety.Event>?;
         break;
 
       case EVENTMAP:
-        this.eventMap = value as dynamic;
+        this.eventMap = value as Map<int, t_variety.Event>?;
         break;
 
       case NUMS:
-        this.nums = value as dynamic;
+        this.nums = value as List<List<int>>?;
         break;
 
       case ENUMS:
-        this.enums = value as dynamic;
+        this.enums = value as List<int>?;
         break;
 
       case ABOOLFIELD:
         if (value == null) {
           unsetABoolField();
         } else {
-          this.aBoolField = value as bool;
+          this.aBoolField = value as bool?;
         }
         break;
 
       case A_UNION:
-        this.a_union = value as dynamic;
+        this.a_union = value as t_variety.TestingUnions?;
         break;
 
       case TYPEDEFOFTYPEDEF:
-        this.typedefOfTypedef = value as dynamic;
+        this.typedefOfTypedef = value as String?;
         break;
 
       case DEPR:
@@ -402,30 +402,30 @@ class EventWrapper implements thrift.TBase {
           unsetDepr();
         } else {
           // ignore: deprecated_member_use
-          this.depr = value as bool;
+          this.depr = value as bool?;
         }
         break;
 
       case DEPRBINARY:
         // ignore: deprecated_member_use
-        this.deprBinary = value as dynamic;
+        this.deprBinary = value as Uint8List?;
         break;
 
       case DEPRLIST:
         // ignore: deprecated_member_use
-        this.deprList = value as dynamic;
+        this.deprList = value as List<bool>?;
         break;
 
       case EVENTSDEFAULT:
-        this.eventsDefault = value as dynamic;
+        this.eventsDefault = value as List<t_variety.Event>?;
         break;
 
       case EVENTMAPDEFAULT:
-        this.eventMapDefault = value as dynamic;
+        this.eventMapDefault = value as Map<int, t_variety.Event>?;
         break;
 
       case EVENTSETDEFAULT:
-        this.eventSetDefault = value as dynamic;
+        this.eventSetDefault = value as Set<t_variety.Event>?;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_foo_args.dart
@@ -82,18 +82,18 @@ class FooArgs implements thrift.TBase {
   }
 
   @override
-  setFieldValue(int fieldID, Object value) {
+  setFieldValue(int fieldID, Object? value) {
     switch (fieldID) {
       case NEWMESSAGE:
-        this.newMessage = value as dynamic;
+        this.newMessage = value as String?;
         break;
 
       case MESSAGEARGS:
-        this.messageArgs = value as dynamic;
+        this.messageArgs = value as String?;
         break;
 
       case MESSAGERESULT:
-        this.messageResult = value as dynamic;
+        this.messageResult = value as String?;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_test_base.dart
@@ -48,10 +48,10 @@ class TestBase implements thrift.TBase {
   }
 
   @override
-  setFieldValue(int fieldID, Object value) {
+  setFieldValue(int fieldID, Object? value) {
     switch (fieldID) {
       case BASE_STRUCT:
-        this.base_struct = value as dynamic;
+        this.base_struct = value as t_actual_base_dart.thing?;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_test_lowercase.dart
@@ -50,13 +50,13 @@ class TestLowercase implements thrift.TBase {
   }
 
   @override
-  setFieldValue(int fieldID, Object value) {
+  setFieldValue(int fieldID, Object? value) {
     switch (fieldID) {
       case LOWERCASEINT:
         if (value == null) {
           unsetLowercaseInt();
         } else {
-          this.lowercaseInt = value as int;
+          this.lowercaseInt = value as int?;
         }
         break;
 

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
@@ -394,89 +394,89 @@ class TestingDefaults implements thrift.TBase {
   }
 
   @override
-  setFieldValue(int fieldID, Object value) {
+  setFieldValue(int fieldID, Object? value) {
     switch (fieldID) {
       case ID2:
         if (value == null) {
           unsetID2();
         } else {
-          this.iD2 = value as int;
+          this.iD2 = value as int?;
         }
         break;
 
       case EV1:
-        this.ev1 = value as dynamic;
+        this.ev1 = value as t_variety.Event?;
         break;
 
       case EV2:
-        this.ev2 = value as dynamic;
+        this.ev2 = value as t_variety.Event?;
         break;
 
       case ID:
         if (value == null) {
           unsetID();
         } else {
-          this.iD = value as int;
+          this.iD = value as int?;
         }
         break;
 
       case THING:
-        this.thing = value as dynamic;
+        this.thing = value as String?;
         break;
 
       case THING2:
-        this.thing2 = value as dynamic;
+        this.thing2 = value as String?;
         break;
 
       case LISTFIELD:
-        this.listfield = value as dynamic;
+        this.listfield = value as List<int>?;
         break;
 
       case ID3:
         if (value == null) {
           unsetID3();
         } else {
-          this.iD3 = value as int;
+          this.iD3 = value as int?;
         }
         break;
 
       case BIN_FIELD:
-        this.bin_field = value as dynamic;
+        this.bin_field = value as Uint8List?;
         break;
 
       case BIN_FIELD2:
-        this.bin_field2 = value as dynamic;
+        this.bin_field2 = value as Uint8List?;
         break;
 
       case BIN_FIELD3:
-        this.bin_field3 = value as dynamic;
+        this.bin_field3 = value as Uint8List?;
         break;
 
       case BIN_FIELD4:
-        this.bin_field4 = value as dynamic;
+        this.bin_field4 = value as Uint8List?;
         break;
 
       case LIST2:
-        this.list2 = value as dynamic;
+        this.list2 = value as List<int>?;
         break;
 
       case LIST3:
-        this.list3 = value as dynamic;
+        this.list3 = value as List<int>?;
         break;
 
       case LIST4:
-        this.list4 = value as dynamic;
+        this.list4 = value as List<int>?;
         break;
 
       case A_MAP:
-        this.a_map = value as dynamic;
+        this.a_map = value as Map<String, String>?;
         break;
 
       case STATUS:
         if (value == null) {
           unsetStatus();
         } else {
-          this.status = value as int;
+          this.status = value as int?;
         }
         break;
 
@@ -484,7 +484,7 @@ class TestingDefaults implements thrift.TBase {
         if (value == null) {
           unsetBase_status();
         } else {
-          this.base_status = value as int;
+          this.base_status = value as int?;
         }
         break;
 

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
@@ -184,25 +184,25 @@ class TestingUnions implements thrift.TBase {
   }
 
   @override
-  setFieldValue(int fieldID, Object value) {
+  setFieldValue(int fieldID, Object? value) {
     switch (fieldID) {
       case ANID:
         if (value == null) {
           unsetAnID();
         } else {
-          this.anID = value as int;
+          this.anID = value as int?;
         }
         break;
 
       case ASTRING:
-        this.aString = value as dynamic;
+        this.aString = value as String?;
         break;
 
       case SOMEOTHERTHING:
         if (value == null) {
           unsetSomeotherthing();
         } else {
-          this.someotherthing = value as int;
+          this.someotherthing = value as int?;
         }
         break;
 
@@ -210,16 +210,16 @@ class TestingUnions implements thrift.TBase {
         if (value == null) {
           unsetAnInt16();
         } else {
-          this.anInt16 = value as int;
+          this.anInt16 = value as int?;
         }
         break;
 
       case REQUESTS:
-        this.requests = value as dynamic;
+        this.requests = value as Map<int, String>?;
         break;
 
       case BIN_FIELD_IN_UNION:
-        this.bin_field_in_union = value as dynamic;
+        this.bin_field_in_union = value as Uint8List?;
         break;
 
       case DEPR:
@@ -227,7 +227,7 @@ class TestingUnions implements thrift.TBase {
           unsetDepr();
         } else {
           // ignore: deprecated_member_use
-          this.depr = value as bool;
+          this.depr = value as bool?;
         }
         break;
 
@@ -235,7 +235,7 @@ class TestingUnions implements thrift.TBase {
         if (value == null) {
           unsetWHOA_BUDDY();
         } else {
-          this.wHOA_BUDDY = value as bool;
+          this.wHOA_BUDDY = value as bool?;
         }
         break;
 

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
@@ -41,7 +41,7 @@ class nested_thing implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case THINGS:
-        this.things = value as dynamic;
+        this.things = value as List<t_actual_base_dart.thing>;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
@@ -51,11 +51,11 @@ class thing implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case AN_ID:
-        this.an_id = value as dynamic;
+        this.an_id = value as int;
         break;
 
       case A_STRING:
-        this.a_string = value as dynamic;
+        this.a_string = value as String;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
@@ -73,16 +73,16 @@ class AwesomeException extends Error implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case ID:
-        this.iD = value as dynamic;
+        this.iD = value as int;
         break;
 
       case REASON:
-        this.reason = value as dynamic;
+        this.reason = value as String;
         break;
 
       case DEPR:
         // ignore: deprecated_member_use
-        this.depr = value as dynamic;
+        this.depr = value as bool;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullunset/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_event.dart
@@ -79,11 +79,11 @@ class Event implements thrift.TBase {
         break;
 
       case MESSAGE:
-        this.message = value as dynamic;
+        this.message = value as String;
         break;
 
       case YES_NO:
-        this.yES_NO = value as dynamic;
+        this.yES_NO = value as bool;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
@@ -227,70 +227,70 @@ class EventWrapper implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case ID:
-        this.iD = value as dynamic;
+        this.iD = value as int;
         break;
 
       case EV:
-        this.ev = value as dynamic;
+        this.ev = value as t_variety.Event;
         break;
 
       case EVENTS:
-        this.events = value as dynamic;
+        this.events = value as List<t_variety.Event>;
         break;
 
       case EVENTS2:
-        this.events2 = value as dynamic;
+        this.events2 = value as Set<t_variety.Event>;
         break;
 
       case EVENTMAP:
-        this.eventMap = value as dynamic;
+        this.eventMap = value as Map<int, t_variety.Event>;
         break;
 
       case NUMS:
-        this.nums = value as dynamic;
+        this.nums = value as List<List<int>>;
         break;
 
       case ENUMS:
-        this.enums = value as dynamic;
+        this.enums = value as List<int>;
         break;
 
       case ABOOLFIELD:
-        this.aBoolField = value as dynamic;
+        this.aBoolField = value as bool;
         break;
 
       case A_UNION:
-        this.a_union = value as dynamic;
+        this.a_union = value as t_variety.TestingUnions;
         break;
 
       case TYPEDEFOFTYPEDEF:
-        this.typedefOfTypedef = value as dynamic;
+        this.typedefOfTypedef = value as String;
         break;
 
       case DEPR:
         // ignore: deprecated_member_use
-        this.depr = value as dynamic;
+        this.depr = value as bool;
         break;
 
       case DEPRBINARY:
         // ignore: deprecated_member_use
-        this.deprBinary = value as dynamic;
+        this.deprBinary = value as Uint8List;
         break;
 
       case DEPRLIST:
         // ignore: deprecated_member_use
-        this.deprList = value as dynamic;
+        this.deprList = value as List<bool>;
         break;
 
       case EVENTSDEFAULT:
-        this.eventsDefault = value as dynamic;
+        this.eventsDefault = value as List<t_variety.Event>;
         break;
 
       case EVENTMAPDEFAULT:
-        this.eventMapDefault = value as dynamic;
+        this.eventMapDefault = value as Map<int, t_variety.Event>;
         break;
 
       case EVENTSETDEFAULT:
-        this.eventSetDefault = value as dynamic;
+        this.eventSetDefault = value as Set<t_variety.Event>;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
@@ -67,15 +67,15 @@ class FooArgs implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case NEWMESSAGE:
-        this.newMessage = value as dynamic;
+        this.newMessage = value as String;
         break;
 
       case MESSAGEARGS:
-        this.messageArgs = value as dynamic;
+        this.messageArgs = value as String;
         break;
 
       case MESSAGERESULT:
-        this.messageResult = value as dynamic;
+        this.messageResult = value as String;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullunset/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_test_base.dart
@@ -45,7 +45,7 @@ class TestBase implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case BASE_STRUCT:
-        this.base_struct = value as dynamic;
+        this.base_struct = value as t_actual_base_dart.thing;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullunset/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_test_lowercase.dart
@@ -45,7 +45,7 @@ class TestLowercase implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case LOWERCASEINT:
-        this.lowercaseInt = value as dynamic;
+        this.lowercaseInt = value as int;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
@@ -258,15 +258,15 @@ class TestingDefaults implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case ID2:
-        this.iD2 = value as dynamic;
+        this.iD2 = value as int;
         break;
 
       case EV1:
-        this.ev1 = value as dynamic;
+        this.ev1 = value as t_variety.Event;
         break;
 
       case EV2:
-        this.ev2 = value as dynamic;
+        this.ev2 = value as t_variety.Event;
         break;
 
       case ID:
@@ -278,15 +278,15 @@ class TestingDefaults implements thrift.TBase {
         break;
 
       case THING:
-        this.thing = value as dynamic;
+        this.thing = value as String;
         break;
 
       case THING2:
-        this.thing2 = value as dynamic;
+        this.thing2 = value as String;
         break;
 
       case LISTFIELD:
-        this.listfield = value as dynamic;
+        this.listfield = value as List<int>;
         break;
 
       case ID3:
@@ -298,43 +298,43 @@ class TestingDefaults implements thrift.TBase {
         break;
 
       case BIN_FIELD:
-        this.bin_field = value as dynamic;
+        this.bin_field = value as Uint8List;
         break;
 
       case BIN_FIELD2:
-        this.bin_field2 = value as dynamic;
+        this.bin_field2 = value as Uint8List;
         break;
 
       case BIN_FIELD3:
-        this.bin_field3 = value as dynamic;
+        this.bin_field3 = value as Uint8List;
         break;
 
       case BIN_FIELD4:
-        this.bin_field4 = value as dynamic;
+        this.bin_field4 = value as Uint8List;
         break;
 
       case LIST2:
-        this.list2 = value as dynamic;
+        this.list2 = value as List<int>;
         break;
 
       case LIST3:
-        this.list3 = value as dynamic;
+        this.list3 = value as List<int>;
         break;
 
       case LIST4:
-        this.list4 = value as dynamic;
+        this.list4 = value as List<int>;
         break;
 
       case A_MAP:
-        this.a_map = value as dynamic;
+        this.a_map = value as Map<String, String>;
         break;
 
       case STATUS:
-        this.status = value as dynamic;
+        this.status = value as int;
         break;
 
       case BASE_STATUS:
-        this.base_status = value as dynamic;
+        this.base_status = value as int;
         break;
 
       default:

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
@@ -126,36 +126,36 @@ class TestingUnions implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case ANID:
-        this.anID = value as dynamic;
+        this.anID = value as int;
         break;
 
       case ASTRING:
-        this.aString = value as dynamic;
+        this.aString = value as String;
         break;
 
       case SOMEOTHERTHING:
-        this.someotherthing = value as dynamic;
+        this.someotherthing = value as int;
         break;
 
       case ANINT16:
-        this.anInt16 = value as dynamic;
+        this.anInt16 = value as int;
         break;
 
       case REQUESTS:
-        this.requests = value as dynamic;
+        this.requests = value as Map<int, String>;
         break;
 
       case BIN_FIELD_IN_UNION:
-        this.bin_field_in_union = value as dynamic;
+        this.bin_field_in_union = value as Uint8List;
         break;
 
       case DEPR:
         // ignore: deprecated_member_use
-        this.depr = value as dynamic;
+        this.depr = value as bool;
         break;
 
       case WHOA_BUDDY:
-        this.wHOA_BUDDY = value as dynamic;
+        this.wHOA_BUDDY = value as bool;
         break;
 
       default:

--- a/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
@@ -47,7 +47,7 @@ class nested_thing implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case THINGS:
-        this.things = value as dynamic;
+        this.things = value as List<t_actual_base_dart.thing>;
         break;
 
       default:

--- a/compiler/testdata/expected/dart/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_thing.dart
@@ -73,7 +73,7 @@ class thing implements thrift.TBase {
         break;
 
       case A_STRING:
-        this.a_string = value as dynamic;
+        this.a_string = value as String;
         break;
 
       default:

--- a/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
@@ -110,7 +110,7 @@ class AwesomeException extends Error implements thrift.TBase {
         break;
 
       case REASON:
-        this.reason = value as dynamic;
+        this.reason = value as String;
         break;
 
       case DEPR:

--- a/compiler/testdata/expected/dart/variety/f_event.dart
+++ b/compiler/testdata/expected/dart/variety/f_event.dart
@@ -109,7 +109,7 @@ class Event implements thrift.TBase {
         break;
 
       case MESSAGE:
-        this.message = value as dynamic;
+        this.message = value as String;
         break;
 
       case YES_NO:

--- a/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
@@ -358,27 +358,27 @@ class EventWrapper implements thrift.TBase {
         break;
 
       case EV:
-        this.ev = value as dynamic;
+        this.ev = value as t_variety.Event;
         break;
 
       case EVENTS:
-        this.events = value as dynamic;
+        this.events = value as List<t_variety.Event>;
         break;
 
       case EVENTS2:
-        this.events2 = value as dynamic;
+        this.events2 = value as Set<t_variety.Event>;
         break;
 
       case EVENTMAP:
-        this.eventMap = value as dynamic;
+        this.eventMap = value as Map<int, t_variety.Event>;
         break;
 
       case NUMS:
-        this.nums = value as dynamic;
+        this.nums = value as List<List<int>>;
         break;
 
       case ENUMS:
-        this.enums = value as dynamic;
+        this.enums = value as List<int>;
         break;
 
       case ABOOLFIELD:
@@ -390,11 +390,11 @@ class EventWrapper implements thrift.TBase {
         break;
 
       case A_UNION:
-        this.a_union = value as dynamic;
+        this.a_union = value as t_variety.TestingUnions;
         break;
 
       case TYPEDEFOFTYPEDEF:
-        this.typedefOfTypedef = value as dynamic;
+        this.typedefOfTypedef = value as String;
         break;
 
       case DEPR:
@@ -408,24 +408,24 @@ class EventWrapper implements thrift.TBase {
 
       case DEPRBINARY:
         // ignore: deprecated_member_use
-        this.deprBinary = value as dynamic;
+        this.deprBinary = value as Uint8List;
         break;
 
       case DEPRLIST:
         // ignore: deprecated_member_use
-        this.deprList = value as dynamic;
+        this.deprList = value as List<bool>;
         break;
 
       case EVENTSDEFAULT:
-        this.eventsDefault = value as dynamic;
+        this.eventsDefault = value as List<t_variety.Event>;
         break;
 
       case EVENTMAPDEFAULT:
-        this.eventMapDefault = value as dynamic;
+        this.eventMapDefault = value as Map<int, t_variety.Event>;
         break;
 
       case EVENTSETDEFAULT:
-        this.eventSetDefault = value as dynamic;
+        this.eventSetDefault = value as Set<t_variety.Event>;
         break;
 
       default:

--- a/compiler/testdata/expected/dart/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart/variety/f_foo_args.dart
@@ -85,15 +85,15 @@ class FooArgs implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case NEWMESSAGE:
-        this.newMessage = value as dynamic;
+        this.newMessage = value as String;
         break;
 
       case MESSAGEARGS:
-        this.messageArgs = value as dynamic;
+        this.messageArgs = value as String;
         break;
 
       case MESSAGERESULT:
-        this.messageResult = value as dynamic;
+        this.messageResult = value as String;
         break;
 
       default:

--- a/compiler/testdata/expected/dart/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart/variety/f_test_base.dart
@@ -51,7 +51,7 @@ class TestBase implements thrift.TBase {
   setFieldValue(int fieldID, Object value) {
     switch (fieldID) {
       case BASE_STRUCT:
-        this.base_struct = value as dynamic;
+        this.base_struct = value as t_actual_base_dart.thing;
         break;
 
       default:

--- a/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
@@ -405,11 +405,11 @@ class TestingDefaults implements thrift.TBase {
         break;
 
       case EV1:
-        this.ev1 = value as dynamic;
+        this.ev1 = value as t_variety.Event;
         break;
 
       case EV2:
-        this.ev2 = value as dynamic;
+        this.ev2 = value as t_variety.Event;
         break;
 
       case ID:
@@ -421,15 +421,15 @@ class TestingDefaults implements thrift.TBase {
         break;
 
       case THING:
-        this.thing = value as dynamic;
+        this.thing = value as String;
         break;
 
       case THING2:
-        this.thing2 = value as dynamic;
+        this.thing2 = value as String;
         break;
 
       case LISTFIELD:
-        this.listfield = value as dynamic;
+        this.listfield = value as List<int>;
         break;
 
       case ID3:
@@ -441,35 +441,35 @@ class TestingDefaults implements thrift.TBase {
         break;
 
       case BIN_FIELD:
-        this.bin_field = value as dynamic;
+        this.bin_field = value as Uint8List;
         break;
 
       case BIN_FIELD2:
-        this.bin_field2 = value as dynamic;
+        this.bin_field2 = value as Uint8List;
         break;
 
       case BIN_FIELD3:
-        this.bin_field3 = value as dynamic;
+        this.bin_field3 = value as Uint8List;
         break;
 
       case BIN_FIELD4:
-        this.bin_field4 = value as dynamic;
+        this.bin_field4 = value as Uint8List;
         break;
 
       case LIST2:
-        this.list2 = value as dynamic;
+        this.list2 = value as List<int>;
         break;
 
       case LIST3:
-        this.list3 = value as dynamic;
+        this.list3 = value as List<int>;
         break;
 
       case LIST4:
-        this.list4 = value as dynamic;
+        this.list4 = value as List<int>;
         break;
 
       case A_MAP:
-        this.a_map = value as dynamic;
+        this.a_map = value as Map<String, String>;
         break;
 
       case STATUS:

--- a/compiler/testdata/expected/dart/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_unions.dart
@@ -195,7 +195,7 @@ class TestingUnions implements thrift.TBase {
         break;
 
       case ASTRING:
-        this.aString = value as dynamic;
+        this.aString = value as String;
         break;
 
       case SOMEOTHERTHING:
@@ -215,11 +215,11 @@ class TestingUnions implements thrift.TBase {
         break;
 
       case REQUESTS:
-        this.requests = value as dynamic;
+        this.requests = value as Map<int, String>;
         break;
 
       case BIN_FIELD_IN_UNION:
-        this.bin_field_in_union = value as dynamic;
+        this.bin_field_in_union = value as Uint8List;
         break;
 
       case DEPR:


### PR DESCRIPTION
### Story:

When consumer testing the frugal generated nullsafe Dart code in w_comments https://github.com/Workiva/w_comments/pull/2561
I found that the casts `as dynamic` were causing analysis warnings and failing the build. This was due to 
```
     strong-mode:
         implicit-casts: false
```
in the analysis_options.yaml file. Commenting that out gets it to not complain, but it should work regardless of the lint settings. While investigating, we also spotted the setField should take a nullable value (`Object? value`) to match thrift 
https://github.com/Workiva/thrift-dart/blob/3253deb35e8febd31964e577724f95296377b554/lib/src/t_base.dart#L34-L39

So, the changes are to update the setField value param to be nullable, and use the full type when casting, optionally adding the `?` if generating nullsafe code.


### Acceptance Criteria:
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master
