### PR TITLE
Adjust nullsafe generated code

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1194,11 +1194,12 @@ func (g *Generator) generateReadFieldRec(field *parser.Field, kind structKind, f
 			contents += fmt.Sprintf(ind+"this.__isset_%s = true;\n", fName)
 		}
 	} else if g.Frugal.IsStruct(underlyingType) {
+		valElem := g.GetElem()
 		contents += ignoreDeprecationWarningIfNeeded(ind, field.Annotations)
-		contents += fmt.Sprintf(ind+"final tmp_%s = %s();\n", fName, dartType)
-		contents += fmt.Sprintf(ind+"%s%s = tmp_%s;\n", prefix, fName, fName)
+		contents += fmt.Sprintf(ind+"final %s = %s();\n", valElem, dartType)
+		contents += fmt.Sprintf(ind+"%s%s = %s;\n", prefix, fName, valElem)
 		contents += ignoreDeprecationWarningIfNeeded(ind, field.Annotations)
-		contents += fmt.Sprintf(ind+"tmp_%s.read(iprot);\n", fName)
+		contents += fmt.Sprintf(ind+"%s.read(iprot);\n", valElem)
 	} else if underlyingType.IsContainer() {
 		containerElem := g.GetElem()
 		valElem := g.GetElem()

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1390,12 +1390,13 @@ func (g *Generator) generateWriteFieldRec(field *parser.Field, first bool, ind s
 		case "map":
 			keyEnumType := g.getEnumFromThriftType(underlyingType.KeyType)
 			keyElem := g.GetElem()
+			valElem := g.GetElem()
 			keyField := parser.FieldFromType(underlyingType.KeyType, keyElem)
-			valField := parser.FieldFromType(underlyingType.ValueType, fmt.Sprintf("val"))
+			valField := parser.FieldFromType(underlyingType.ValueType, valElem)
 			contents += fmt.Sprintf(tabtab+ind+"oprot.writeMapBegin(thrift.TMap(%s, %s, %s.length));\n", keyEnumType, valEnumType, localVar)
 			contents += ignoreDeprecationWarningIfNeeded(tabtab+ind, field.Annotations)
 			contents += fmt.Sprintf(tabtab+ind+"for(var %s in %s.keys) {\n", keyElem, localVar)
-			contents += tabtabtab+ind+fmt.Sprintf("final val = %s[%s]%s;\n", localVar, keyElem, g.notNullOperator)
+			contents += tabtabtab+ind+fmt.Sprintf("final %s = %s[%s]%s;\n", valElem, localVar, keyElem, g.notNullOperator)
 			contents += g.generateWriteFieldRec(keyField, false, ind+tab)
 			contents += g.generateWriteFieldRec(valField, false, ind+tab)
 			contents += tabtab + ind + "}\n"

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1390,14 +1390,12 @@ func (g *Generator) generateWriteFieldRec(field *parser.Field, first bool, ind s
 			contents += tabtab + ind + "oprot.writeSetEnd();\n"
 		case "map":
 			keyEnumType := g.getEnumFromThriftType(underlyingType.KeyType)
-			keyElem := g.GetElem()
-			valElem := g.GetElem()
-			keyField := parser.FieldFromType(underlyingType.KeyType, keyElem)
-			valField := parser.FieldFromType(underlyingType.ValueType, valElem)
+			
+			keyField := parser.FieldFromType(underlyingType.KeyType, "entry.key")
+			valField := parser.FieldFromType(underlyingType.ValueType, "entry.value")
 			contents += fmt.Sprintf(tabtab+ind+"oprot.writeMapBegin(thrift.TMap(%s, %s, %s.length));\n", keyEnumType, valEnumType, localVar)
 			contents += ignoreDeprecationWarningIfNeeded(tabtab+ind, field.Annotations)
-			contents += fmt.Sprintf(tabtab+ind+"for(var %s in %s.keys) {\n", keyElem, localVar)
-			contents += tabtabtab+ind+fmt.Sprintf("final %s = %s[%s]%s;\n", valElem, localVar, keyElem, g.notNullOperator)
+			contents += fmt.Sprintf(tabtab+ind+"for(var entry in %s.entries) {\n", localVar)
 			contents += g.generateWriteFieldRec(keyField, false, ind+tab)
 			contents += g.generateWriteFieldRec(valField, false, ind+tab)
 			contents += tabtab + ind + "}\n"

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1366,7 +1366,7 @@ func (g *Generator) generateWriteFieldRec(field *parser.Field, first bool, ind s
 		valEnumType := g.getEnumFromThriftType(underlyingType.ValueType)
 		localVar := fName
 		if first {
-			localVar = g.GetElem() // this used to be "temp"
+			localVar = g.GetElem()
 			contents += fmt.Sprintf(tabtab+ind+"final %s = this.%s%s;\n", localVar, fName, g.notNullOperator)
 		}
 		switch underlyingType.Name {

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1366,7 +1366,7 @@ func (g *Generator) generateWriteFieldRec(field *parser.Field, first bool, ind s
 		valEnumType := g.getEnumFromThriftType(underlyingType.ValueType)
 		localVar := fName
 		if first {
-			localVar = "temp"
+			localVar = g.GetElem() // this used to be "temp"
 			contents += fmt.Sprintf(tabtab+ind+"final %s = this.%s%s;\n", localVar, fName, g.notNullOperator)
 		}
 		switch underlyingType.Name {

--- a/compiler/testdata/expected/dart.int64/actual_base/f_actual_base_dart_constants.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_actual_base_dart_constants.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:convert' show utf8;
 import 'package:fixnum/fixnum.dart' as fixnum;
 import 'dart:typed_data' show Uint8List;

--- a/compiler/testdata/expected/dart.int64/actual_base/f_api_exception.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_api_exception.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.int64/actual_base/f_base_foo_service.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_base_foo_service.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
@@ -68,16 +68,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem194 = iprot.readListBegin();
-            final elem198 = <t_actual_base_dart.thing>[];
-            for(int elem197 = 0; elem197 < elem194.length; ++elem197) {
-              final elem196 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem195 = elem196;
-              elem196.read(iprot);
-              elem198.add(elem195);
+            thrift.TList elem182 = iprot.readListBegin();
+            final elem186 = <t_actual_base_dart.thing>[];
+            for(int elem185 = 0; elem185 < elem182.length; ++elem185) {
+              final elem184 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem183 = elem184;
+              elem184.read(iprot);
+              elem186.add(elem183);
             }
             iprot.readListEnd();
-            this.things = elem198;
+            this.things = elem186;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -98,12 +98,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem199 = things;
-    if (elem199 != null) {
+    final elem187 = things;
+    if (elem187 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem199.length));
-      for(var elem200 in elem199) {
-        elem200.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem187.length));
+      for(var elem188 in elem187) {
+        elem188.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
@@ -68,16 +68,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem170 = iprot.readListBegin();
-            final elem173 = <t_actual_base_dart.thing>[];
-            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
-              final tmp_elem171 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem171 = tmp_elem171;
-              tmp_elem171.read(iprot);
-              elem173.add(elem171);
+            thrift.TList elem176 = iprot.readListBegin();
+            final elem179 = <t_actual_base_dart.thing>[];
+            for(int elem178 = 0; elem178 < elem176.length; ++elem178) {
+              final tmp_elem177 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem177 = tmp_elem177;
+              tmp_elem177.read(iprot);
+              elem179.add(elem177);
             }
             iprot.readListEnd();
-            this.things = elem173;
+            this.things = elem179;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -98,12 +98,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem174 = things;
-    if (elem174 != null) {
+    final elem180 = things;
+    if (elem180 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem174.length));
-      for(var elem175 in elem174) {
-        elem175.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem180.length));
+      for(var elem181 in elem180) {
+        elem181.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
@@ -68,16 +68,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem176 = iprot.readListBegin();
-            final elem179 = <t_actual_base_dart.thing>[];
-            for(int elem178 = 0; elem178 < elem176.length; ++elem178) {
-              final tmp_elem177 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem177 = tmp_elem177;
-              tmp_elem177.read(iprot);
-              elem179.add(elem177);
+            thrift.TList elem194 = iprot.readListBegin();
+            final elem198 = <t_actual_base_dart.thing>[];
+            for(int elem197 = 0; elem197 < elem194.length; ++elem197) {
+              final elem196 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem195 = elem196;
+              elem196.read(iprot);
+              elem198.add(elem195);
             }
             iprot.readListEnd();
-            this.things = elem179;
+            this.things = elem198;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -98,12 +98,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem180 = things;
-    if (elem180 != null) {
+    final elem199 = things;
+    if (elem199 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem180.length));
-      for(var elem181 in elem180) {
-        elem181.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem199.length));
+      for(var elem200 in elem199) {
+        elem200.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
@@ -68,15 +68,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem99 = iprot.readListBegin();
-            final elem102 = <t_actual_base_dart.thing>[];
-            for(int elem101 = 0; elem101 < elem99.length; ++elem101) {
-              t_actual_base_dart.thing elem100 = t_actual_base_dart.thing();
-              elem100.read(iprot);
-              elem102.add(elem100);
+            thrift.TList elem170 = iprot.readListBegin();
+            final elem173 = <t_actual_base_dart.thing>[];
+            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
+              final tmp_elem171 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem171 = tmp_elem171;
+              tmp_elem171.read(iprot);
+              elem173.add(elem171);
             }
             iprot.readListEnd();
-            this.things = elem102;
+            this.things = elem173;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -97,12 +98,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.things != null) {
+    final elem174 = things;
+    if (elem174 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      final temp = this.things;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
-      for(var elem103 in temp) {
-        elem103.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem174.length));
+      for(var elem175 in elem174) {
+        elem175.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
@@ -127,14 +127,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem174 = an_id;
+    final elem192 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem174);
+    oprot.writeI32(elem192);
     oprot.writeFieldEnd();
-    final elem175 = a_string;
-    if (elem175 != null) {
+    final elem193 = a_string;
+    if (elem193 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem175);
+      oprot.writeString(elem193);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
@@ -127,14 +127,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem168 = an_id;
+    final elem174 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem168);
+    oprot.writeI32(elem174);
     oprot.writeFieldEnd();
-    final elem169 = a_string;
-    if (elem169 != null) {
+    final elem175 = a_string;
+    if (elem175 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem169);
+      oprot.writeString(elem175);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
@@ -127,14 +127,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem192 = an_id;
+    final elem180 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem192);
+    oprot.writeI32(elem180);
     oprot.writeFieldEnd();
-    final elem193 = a_string;
-    if (elem193 != null) {
+    final elem181 = a_string;
+    if (elem181 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem193);
+      oprot.writeString(elem181);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
@@ -127,12 +127,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem168 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(this.an_id);
+    oprot.writeI32(elem168);
     oprot.writeFieldEnd();
-    if (this.a_string != null) {
+    final elem169 = a_string;
+    if (elem169 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(this.a_string);
+      oprot.writeString(elem169);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
@@ -185,17 +185,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem133 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(this.iD);
+    oprot.writeInt64(elem133);
     oprot.writeFieldEnd();
-    if (this.reason != null) {
+    final elem134 = reason;
+    if (elem134 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(this.reason);
+      oprot.writeString(elem134);
       oprot.writeFieldEnd();
     }
+    final elem135 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    // ignore: deprecated_member_use
-    oprot.writeBool(this.depr);
+    oprot.writeBool(elem135);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
@@ -185,19 +185,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem148 = iD;
+    final elem140 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(elem148);
+    oprot.writeInt64(elem140);
     oprot.writeFieldEnd();
-    final elem149 = reason;
-    if (elem149 != null) {
+    final elem141 = reason;
+    if (elem141 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem149);
+      oprot.writeString(elem141);
       oprot.writeFieldEnd();
     }
-    final elem150 = depr;
+    final elem142 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem150);
+    oprot.writeBool(elem142);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
@@ -185,19 +185,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem137 = iD;
+    final elem148 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(elem137);
+    oprot.writeInt64(elem148);
     oprot.writeFieldEnd();
-    final elem138 = reason;
-    if (elem138 != null) {
+    final elem149 = reason;
+    if (elem149 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem138);
+      oprot.writeString(elem149);
       oprot.writeFieldEnd();
     }
-    final elem139 = depr;
+    final elem150 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem139);
+    oprot.writeBool(elem150);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
@@ -185,19 +185,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem133 = iD;
+    final elem137 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(elem133);
+    oprot.writeInt64(elem137);
     oprot.writeFieldEnd();
-    final elem134 = reason;
-    if (elem134 != null) {
+    final elem138 = reason;
+    if (elem138 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem134);
+      oprot.writeString(elem138);
       oprot.writeFieldEnd();
     }
-    final elem135 = depr;
+    final elem139 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem135);
+    oprot.writeBool(elem139);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.int64/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_event.dart
@@ -181,19 +181,19 @@ class Event implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem2 = iD;
+    final elem3 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(elem2);
+    oprot.writeInt64(elem3);
     oprot.writeFieldEnd();
-    final elem3 = message;
-    if (elem3 != null) {
+    final elem4 = message;
+    if (elem4 != null) {
       oprot.writeFieldBegin(_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem3);
+      oprot.writeString(elem4);
       oprot.writeFieldEnd();
     }
-    final elem4 = yES_NO;
+    final elem5 = yES_NO;
     oprot.writeFieldBegin(_YE_S__NO_FIELD_DESC);
-    oprot.writeBool(elem4);
+    oprot.writeBool(elem5);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_event.dart
@@ -181,16 +181,19 @@ class Event implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem2 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(this.iD);
+    oprot.writeInt64(elem2);
     oprot.writeFieldEnd();
-    if (this.message != null) {
+    final elem3 = message;
+    if (elem3 != null) {
       oprot.writeFieldBegin(_MESSAGE_FIELD_DESC);
-      oprot.writeString(this.message);
+      oprot.writeString(elem3);
       oprot.writeFieldEnd();
     }
+    final elem4 = yES_NO;
     oprot.writeFieldBegin(_YE_S__NO_FIELD_DESC);
-    oprot.writeBool(this.yES_NO);
+    oprot.writeBool(elem4);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_event.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
@@ -472,83 +472,83 @@ class EventWrapper implements thrift.TBase {
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem49 = iprot.readListBegin();
-            final elem52 = <t_variety.Event>[];
-            for(int elem51 = 0; elem51 < elem49.length; ++elem51) {
-              final tmp_elem50 = t_variety.Event();
-              t_variety.Event elem50 = tmp_elem50;
-              tmp_elem50.read(iprot);
-              elem52.add(elem50);
+            thrift.TList elem50 = iprot.readListBegin();
+            final elem53 = <t_variety.Event>[];
+            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
+              final tmp_elem51 = t_variety.Event();
+              t_variety.Event elem51 = tmp_elem51;
+              tmp_elem51.read(iprot);
+              elem53.add(elem51);
             }
             iprot.readListEnd();
-            this.events = elem52;
+            this.events = elem53;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem53 = iprot.readSetBegin();
-            final elem56 = <t_variety.Event>{};
-            for(int elem55 = 0; elem55 < elem53.length; ++elem55) {
-              final tmp_elem54 = t_variety.Event();
-              t_variety.Event elem54 = tmp_elem54;
-              tmp_elem54.read(iprot);
-              elem56.add(elem54);
+            thrift.TSet elem54 = iprot.readSetBegin();
+            final elem57 = <t_variety.Event>{};
+            for(int elem56 = 0; elem56 < elem54.length; ++elem56) {
+              final tmp_elem55 = t_variety.Event();
+              t_variety.Event elem55 = tmp_elem55;
+              tmp_elem55.read(iprot);
+              elem57.add(elem55);
             }
             iprot.readSetEnd();
-            this.events2 = elem56;
+            this.events2 = elem57;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem57 = iprot.readMapBegin();
-            final elem60 = <fixnum.Int64, t_variety.Event>{};
-            for(int elem59 = 0; elem59 < elem57.length; ++elem59) {
-              fixnum.Int64 elem61 = iprot.readInt64();
-              final tmp_elem58 = t_variety.Event();
-              t_variety.Event elem58 = tmp_elem58;
-              tmp_elem58.read(iprot);
-              elem60[elem61] = elem58;
+            thrift.TMap elem58 = iprot.readMapBegin();
+            final elem61 = <fixnum.Int64, t_variety.Event>{};
+            for(int elem60 = 0; elem60 < elem58.length; ++elem60) {
+              fixnum.Int64 elem62 = iprot.readInt64();
+              final tmp_elem59 = t_variety.Event();
+              t_variety.Event elem59 = tmp_elem59;
+              tmp_elem59.read(iprot);
+              elem61[elem62] = elem59;
             }
             iprot.readMapEnd();
-            this.eventMap = elem60;
+            this.eventMap = elem61;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem62 = iprot.readListBegin();
-            final elem68 = <List<int>>[];
-            for(int elem67 = 0; elem67 < elem62.length; ++elem67) {
-              thrift.TList elem64 = iprot.readListBegin();
-              final elem63 = <int>[];
-              for(int elem66 = 0; elem66 < elem64.length; ++elem66) {
-                int elem65 = iprot.readI32();
-                elem63.add(elem65);
+            thrift.TList elem63 = iprot.readListBegin();
+            final elem69 = <List<int>>[];
+            for(int elem68 = 0; elem68 < elem63.length; ++elem68) {
+              thrift.TList elem65 = iprot.readListBegin();
+              final elem64 = <int>[];
+              for(int elem67 = 0; elem67 < elem65.length; ++elem67) {
+                int elem66 = iprot.readI32();
+                elem64.add(elem66);
               }
               iprot.readListEnd();
-              elem68.add(elem63);
+              elem69.add(elem64);
             }
             iprot.readListEnd();
-            this.nums = elem68;
+            this.nums = elem69;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem69 = iprot.readListBegin();
-            final elem72 = <int>[];
-            for(int elem71 = 0; elem71 < elem69.length; ++elem71) {
-              int elem70 = iprot.readI32();
-              elem72.add(elem70);
+            thrift.TList elem70 = iprot.readListBegin();
+            final elem73 = <int>[];
+            for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
+              int elem71 = iprot.readI32();
+              elem73.add(elem71);
             }
             iprot.readListEnd();
-            this.enums = elem72;
+            this.enums = elem73;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -596,65 +596,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem73 = iprot.readListBegin();
+            thrift.TList elem74 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem76 = <bool>[];
-            for(int elem75 = 0; elem75 < elem73.length; ++elem75) {
-              bool elem74 = iprot.readBool();
+            final elem77 = <bool>[];
+            for(int elem76 = 0; elem76 < elem74.length; ++elem76) {
+              bool elem75 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem76.add(elem74);
+              elem77.add(elem75);
             }
             iprot.readListEnd();
-            this.deprList = elem76;
+            this.deprList = elem77;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem77 = iprot.readListBegin();
-            final elem80 = <t_variety.Event>[];
-            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
-              final tmp_elem78 = t_variety.Event();
-              t_variety.Event elem78 = tmp_elem78;
-              tmp_elem78.read(iprot);
-              elem80.add(elem78);
+            thrift.TList elem78 = iprot.readListBegin();
+            final elem81 = <t_variety.Event>[];
+            for(int elem80 = 0; elem80 < elem78.length; ++elem80) {
+              final tmp_elem79 = t_variety.Event();
+              t_variety.Event elem79 = tmp_elem79;
+              tmp_elem79.read(iprot);
+              elem81.add(elem79);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem80;
+            this.eventsDefault = elem81;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem81 = iprot.readMapBegin();
-            final elem84 = <fixnum.Int64, t_variety.Event>{};
-            for(int elem83 = 0; elem83 < elem81.length; ++elem83) {
-              fixnum.Int64 elem85 = iprot.readInt64();
-              final tmp_elem82 = t_variety.Event();
-              t_variety.Event elem82 = tmp_elem82;
-              tmp_elem82.read(iprot);
-              elem84[elem85] = elem82;
+            thrift.TMap elem82 = iprot.readMapBegin();
+            final elem85 = <fixnum.Int64, t_variety.Event>{};
+            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
+              fixnum.Int64 elem86 = iprot.readInt64();
+              final tmp_elem83 = t_variety.Event();
+              t_variety.Event elem83 = tmp_elem83;
+              tmp_elem83.read(iprot);
+              elem85[elem86] = elem83;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem84;
+            this.eventMapDefault = elem85;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem86 = iprot.readSetBegin();
-            final elem89 = <t_variety.Event>{};
-            for(int elem88 = 0; elem88 < elem86.length; ++elem88) {
-              final tmp_elem87 = t_variety.Event();
-              t_variety.Event elem87 = tmp_elem87;
-              tmp_elem87.read(iprot);
-              elem89.add(elem87);
+            thrift.TSet elem87 = iprot.readSetBegin();
+            final elem90 = <t_variety.Event>{};
+            for(int elem89 = 0; elem89 < elem87.length; ++elem89) {
+              final tmp_elem88 = t_variety.Event();
+              t_variety.Event elem88 = tmp_elem88;
+              tmp_elem88.read(iprot);
+              elem90.add(elem88);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem89;
+            this.eventSetDefault = elem90;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -675,140 +675,140 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem90 = iD;
+    final elem91 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeInt64(elem90);
+      oprot.writeInt64(elem91);
       oprot.writeFieldEnd();
     }
-    final elem91 = ev;
-    if (elem91 != null) {
-      oprot.writeFieldBegin(_EV_FIELD_DESC);
-      elem91.write(oprot);
-      oprot.writeFieldEnd();
-    }
-    final elem92 = events;
+    final elem92 = ev;
     if (elem92 != null) {
+      oprot.writeFieldBegin(_EV_FIELD_DESC);
+      elem92.write(oprot);
+      oprot.writeFieldEnd();
+    }
+    final elem93 = events;
+    if (elem93 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem92.length));
-      for(var elem93 in elem92) {
-        elem93.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem93.length));
+      for(var elem94 in elem93) {
+        elem94.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem94 = events2;
-    if (elem94 != null) {
+    final elem95 = events2;
+    if (elem95 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem94.length));
-      for(var elem95 in elem94) {
-        elem95.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem95.length));
+      for(var elem96 in elem95) {
+        elem96.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem96 = eventMap;
-    if (elem96 != null) {
+    final elem97 = eventMap;
+    if (elem97 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem96.length));
-      for(var elem97 in elem96.keys) {
-        final val = elem96[elem97];
-        oprot.writeInt64(elem97);
-        val.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem97.length));
+      for(var elem98 in elem97.keys) {
+        final elem99 = elem97[elem98];
+        oprot.writeInt64(elem98);
+        elem99.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem98 = nums;
-    if (elem98 != null) {
+    final elem100 = nums;
+    if (elem100 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem98.length));
-      for(var elem99 in elem98) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem99.length));
-        for(var elem100 in elem99) {
-          oprot.writeI32(elem100);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem100.length));
+      for(var elem101 in elem100) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
+        for(var elem102 in elem101) {
+          oprot.writeI32(elem102);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem101 = enums;
-    if (elem101 != null) {
+    final elem103 = enums;
+    if (elem103 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
-      for(var elem102 in elem101) {
-        oprot.writeI32(elem102);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem103.length));
+      for(var elem104 in elem103) {
+        oprot.writeI32(elem104);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem103 = aBoolField;
+    final elem105 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem103);
+    oprot.writeBool(elem105);
     oprot.writeFieldEnd();
-    final elem104 = a_union;
-    if (elem104 != null) {
+    final elem106 = a_union;
+    if (elem106 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem104.write(oprot);
+      elem106.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem105 = typedefOfTypedef;
-    if (elem105 != null) {
-      oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem105);
-      oprot.writeFieldEnd();
-    }
-    final elem106 = depr;
-    oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem106);
-    oprot.writeFieldEnd();
-    final elem107 = deprBinary;
-    // ignore: deprecated_member_use
+    final elem107 = typedefOfTypedef;
     if (elem107 != null) {
-      oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem107);
+      oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
+      oprot.writeString(elem107);
       oprot.writeFieldEnd();
     }
-    final elem108 = deprList;
+    final elem108 = depr;
+    oprot.writeFieldBegin(_DEPR_FIELD_DESC);
+    oprot.writeBool(elem108);
+    oprot.writeFieldEnd();
+    final elem109 = deprBinary;
     // ignore: deprecated_member_use
-    if (elem108 != null) {
+    if (elem109 != null) {
+      oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
+      oprot.writeBinary(elem109);
+      oprot.writeFieldEnd();
+    }
+    final elem110 = deprList;
+    // ignore: deprecated_member_use
+    if (elem110 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem108.length));
-      for(var elem109 in elem108) {
-        oprot.writeBool(elem109);
-      }
-      oprot.writeListEnd();
-      oprot.writeFieldEnd();
-    }
-    final elem110 = eventsDefault;
-    if (isSetEventsDefault() && elem110 != null) {
-      oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem110.length));
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem110.length));
       for(var elem111 in elem110) {
-        elem111.write(oprot);
+        oprot.writeBool(elem111);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem112 = eventMapDefault;
-    if (isSetEventMapDefault() && elem112 != null) {
+    final elem112 = eventsDefault;
+    if (isSetEventsDefault() && elem112 != null) {
+      oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem112.length));
+      for(var elem113 in elem112) {
+        elem113.write(oprot);
+      }
+      oprot.writeListEnd();
+      oprot.writeFieldEnd();
+    }
+    final elem114 = eventMapDefault;
+    if (isSetEventMapDefault() && elem114 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem112.length));
-      for(var elem113 in elem112.keys) {
-        final val = elem112[elem113];
-        oprot.writeInt64(elem113);
-        val.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem114.length));
+      for(var elem115 in elem114.keys) {
+        final elem116 = elem114[elem115];
+        oprot.writeInt64(elem115);
+        elem116.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem114 = eventSetDefault;
-    if (isSetEventSetDefault() && elem114 != null) {
+    final elem117 = eventSetDefault;
+    if (isSetEventSetDefault() && elem117 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem114.length));
-      for(var elem115 in elem114) {
-        elem115.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem117.length));
+      for(var elem118 in elem117) {
+        elem118.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
@@ -463,88 +463,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            this.ev = t_variety.Event();
-            ev.read(iprot);
+            final tmp_ev = t_variety.Event();
+            this.ev = tmp_ev;
+            tmp_ev.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem26 = iprot.readListBegin();
-            final elem29 = <t_variety.Event>[];
-            for(int elem28 = 0; elem28 < elem26.length; ++elem28) {
-              t_variety.Event elem27 = t_variety.Event();
-              elem27.read(iprot);
-              elem29.add(elem27);
+            thrift.TList elem49 = iprot.readListBegin();
+            final elem52 = <t_variety.Event>[];
+            for(int elem51 = 0; elem51 < elem49.length; ++elem51) {
+              final tmp_elem50 = t_variety.Event();
+              t_variety.Event elem50 = tmp_elem50;
+              tmp_elem50.read(iprot);
+              elem52.add(elem50);
             }
             iprot.readListEnd();
-            this.events = elem29;
+            this.events = elem52;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem30 = iprot.readSetBegin();
-            final elem33 = <t_variety.Event>{};
-            for(int elem32 = 0; elem32 < elem30.length; ++elem32) {
-              t_variety.Event elem31 = t_variety.Event();
-              elem31.read(iprot);
-              elem33.add(elem31);
+            thrift.TSet elem53 = iprot.readSetBegin();
+            final elem56 = <t_variety.Event>{};
+            for(int elem55 = 0; elem55 < elem53.length; ++elem55) {
+              final tmp_elem54 = t_variety.Event();
+              t_variety.Event elem54 = tmp_elem54;
+              tmp_elem54.read(iprot);
+              elem56.add(elem54);
             }
             iprot.readSetEnd();
-            this.events2 = elem33;
+            this.events2 = elem56;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem34 = iprot.readMapBegin();
-            final elem37 = <fixnum.Int64, t_variety.Event>{};
-            for(int elem36 = 0; elem36 < elem34.length; ++elem36) {
-              fixnum.Int64 elem38 = iprot.readInt64();
-              t_variety.Event elem35 = t_variety.Event();
-              elem35.read(iprot);
-              elem37[elem38] = elem35;
+            thrift.TMap elem57 = iprot.readMapBegin();
+            final elem60 = <fixnum.Int64, t_variety.Event>{};
+            for(int elem59 = 0; elem59 < elem57.length; ++elem59) {
+              fixnum.Int64 elem61 = iprot.readInt64();
+              final tmp_elem58 = t_variety.Event();
+              t_variety.Event elem58 = tmp_elem58;
+              tmp_elem58.read(iprot);
+              elem60[elem61] = elem58;
             }
             iprot.readMapEnd();
-            this.eventMap = elem37;
+            this.eventMap = elem60;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem39 = iprot.readListBegin();
-            final elem45 = <List<int>>[];
-            for(int elem44 = 0; elem44 < elem39.length; ++elem44) {
-              thrift.TList elem41 = iprot.readListBegin();
-              final elem40 = <int>[];
-              for(int elem43 = 0; elem43 < elem41.length; ++elem43) {
-                int elem42 = iprot.readI32();
-                elem40.add(elem42);
+            thrift.TList elem62 = iprot.readListBegin();
+            final elem68 = <List<int>>[];
+            for(int elem67 = 0; elem67 < elem62.length; ++elem67) {
+              thrift.TList elem64 = iprot.readListBegin();
+              final elem63 = <int>[];
+              for(int elem66 = 0; elem66 < elem64.length; ++elem66) {
+                int elem65 = iprot.readI32();
+                elem63.add(elem65);
               }
               iprot.readListEnd();
-              elem45.add(elem40);
+              elem68.add(elem63);
             }
             iprot.readListEnd();
-            this.nums = elem45;
+            this.nums = elem68;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem46 = iprot.readListBegin();
-            final elem49 = <int>[];
-            for(int elem48 = 0; elem48 < elem46.length; ++elem48) {
-              int elem47 = iprot.readI32();
-              elem49.add(elem47);
+            thrift.TList elem69 = iprot.readListBegin();
+            final elem72 = <int>[];
+            for(int elem71 = 0; elem71 < elem69.length; ++elem71) {
+              int elem70 = iprot.readI32();
+              elem72.add(elem70);
             }
             iprot.readListEnd();
-            this.enums = elem49;
+            this.enums = elem72;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -559,8 +563,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            this.a_union = t_variety.TestingUnions();
-            a_union.read(iprot);
+            final tmp_a_union = t_variety.TestingUnions();
+            this.a_union = tmp_a_union;
+            tmp_a_union.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -591,62 +596,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem50 = iprot.readListBegin();
+            thrift.TList elem73 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem53 = <bool>[];
-            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
-              bool elem51 = iprot.readBool();
+            final elem76 = <bool>[];
+            for(int elem75 = 0; elem75 < elem73.length; ++elem75) {
+              bool elem74 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem53.add(elem51);
+              elem76.add(elem74);
             }
             iprot.readListEnd();
-            this.deprList = elem53;
+            this.deprList = elem76;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem54 = iprot.readListBegin();
-            final elem57 = <t_variety.Event>[];
-            for(int elem56 = 0; elem56 < elem54.length; ++elem56) {
-              t_variety.Event elem55 = t_variety.Event();
-              elem55.read(iprot);
-              elem57.add(elem55);
+            thrift.TList elem77 = iprot.readListBegin();
+            final elem80 = <t_variety.Event>[];
+            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
+              final tmp_elem78 = t_variety.Event();
+              t_variety.Event elem78 = tmp_elem78;
+              tmp_elem78.read(iprot);
+              elem80.add(elem78);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem57;
+            this.eventsDefault = elem80;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem58 = iprot.readMapBegin();
-            final elem61 = <fixnum.Int64, t_variety.Event>{};
-            for(int elem60 = 0; elem60 < elem58.length; ++elem60) {
-              fixnum.Int64 elem62 = iprot.readInt64();
-              t_variety.Event elem59 = t_variety.Event();
-              elem59.read(iprot);
-              elem61[elem62] = elem59;
+            thrift.TMap elem81 = iprot.readMapBegin();
+            final elem84 = <fixnum.Int64, t_variety.Event>{};
+            for(int elem83 = 0; elem83 < elem81.length; ++elem83) {
+              fixnum.Int64 elem85 = iprot.readInt64();
+              final tmp_elem82 = t_variety.Event();
+              t_variety.Event elem82 = tmp_elem82;
+              tmp_elem82.read(iprot);
+              elem84[elem85] = elem82;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem61;
+            this.eventMapDefault = elem84;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem63 = iprot.readSetBegin();
-            final elem66 = <t_variety.Event>{};
-            for(int elem65 = 0; elem65 < elem63.length; ++elem65) {
-              t_variety.Event elem64 = t_variety.Event();
-              elem64.read(iprot);
-              elem66.add(elem64);
+            thrift.TSet elem86 = iprot.readSetBegin();
+            final elem89 = <t_variety.Event>{};
+            for(int elem88 = 0; elem88 < elem86.length; ++elem88) {
+              final tmp_elem87 = t_variety.Event();
+              t_variety.Event elem87 = tmp_elem87;
+              tmp_elem87.read(iprot);
+              elem89.add(elem87);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem66;
+            this.eventSetDefault = elem89;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -667,135 +675,140 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem90 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeInt64(this.iD);
+      oprot.writeInt64(elem90);
       oprot.writeFieldEnd();
     }
-    if (this.ev != null) {
+    final elem91 = ev;
+    if (elem91 != null) {
       oprot.writeFieldBegin(_EV_FIELD_DESC);
-      this.ev.write(oprot);
+      elem91.write(oprot);
       oprot.writeFieldEnd();
     }
-    if (this.events != null) {
+    final elem92 = events;
+    if (elem92 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      final temp = this.events;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
-      for(var elem67 in temp) {
-        elem67.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem92.length));
+      for(var elem93 in elem92) {
+        elem93.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (this.events2 != null) {
+    final elem94 = events2;
+    if (elem94 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      final temp = this.events2;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, temp.length));
-      for(var elem68 in temp) {
-        elem68.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem94.length));
+      for(var elem95 in elem94) {
+        elem95.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    if (this.eventMap != null) {
+    final elem96 = eventMap;
+    if (elem96 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      final temp = this.eventMap;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, temp.length));
-      for(var elem69 in temp.keys) {
-        oprot.writeInt64(elem69);
-        temp[elem69].write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem96.length));
+      for(var elem97 in elem96.keys) {
+        final val = elem96[elem97];
+        oprot.writeInt64(elem97);
+        val.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    if (this.nums != null) {
+    final elem98 = nums;
+    if (elem98 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      final temp = this.nums;
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, temp.length));
-      for(var elem70 in temp) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem70.length));
-        for(var elem71 in elem70) {
-          oprot.writeI32(elem71);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem98.length));
+      for(var elem99 in elem98) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem99.length));
+        for(var elem100 in elem99) {
+          oprot.writeI32(elem100);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (this.enums != null) {
+    final elem101 = enums;
+    if (elem101 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      final temp = this.enums;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem72 in temp) {
-        oprot.writeI32(elem72);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
+      for(var elem102 in elem101) {
+        oprot.writeI32(elem102);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem103 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(this.aBoolField);
+    oprot.writeBool(elem103);
     oprot.writeFieldEnd();
-    if (this.a_union != null) {
+    final elem104 = a_union;
+    if (elem104 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      this.a_union.write(oprot);
+      elem104.write(oprot);
       oprot.writeFieldEnd();
     }
-    if (this.typedefOfTypedef != null) {
+    final elem105 = typedefOfTypedef;
+    if (elem105 != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(this.typedefOfTypedef);
+      oprot.writeString(elem105);
       oprot.writeFieldEnd();
     }
+    final elem106 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    // ignore: deprecated_member_use
-    oprot.writeBool(this.depr);
+    oprot.writeBool(elem106);
     oprot.writeFieldEnd();
+    final elem107 = deprBinary;
     // ignore: deprecated_member_use
-    if (this.deprBinary != null) {
+    if (elem107 != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      // ignore: deprecated_member_use
-      oprot.writeBinary(this.deprBinary);
+      oprot.writeBinary(elem107);
       oprot.writeFieldEnd();
     }
+    final elem108 = deprList;
     // ignore: deprecated_member_use
-    if (this.deprList != null) {
+    if (elem108 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      // ignore: deprecated_member_use
-      final temp = this.deprList;
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, temp.length));
-      // ignore: deprecated_member_use
-      for(var elem73 in temp) {
-        oprot.writeBool(elem73);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem108.length));
+      for(var elem109 in elem108) {
+        oprot.writeBool(elem109);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetEventsDefault() && this.eventsDefault != null) {
+    final elem110 = eventsDefault;
+    if (isSetEventsDefault() && elem110 != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      final temp = this.eventsDefault;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
-      for(var elem74 in temp) {
-        elem74.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem110.length));
+      for(var elem111 in elem110) {
+        elem111.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetEventMapDefault() && this.eventMapDefault != null) {
+    final elem112 = eventMapDefault;
+    if (isSetEventMapDefault() && elem112 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      final temp = this.eventMapDefault;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, temp.length));
-      for(var elem75 in temp.keys) {
-        oprot.writeInt64(elem75);
-        temp[elem75].write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem112.length));
+      for(var elem113 in elem112.keys) {
+        final val = elem112[elem113];
+        oprot.writeInt64(elem113);
+        val.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetEventSetDefault() && this.eventSetDefault != null) {
+    final elem114 = eventSetDefault;
+    if (isSetEventSetDefault() && elem114 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      final temp = this.eventSetDefault;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, temp.length));
-      for(var elem76 in temp) {
-        elem76.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem114.length));
+      for(var elem115 in elem114) {
+        elem115.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
@@ -463,92 +463,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_ev = t_variety.Event();
-            this.ev = tmp_ev;
-            tmp_ev.read(iprot);
+            final elem53 = t_variety.Event();
+            this.ev = elem53;
+            elem53.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem50 = iprot.readListBegin();
-            final elem53 = <t_variety.Event>[];
-            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
-              final tmp_elem51 = t_variety.Event();
-              t_variety.Event elem51 = tmp_elem51;
-              tmp_elem51.read(iprot);
-              elem53.add(elem51);
+            thrift.TList elem54 = iprot.readListBegin();
+            final elem58 = <t_variety.Event>[];
+            for(int elem57 = 0; elem57 < elem54.length; ++elem57) {
+              final elem56 = t_variety.Event();
+              t_variety.Event elem55 = elem56;
+              elem56.read(iprot);
+              elem58.add(elem55);
             }
             iprot.readListEnd();
-            this.events = elem53;
+            this.events = elem58;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem54 = iprot.readSetBegin();
-            final elem57 = <t_variety.Event>{};
-            for(int elem56 = 0; elem56 < elem54.length; ++elem56) {
-              final tmp_elem55 = t_variety.Event();
-              t_variety.Event elem55 = tmp_elem55;
-              tmp_elem55.read(iprot);
-              elem57.add(elem55);
+            thrift.TSet elem59 = iprot.readSetBegin();
+            final elem63 = <t_variety.Event>{};
+            for(int elem62 = 0; elem62 < elem59.length; ++elem62) {
+              final elem61 = t_variety.Event();
+              t_variety.Event elem60 = elem61;
+              elem61.read(iprot);
+              elem63.add(elem60);
             }
             iprot.readSetEnd();
-            this.events2 = elem57;
+            this.events2 = elem63;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem58 = iprot.readMapBegin();
-            final elem61 = <fixnum.Int64, t_variety.Event>{};
-            for(int elem60 = 0; elem60 < elem58.length; ++elem60) {
-              fixnum.Int64 elem62 = iprot.readInt64();
-              final tmp_elem59 = t_variety.Event();
-              t_variety.Event elem59 = tmp_elem59;
-              tmp_elem59.read(iprot);
-              elem61[elem62] = elem59;
+            thrift.TMap elem64 = iprot.readMapBegin();
+            final elem68 = <fixnum.Int64, t_variety.Event>{};
+            for(int elem67 = 0; elem67 < elem64.length; ++elem67) {
+              fixnum.Int64 elem69 = iprot.readInt64();
+              final elem66 = t_variety.Event();
+              t_variety.Event elem65 = elem66;
+              elem66.read(iprot);
+              elem68[elem69] = elem65;
             }
             iprot.readMapEnd();
-            this.eventMap = elem61;
+            this.eventMap = elem68;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem63 = iprot.readListBegin();
-            final elem69 = <List<int>>[];
-            for(int elem68 = 0; elem68 < elem63.length; ++elem68) {
-              thrift.TList elem65 = iprot.readListBegin();
-              final elem64 = <int>[];
-              for(int elem67 = 0; elem67 < elem65.length; ++elem67) {
-                int elem66 = iprot.readI32();
-                elem64.add(elem66);
+            thrift.TList elem70 = iprot.readListBegin();
+            final elem76 = <List<int>>[];
+            for(int elem75 = 0; elem75 < elem70.length; ++elem75) {
+              thrift.TList elem72 = iprot.readListBegin();
+              final elem71 = <int>[];
+              for(int elem74 = 0; elem74 < elem72.length; ++elem74) {
+                int elem73 = iprot.readI32();
+                elem71.add(elem73);
               }
               iprot.readListEnd();
-              elem69.add(elem64);
+              elem76.add(elem71);
             }
             iprot.readListEnd();
-            this.nums = elem69;
+            this.nums = elem76;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem70 = iprot.readListBegin();
-            final elem73 = <int>[];
-            for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
-              int elem71 = iprot.readI32();
-              elem73.add(elem71);
+            thrift.TList elem77 = iprot.readListBegin();
+            final elem80 = <int>[];
+            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
+              int elem78 = iprot.readI32();
+              elem80.add(elem78);
             }
             iprot.readListEnd();
-            this.enums = elem73;
+            this.enums = elem80;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -563,9 +563,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_a_union = t_variety.TestingUnions();
-            this.a_union = tmp_a_union;
-            tmp_a_union.read(iprot);
+            final elem81 = t_variety.TestingUnions();
+            this.a_union = elem81;
+            elem81.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -596,65 +596,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem74 = iprot.readListBegin();
+            thrift.TList elem82 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem77 = <bool>[];
-            for(int elem76 = 0; elem76 < elem74.length; ++elem76) {
-              bool elem75 = iprot.readBool();
+            final elem85 = <bool>[];
+            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
+              bool elem83 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem77.add(elem75);
+              elem85.add(elem83);
             }
             iprot.readListEnd();
-            this.deprList = elem77;
+            this.deprList = elem85;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem78 = iprot.readListBegin();
-            final elem81 = <t_variety.Event>[];
-            for(int elem80 = 0; elem80 < elem78.length; ++elem80) {
-              final tmp_elem79 = t_variety.Event();
-              t_variety.Event elem79 = tmp_elem79;
-              tmp_elem79.read(iprot);
-              elem81.add(elem79);
+            thrift.TList elem86 = iprot.readListBegin();
+            final elem90 = <t_variety.Event>[];
+            for(int elem89 = 0; elem89 < elem86.length; ++elem89) {
+              final elem88 = t_variety.Event();
+              t_variety.Event elem87 = elem88;
+              elem88.read(iprot);
+              elem90.add(elem87);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem81;
+            this.eventsDefault = elem90;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem82 = iprot.readMapBegin();
-            final elem85 = <fixnum.Int64, t_variety.Event>{};
-            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
-              fixnum.Int64 elem86 = iprot.readInt64();
-              final tmp_elem83 = t_variety.Event();
-              t_variety.Event elem83 = tmp_elem83;
-              tmp_elem83.read(iprot);
-              elem85[elem86] = elem83;
+            thrift.TMap elem91 = iprot.readMapBegin();
+            final elem95 = <fixnum.Int64, t_variety.Event>{};
+            for(int elem94 = 0; elem94 < elem91.length; ++elem94) {
+              fixnum.Int64 elem96 = iprot.readInt64();
+              final elem93 = t_variety.Event();
+              t_variety.Event elem92 = elem93;
+              elem93.read(iprot);
+              elem95[elem96] = elem92;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem85;
+            this.eventMapDefault = elem95;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem87 = iprot.readSetBegin();
-            final elem90 = <t_variety.Event>{};
-            for(int elem89 = 0; elem89 < elem87.length; ++elem89) {
-              final tmp_elem88 = t_variety.Event();
-              t_variety.Event elem88 = tmp_elem88;
-              tmp_elem88.read(iprot);
-              elem90.add(elem88);
+            thrift.TSet elem97 = iprot.readSetBegin();
+            final elem101 = <t_variety.Event>{};
+            for(int elem100 = 0; elem100 < elem97.length; ++elem100) {
+              final elem99 = t_variety.Event();
+              t_variety.Event elem98 = elem99;
+              elem99.read(iprot);
+              elem101.add(elem98);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem90;
+            this.eventSetDefault = elem101;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -675,140 +675,140 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem91 = iD;
+    final elem102 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeInt64(elem91);
+      oprot.writeInt64(elem102);
       oprot.writeFieldEnd();
     }
-    final elem92 = ev;
-    if (elem92 != null) {
+    final elem103 = ev;
+    if (elem103 != null) {
       oprot.writeFieldBegin(_EV_FIELD_DESC);
-      elem92.write(oprot);
+      elem103.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem93 = events;
-    if (elem93 != null) {
+    final elem104 = events;
+    if (elem104 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem93.length));
-      for(var elem94 in elem93) {
-        elem94.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem104.length));
+      for(var elem105 in elem104) {
+        elem105.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem95 = events2;
-    if (elem95 != null) {
+    final elem106 = events2;
+    if (elem106 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem95.length));
-      for(var elem96 in elem95) {
-        elem96.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem106.length));
+      for(var elem107 in elem106) {
+        elem107.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem97 = eventMap;
-    if (elem97 != null) {
+    final elem108 = eventMap;
+    if (elem108 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem97.length));
-      for(var elem98 in elem97.keys) {
-        final elem99 = elem97[elem98];
-        oprot.writeInt64(elem98);
-        elem99.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem108.length));
+      for(var elem109 in elem108.keys) {
+        final elem110 = elem108[elem109];
+        oprot.writeInt64(elem109);
+        elem110.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem100 = nums;
-    if (elem100 != null) {
+    final elem111 = nums;
+    if (elem111 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem100.length));
-      for(var elem101 in elem100) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
-        for(var elem102 in elem101) {
-          oprot.writeI32(elem102);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem111.length));
+      for(var elem112 in elem111) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem112.length));
+        for(var elem113 in elem112) {
+          oprot.writeI32(elem113);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem103 = enums;
-    if (elem103 != null) {
+    final elem114 = enums;
+    if (elem114 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem103.length));
-      for(var elem104 in elem103) {
-        oprot.writeI32(elem104);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem114.length));
+      for(var elem115 in elem114) {
+        oprot.writeI32(elem115);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem105 = aBoolField;
+    final elem116 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem105);
+    oprot.writeBool(elem116);
     oprot.writeFieldEnd();
-    final elem106 = a_union;
-    if (elem106 != null) {
+    final elem117 = a_union;
+    if (elem117 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem106.write(oprot);
+      elem117.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem107 = typedefOfTypedef;
-    if (elem107 != null) {
+    final elem118 = typedefOfTypedef;
+    if (elem118 != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem107);
+      oprot.writeString(elem118);
       oprot.writeFieldEnd();
     }
-    final elem108 = depr;
+    final elem119 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem108);
+    oprot.writeBool(elem119);
     oprot.writeFieldEnd();
-    final elem109 = deprBinary;
+    final elem120 = deprBinary;
     // ignore: deprecated_member_use
-    if (elem109 != null) {
+    if (elem120 != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem109);
+      oprot.writeBinary(elem120);
       oprot.writeFieldEnd();
     }
-    final elem110 = deprList;
+    final elem121 = deprList;
     // ignore: deprecated_member_use
-    if (elem110 != null) {
+    if (elem121 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem110.length));
-      for(var elem111 in elem110) {
-        oprot.writeBool(elem111);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem121.length));
+      for(var elem122 in elem121) {
+        oprot.writeBool(elem122);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem112 = eventsDefault;
-    if (isSetEventsDefault() && elem112 != null) {
+    final elem123 = eventsDefault;
+    if (isSetEventsDefault() && elem123 != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem112.length));
-      for(var elem113 in elem112) {
-        elem113.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem123.length));
+      for(var elem124 in elem123) {
+        elem124.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem114 = eventMapDefault;
-    if (isSetEventMapDefault() && elem114 != null) {
+    final elem125 = eventMapDefault;
+    if (isSetEventMapDefault() && elem125 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem114.length));
-      for(var elem115 in elem114.keys) {
-        final elem116 = elem114[elem115];
-        oprot.writeInt64(elem115);
-        elem116.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem125.length));
+      for(var elem126 in elem125.keys) {
+        final elem127 = elem125[elem126];
+        oprot.writeInt64(elem126);
+        elem127.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem117 = eventSetDefault;
-    if (isSetEventSetDefault() && elem117 != null) {
+    final elem128 = eventSetDefault;
+    if (isSetEventSetDefault() && elem128 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem117.length));
-      for(var elem118 in elem117) {
-        elem118.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem128.length));
+      for(var elem129 in elem128) {
+        elem129.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
@@ -463,92 +463,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            final elem53 = t_variety.Event();
-            this.ev = elem53;
-            elem53.read(iprot);
+            final elem51 = t_variety.Event();
+            this.ev = elem51;
+            elem51.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem54 = iprot.readListBegin();
-            final elem58 = <t_variety.Event>[];
-            for(int elem57 = 0; elem57 < elem54.length; ++elem57) {
-              final elem56 = t_variety.Event();
-              t_variety.Event elem55 = elem56;
-              elem56.read(iprot);
-              elem58.add(elem55);
+            thrift.TList elem52 = iprot.readListBegin();
+            final elem56 = <t_variety.Event>[];
+            for(int elem55 = 0; elem55 < elem52.length; ++elem55) {
+              final elem54 = t_variety.Event();
+              t_variety.Event elem53 = elem54;
+              elem54.read(iprot);
+              elem56.add(elem53);
             }
             iprot.readListEnd();
-            this.events = elem58;
+            this.events = elem56;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem59 = iprot.readSetBegin();
-            final elem63 = <t_variety.Event>{};
-            for(int elem62 = 0; elem62 < elem59.length; ++elem62) {
-              final elem61 = t_variety.Event();
-              t_variety.Event elem60 = elem61;
-              elem61.read(iprot);
-              elem63.add(elem60);
+            thrift.TSet elem57 = iprot.readSetBegin();
+            final elem61 = <t_variety.Event>{};
+            for(int elem60 = 0; elem60 < elem57.length; ++elem60) {
+              final elem59 = t_variety.Event();
+              t_variety.Event elem58 = elem59;
+              elem59.read(iprot);
+              elem61.add(elem58);
             }
             iprot.readSetEnd();
-            this.events2 = elem63;
+            this.events2 = elem61;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem64 = iprot.readMapBegin();
-            final elem68 = <fixnum.Int64, t_variety.Event>{};
-            for(int elem67 = 0; elem67 < elem64.length; ++elem67) {
-              fixnum.Int64 elem69 = iprot.readInt64();
-              final elem66 = t_variety.Event();
-              t_variety.Event elem65 = elem66;
-              elem66.read(iprot);
-              elem68[elem69] = elem65;
+            thrift.TMap elem62 = iprot.readMapBegin();
+            final elem66 = <fixnum.Int64, t_variety.Event>{};
+            for(int elem65 = 0; elem65 < elem62.length; ++elem65) {
+              fixnum.Int64 elem67 = iprot.readInt64();
+              final elem64 = t_variety.Event();
+              t_variety.Event elem63 = elem64;
+              elem64.read(iprot);
+              elem66[elem67] = elem63;
             }
             iprot.readMapEnd();
-            this.eventMap = elem68;
+            this.eventMap = elem66;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem70 = iprot.readListBegin();
-            final elem76 = <List<int>>[];
-            for(int elem75 = 0; elem75 < elem70.length; ++elem75) {
-              thrift.TList elem72 = iprot.readListBegin();
-              final elem71 = <int>[];
-              for(int elem74 = 0; elem74 < elem72.length; ++elem74) {
-                int elem73 = iprot.readI32();
-                elem71.add(elem73);
+            thrift.TList elem68 = iprot.readListBegin();
+            final elem74 = <List<int>>[];
+            for(int elem73 = 0; elem73 < elem68.length; ++elem73) {
+              thrift.TList elem70 = iprot.readListBegin();
+              final elem69 = <int>[];
+              for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
+                int elem71 = iprot.readI32();
+                elem69.add(elem71);
               }
               iprot.readListEnd();
-              elem76.add(elem71);
+              elem74.add(elem69);
             }
             iprot.readListEnd();
-            this.nums = elem76;
+            this.nums = elem74;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem77 = iprot.readListBegin();
-            final elem80 = <int>[];
-            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
-              int elem78 = iprot.readI32();
-              elem80.add(elem78);
+            thrift.TList elem75 = iprot.readListBegin();
+            final elem78 = <int>[];
+            for(int elem77 = 0; elem77 < elem75.length; ++elem77) {
+              int elem76 = iprot.readI32();
+              elem78.add(elem76);
             }
             iprot.readListEnd();
-            this.enums = elem80;
+            this.enums = elem78;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -563,9 +563,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            final elem81 = t_variety.TestingUnions();
-            this.a_union = elem81;
-            elem81.read(iprot);
+            final elem79 = t_variety.TestingUnions();
+            this.a_union = elem79;
+            elem79.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -596,65 +596,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem82 = iprot.readListBegin();
+            thrift.TList elem80 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem85 = <bool>[];
-            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
-              bool elem83 = iprot.readBool();
+            final elem83 = <bool>[];
+            for(int elem82 = 0; elem82 < elem80.length; ++elem82) {
+              bool elem81 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem85.add(elem83);
+              elem83.add(elem81);
             }
             iprot.readListEnd();
-            this.deprList = elem85;
+            this.deprList = elem83;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem86 = iprot.readListBegin();
-            final elem90 = <t_variety.Event>[];
-            for(int elem89 = 0; elem89 < elem86.length; ++elem89) {
-              final elem88 = t_variety.Event();
-              t_variety.Event elem87 = elem88;
-              elem88.read(iprot);
-              elem90.add(elem87);
+            thrift.TList elem84 = iprot.readListBegin();
+            final elem88 = <t_variety.Event>[];
+            for(int elem87 = 0; elem87 < elem84.length; ++elem87) {
+              final elem86 = t_variety.Event();
+              t_variety.Event elem85 = elem86;
+              elem86.read(iprot);
+              elem88.add(elem85);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem90;
+            this.eventsDefault = elem88;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem91 = iprot.readMapBegin();
-            final elem95 = <fixnum.Int64, t_variety.Event>{};
-            for(int elem94 = 0; elem94 < elem91.length; ++elem94) {
-              fixnum.Int64 elem96 = iprot.readInt64();
-              final elem93 = t_variety.Event();
-              t_variety.Event elem92 = elem93;
-              elem93.read(iprot);
-              elem95[elem96] = elem92;
+            thrift.TMap elem89 = iprot.readMapBegin();
+            final elem93 = <fixnum.Int64, t_variety.Event>{};
+            for(int elem92 = 0; elem92 < elem89.length; ++elem92) {
+              fixnum.Int64 elem94 = iprot.readInt64();
+              final elem91 = t_variety.Event();
+              t_variety.Event elem90 = elem91;
+              elem91.read(iprot);
+              elem93[elem94] = elem90;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem95;
+            this.eventMapDefault = elem93;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem97 = iprot.readSetBegin();
-            final elem101 = <t_variety.Event>{};
-            for(int elem100 = 0; elem100 < elem97.length; ++elem100) {
-              final elem99 = t_variety.Event();
-              t_variety.Event elem98 = elem99;
-              elem99.read(iprot);
-              elem101.add(elem98);
+            thrift.TSet elem95 = iprot.readSetBegin();
+            final elem99 = <t_variety.Event>{};
+            for(int elem98 = 0; elem98 < elem95.length; ++elem98) {
+              final elem97 = t_variety.Event();
+              t_variety.Event elem96 = elem97;
+              elem97.read(iprot);
+              elem99.add(elem96);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem101;
+            this.eventSetDefault = elem99;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -675,140 +675,138 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem102 = iD;
+    final elem100 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeInt64(elem102);
+      oprot.writeInt64(elem100);
       oprot.writeFieldEnd();
     }
-    final elem103 = ev;
-    if (elem103 != null) {
+    final elem101 = ev;
+    if (elem101 != null) {
       oprot.writeFieldBegin(_EV_FIELD_DESC);
-      elem103.write(oprot);
+      elem101.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem104 = events;
-    if (elem104 != null) {
+    final elem102 = events;
+    if (elem102 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem104.length));
-      for(var elem105 in elem104) {
-        elem105.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem102.length));
+      for(var elem103 in elem102) {
+        elem103.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem106 = events2;
-    if (elem106 != null) {
+    final elem104 = events2;
+    if (elem104 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem106.length));
-      for(var elem107 in elem106) {
-        elem107.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem104.length));
+      for(var elem105 in elem104) {
+        elem105.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem108 = eventMap;
-    if (elem108 != null) {
+    final elem106 = eventMap;
+    if (elem106 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem108.length));
-      for(var elem109 in elem108.keys) {
-        final elem110 = elem108[elem109];
-        oprot.writeInt64(elem109);
-        elem110.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem106.length));
+      for(var entry in elem106.entries) {
+        oprot.writeInt64(entry.key);
+        entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem111 = nums;
-    if (elem111 != null) {
+    final elem107 = nums;
+    if (elem107 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem111.length));
-      for(var elem112 in elem111) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem112.length));
-        for(var elem113 in elem112) {
-          oprot.writeI32(elem113);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem107.length));
+      for(var elem108 in elem107) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem108.length));
+        for(var elem109 in elem108) {
+          oprot.writeI32(elem109);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem114 = enums;
-    if (elem114 != null) {
+    final elem110 = enums;
+    if (elem110 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem114.length));
-      for(var elem115 in elem114) {
-        oprot.writeI32(elem115);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem110.length));
+      for(var elem111 in elem110) {
+        oprot.writeI32(elem111);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem116 = aBoolField;
+    final elem112 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem116);
+    oprot.writeBool(elem112);
     oprot.writeFieldEnd();
-    final elem117 = a_union;
-    if (elem117 != null) {
+    final elem113 = a_union;
+    if (elem113 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem117.write(oprot);
+      elem113.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem118 = typedefOfTypedef;
-    if (elem118 != null) {
+    final elem114 = typedefOfTypedef;
+    if (elem114 != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem118);
+      oprot.writeString(elem114);
       oprot.writeFieldEnd();
     }
-    final elem119 = depr;
+    final elem115 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem119);
+    oprot.writeBool(elem115);
     oprot.writeFieldEnd();
-    final elem120 = deprBinary;
+    final elem116 = deprBinary;
     // ignore: deprecated_member_use
-    if (elem120 != null) {
+    if (elem116 != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem120);
+      oprot.writeBinary(elem116);
       oprot.writeFieldEnd();
     }
-    final elem121 = deprList;
+    final elem117 = deprList;
     // ignore: deprecated_member_use
-    if (elem121 != null) {
+    if (elem117 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem121.length));
-      for(var elem122 in elem121) {
-        oprot.writeBool(elem122);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem117.length));
+      for(var elem118 in elem117) {
+        oprot.writeBool(elem118);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem123 = eventsDefault;
-    if (isSetEventsDefault() && elem123 != null) {
+    final elem119 = eventsDefault;
+    if (isSetEventsDefault() && elem119 != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem123.length));
-      for(var elem124 in elem123) {
-        elem124.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem119.length));
+      for(var elem120 in elem119) {
+        elem120.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem125 = eventMapDefault;
-    if (isSetEventMapDefault() && elem125 != null) {
+    final elem121 = eventMapDefault;
+    if (isSetEventMapDefault() && elem121 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem125.length));
-      for(var elem126 in elem125.keys) {
-        final elem127 = elem125[elem126];
-        oprot.writeInt64(elem126);
-        elem127.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem121.length));
+      for(var entry in elem121.entries) {
+        oprot.writeInt64(entry.key);
+        entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem128 = eventSetDefault;
-    if (isSetEventSetDefault() && elem128 != null) {
+    final elem122 = eventSetDefault;
+    if (isSetEventSetDefault() && elem122 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem128.length));
-      for(var elem129 in elem128) {
-        elem129.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem122.length));
+      for(var elem123 in elem122) {
+        elem123.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.int64/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_events_scope.dart
@@ -123,12 +123,12 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem164 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem164.length));
-      for(var elem165 in elem164.keys) {
-        final elem166 = elem164[elem165];
-        oprot.writeInt64(elem165);
-        elem166.write(oprot);
+    for(var elem180 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem180.length));
+      for(var elem181 in elem180.keys) {
+        final elem182 = elem180[elem181];
+        oprot.writeInt64(elem181);
+        elem182.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -176,9 +176,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final tmp_req = t_variety.Event();
-      t_variety.Event req = tmp_req;
-      tmp_req.read(iprot);
+      final elem183 = t_variety.Event();
+      t_variety.Event req = elem183;
+      elem183.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -265,20 +265,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem167 = iprot.readListBegin();
+      thrift.TList elem184 = iprot.readListBegin();
       final req = <Map<fixnum.Int64, t_variety.Event>>[];
-      for(int elem173 = 0; elem173 < elem167.length; ++elem173) {
-        thrift.TMap elem169 = iprot.readMapBegin();
-        final elem168 = <fixnum.Int64, t_variety.Event>{};
-        for(int elem171 = 0; elem171 < elem169.length; ++elem171) {
-          fixnum.Int64 elem172 = iprot.readInt64();
-          final tmp_elem170 = t_variety.Event();
-          t_variety.Event elem170 = tmp_elem170;
-          tmp_elem170.read(iprot);
-          elem168[elem172] = elem170;
+      for(int elem191 = 0; elem191 < elem184.length; ++elem191) {
+        thrift.TMap elem186 = iprot.readMapBegin();
+        final elem185 = <fixnum.Int64, t_variety.Event>{};
+        for(int elem189 = 0; elem189 < elem186.length; ++elem189) {
+          fixnum.Int64 elem190 = iprot.readInt64();
+          final elem188 = t_variety.Event();
+          t_variety.Event elem187 = elem188;
+          elem188.read(iprot);
+          elem185[elem190] = elem187;
         }
         iprot.readMapEnd();
-        req.add(elem168);
+        req.add(elem185);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_events_scope.dart
@@ -123,12 +123,11 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem180 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem180.length));
-      for(var elem181 in elem180.keys) {
-        final elem182 = elem180[elem181];
-        oprot.writeInt64(elem181);
-        elem182.write(oprot);
+    for(var elem170 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem170.length));
+      for(var entry in elem170.entries) {
+        oprot.writeInt64(entry.key);
+        entry.value.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -176,9 +175,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final elem183 = t_variety.Event();
-      t_variety.Event req = elem183;
-      elem183.read(iprot);
+      final elem171 = t_variety.Event();
+      t_variety.Event req = elem171;
+      elem171.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -265,20 +264,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem184 = iprot.readListBegin();
+      thrift.TList elem172 = iprot.readListBegin();
       final req = <Map<fixnum.Int64, t_variety.Event>>[];
-      for(int elem191 = 0; elem191 < elem184.length; ++elem191) {
-        thrift.TMap elem186 = iprot.readMapBegin();
-        final elem185 = <fixnum.Int64, t_variety.Event>{};
-        for(int elem189 = 0; elem189 < elem186.length; ++elem189) {
-          fixnum.Int64 elem190 = iprot.readInt64();
-          final elem188 = t_variety.Event();
-          t_variety.Event elem187 = elem188;
-          elem188.read(iprot);
-          elem185[elem190] = elem187;
+      for(int elem179 = 0; elem179 < elem172.length; ++elem179) {
+        thrift.TMap elem174 = iprot.readMapBegin();
+        final elem173 = <fixnum.Int64, t_variety.Event>{};
+        for(int elem177 = 0; elem177 < elem174.length; ++elem177) {
+          fixnum.Int64 elem178 = iprot.readInt64();
+          final elem176 = t_variety.Event();
+          t_variety.Event elem175 = elem176;
+          elem176.read(iprot);
+          elem173[elem178] = elem175;
         }
         iprot.readMapEnd();
-        req.add(elem185);
+        req.add(elem173);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_events_scope.dart
@@ -123,11 +123,12 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem90 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem90.length));
-      for(var elem91 in elem90.keys) {
-        oprot.writeInt64(elem91);
-        elem90[elem91].write(oprot);
+    for(var elem159 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem159.length));
+      for(var elem160 in elem159.keys) {
+        final val = elem159[elem160];
+        oprot.writeInt64(elem160);
+        val.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -175,8 +176,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      t_variety.Event req = t_variety.Event();
-      req.read(iprot);
+      final tmp_req = t_variety.Event();
+      t_variety.Event req = tmp_req;
+      tmp_req.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -263,19 +265,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem92 = iprot.readListBegin();
+      thrift.TList elem161 = iprot.readListBegin();
       final req = <Map<fixnum.Int64, t_variety.Event>>[];
-      for(int elem98 = 0; elem98 < elem92.length; ++elem98) {
-        thrift.TMap elem94 = iprot.readMapBegin();
-        final elem93 = <fixnum.Int64, t_variety.Event>{};
-        for(int elem96 = 0; elem96 < elem94.length; ++elem96) {
-          fixnum.Int64 elem97 = iprot.readInt64();
-          t_variety.Event elem95 = t_variety.Event();
-          elem95.read(iprot);
-          elem93[elem97] = elem95;
+      for(int elem167 = 0; elem167 < elem161.length; ++elem167) {
+        thrift.TMap elem163 = iprot.readMapBegin();
+        final elem162 = <fixnum.Int64, t_variety.Event>{};
+        for(int elem165 = 0; elem165 < elem163.length; ++elem165) {
+          fixnum.Int64 elem166 = iprot.readInt64();
+          final tmp_elem164 = t_variety.Event();
+          t_variety.Event elem164 = tmp_elem164;
+          tmp_elem164.read(iprot);
+          elem162[elem166] = elem164;
         }
         iprot.readMapEnd();
-        req.add(elem93);
+        req.add(elem162);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_events_scope.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
@@ -66,9 +64,7 @@ class EventsPublisher {
     oprot.writeMessageBegin(msg);
     req.write(oprot);
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 
 
@@ -88,9 +84,7 @@ class EventsPublisher {
     oprot.writeMessageBegin(msg);
     oprot.writeInt64(req);
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 
 
@@ -110,9 +104,7 @@ class EventsPublisher {
     oprot.writeMessageBegin(msg);
     oprot.writeString(req);
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 
 
@@ -141,9 +133,7 @@ class EventsPublisher {
     }
     oprot.writeListEnd();
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 }
 

--- a/compiler/testdata/expected/dart.int64/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_events_scope.dart
@@ -123,12 +123,12 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem159 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem159.length));
-      for(var elem160 in elem159.keys) {
-        final val = elem159[elem160];
-        oprot.writeInt64(elem160);
-        val.write(oprot);
+    for(var elem164 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem164.length));
+      for(var elem165 in elem164.keys) {
+        final elem166 = elem164[elem165];
+        oprot.writeInt64(elem165);
+        elem166.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -265,20 +265,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem161 = iprot.readListBegin();
+      thrift.TList elem167 = iprot.readListBegin();
       final req = <Map<fixnum.Int64, t_variety.Event>>[];
-      for(int elem167 = 0; elem167 < elem161.length; ++elem167) {
-        thrift.TMap elem163 = iprot.readMapBegin();
-        final elem162 = <fixnum.Int64, t_variety.Event>{};
-        for(int elem165 = 0; elem165 < elem163.length; ++elem165) {
-          fixnum.Int64 elem166 = iprot.readInt64();
-          final tmp_elem164 = t_variety.Event();
-          t_variety.Event elem164 = tmp_elem164;
-          tmp_elem164.read(iprot);
-          elem162[elem166] = elem164;
+      for(int elem173 = 0; elem173 < elem167.length; ++elem173) {
+        thrift.TMap elem169 = iprot.readMapBegin();
+        final elem168 = <fixnum.Int64, t_variety.Event>{};
+        for(int elem171 = 0; elem171 < elem169.length; ++elem171) {
+          fixnum.Int64 elem172 = iprot.readInt64();
+          final tmp_elem170 = t_variety.Event();
+          t_variety.Event elem170 = tmp_elem170;
+          tmp_elem170.read(iprot);
+          elem168[elem172] = elem170;
         }
         iprot.readMapEnd();
-        req.add(elem162);
+        req.add(elem168);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
@@ -149,22 +149,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem119 = newMessage;
-    if (elem119 != null) {
+    final elem130 = newMessage;
+    if (elem130 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem119);
+      oprot.writeString(elem130);
       oprot.writeFieldEnd();
     }
-    final elem120 = messageArgs;
-    if (elem120 != null) {
+    final elem131 = messageArgs;
+    if (elem131 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem120);
+      oprot.writeString(elem131);
       oprot.writeFieldEnd();
     }
-    final elem121 = messageResult;
-    if (elem121 != null) {
+    final elem132 = messageResult;
+    if (elem132 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem121);
+      oprot.writeString(elem132);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
@@ -149,22 +149,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem130 = newMessage;
-    if (elem130 != null) {
+    final elem124 = newMessage;
+    if (elem124 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem130);
+      oprot.writeString(elem124);
       oprot.writeFieldEnd();
     }
-    final elem131 = messageArgs;
-    if (elem131 != null) {
+    final elem125 = messageArgs;
+    if (elem125 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem131);
+      oprot.writeString(elem125);
       oprot.writeFieldEnd();
     }
-    final elem132 = messageResult;
-    if (elem132 != null) {
+    final elem126 = messageResult;
+    if (elem126 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem132);
+      oprot.writeString(elem126);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
@@ -149,22 +149,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem116 = newMessage;
-    if (elem116 != null) {
+    final elem119 = newMessage;
+    if (elem119 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem116);
+      oprot.writeString(elem119);
       oprot.writeFieldEnd();
     }
-    final elem117 = messageArgs;
-    if (elem117 != null) {
+    final elem120 = messageArgs;
+    if (elem120 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem117);
+      oprot.writeString(elem120);
       oprot.writeFieldEnd();
     }
-    final elem118 = messageResult;
-    if (elem118 != null) {
+    final elem121 = messageResult;
+    if (elem121 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem118);
+      oprot.writeString(elem121);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
@@ -149,19 +149,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.newMessage != null) {
+    final elem116 = newMessage;
+    if (elem116 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(this.newMessage);
+      oprot.writeString(elem116);
       oprot.writeFieldEnd();
     }
-    if (this.messageArgs != null) {
+    final elem117 = messageArgs;
+    if (elem117 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(this.messageArgs);
+      oprot.writeString(elem117);
       oprot.writeFieldEnd();
     }
-    if (this.messageResult != null) {
+    final elem118 = messageResult;
+    if (elem118 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(this.messageResult);
+      oprot.writeString(elem118);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.int64/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_foo_service.dart
@@ -419,20 +419,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem136 = num;
+    final elem140 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem136);
+    oprot.writeI32(elem140);
     oprot.writeFieldEnd();
-    final elem137 = str;
-    if (elem137 != null) {
+    final elem141 = str;
+    if (elem141 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem137);
+      oprot.writeString(elem141);
       oprot.writeFieldEnd();
     }
-    final elem138 = event;
-    if (elem138 != null) {
+    final elem142 = event;
+    if (elem142 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem138.write(oprot);
+      elem142.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -510,18 +510,18 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem139 = id;
+    final elem143 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(elem139);
+    oprot.writeInt64(elem143);
     oprot.writeFieldEnd();
-    final elem140 = req;
-    if (elem140 != null) {
+    final elem144 = req;
+    if (elem144 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem140.length));
-      for(var elem141 in elem140.keys) {
-        final val = elem140[elem141];
-        oprot.writeI32(elem141);
-        oprot.writeString(val);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem144.length));
+      for(var elem145 in elem144.keys) {
+        final elem146 = elem144[elem145];
+        oprot.writeI32(elem145);
+        oprot.writeString(elem146);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -548,16 +548,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem142 = bin;
-    if (elem142 != null) {
+    final elem147 = bin;
+    if (elem147 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem142);
+      oprot.writeBinary(elem147);
       oprot.writeFieldEnd();
     }
-    final elem143 = str;
-    if (elem143 != null) {
+    final elem148 = str;
+    if (elem148 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem143);
+      oprot.writeString(elem148);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -627,17 +627,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem144 = opt_num;
+    final elem149 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem144);
+    oprot.writeI32(elem149);
     oprot.writeFieldEnd();
-    final elem145 = default_num;
+    final elem150 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem145);
+    oprot.writeI32(elem150);
     oprot.writeFieldEnd();
-    final elem146 = req_num;
+    final elem151 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem146);
+    oprot.writeI32(elem151);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -698,22 +698,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem147 = list_type;
-    if (elem147 != null) {
+    final elem152 = list_type;
+    if (elem152 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem147.length));
-      for(var elem148 in elem147) {
-        oprot.writeInt64(elem148);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem152.length));
+      for(var elem153 in elem152) {
+        oprot.writeInt64(elem153);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem149 = set_type;
-    if (elem149 != null) {
+    final elem154 = set_type;
+    if (elem154 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem149.length));
-      for(var elem150 in elem149) {
-        oprot.writeInt64(elem150);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem154.length));
+      for(var elem155 in elem154) {
+        oprot.writeInt64(elem155);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -739,14 +739,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem151 = iprot.readListBegin();
-            final elem154 = <fixnum.Int64>[];
-            for(int elem153 = 0; elem153 < elem151.length; ++elem153) {
-              fixnum.Int64 elem152 = iprot.readInt64();
-              elem154.add(elem152);
+            thrift.TList elem156 = iprot.readListBegin();
+            final elem159 = <fixnum.Int64>[];
+            for(int elem158 = 0; elem158 < elem156.length; ++elem158) {
+              fixnum.Int64 elem157 = iprot.readInt64();
+              elem159.add(elem157);
             }
             iprot.readListEnd();
-            this.success = elem154;
+            this.success = elem159;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -882,10 +882,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem155 = a;
-    if (elem155 != null) {
+    final elem160 = a;
+    if (elem160 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem155.write(oprot);
+      elem160.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -943,10 +943,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem156 = newMessage;
-    if (elem156 != null) {
+    final elem161 = newMessage;
+    if (elem161 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem156);
+      oprot.writeString(elem161);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1002,10 +1002,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem157 = messageArgs;
-    if (elem157 != null) {
+    final elem162 = messageArgs;
+    if (elem162 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem157);
+      oprot.writeString(elem162);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1061,10 +1061,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem158 = messageResult;
-    if (elem158 != null) {
+    final elem163 = messageResult;
+    if (elem163 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem158);
+      oprot.writeString(elem163);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_foo_service.dart
@@ -419,17 +419,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem136 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(this.num);
+    oprot.writeI32(elem136);
     oprot.writeFieldEnd();
-    if (this.str != null) {
+    final elem137 = str;
+    if (elem137 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(this.str);
+      oprot.writeString(elem137);
       oprot.writeFieldEnd();
     }
-    if (this.event != null) {
+    final elem138 = event;
+    if (elem138 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      this.event.write(oprot);
+      elem138.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -462,16 +465,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            this.awe = t_variety.AwesomeException();
-            awe.read(iprot);
+            final tmp_awe = t_variety.AwesomeException();
+            this.awe = tmp_awe;
+            tmp_awe.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            this.api = t_actual_base_dart.api_exception();
-            api.read(iprot);
+            final tmp_api = t_actual_base_dart.api_exception();
+            this.api = tmp_api;
+            tmp_api.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -505,16 +510,18 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem139 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(this.id);
+    oprot.writeInt64(elem139);
     oprot.writeFieldEnd();
-    if (this.req != null) {
+    final elem140 = req;
+    if (elem140 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      final temp = this.req;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, temp.length));
-      for(var elem83 in temp.keys) {
-        oprot.writeI32(elem83);
-        oprot.writeString(temp[elem83]);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem140.length));
+      for(var elem141 in elem140.keys) {
+        final val = elem140[elem141];
+        oprot.writeI32(elem141);
+        oprot.writeString(val);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -541,14 +548,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.bin != null) {
+    final elem142 = bin;
+    if (elem142 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(this.bin);
+      oprot.writeBinary(elem142);
       oprot.writeFieldEnd();
     }
-    if (this.str != null) {
+    final elem143 = str;
+    if (elem143 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(this.str);
+      oprot.writeString(elem143);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -580,8 +589,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            this.api = t_actual_base_dart.api_exception();
-            api.read(iprot);
+            final tmp_api = t_actual_base_dart.api_exception();
+            this.api = tmp_api;
+            tmp_api.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -617,14 +627,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem144 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(this.opt_num);
+    oprot.writeI32(elem144);
     oprot.writeFieldEnd();
+    final elem145 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(this.default_num);
+    oprot.writeI32(elem145);
     oprot.writeFieldEnd();
+    final elem146 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(this.req_num);
+    oprot.writeI32(elem146);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -685,22 +698,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.list_type != null) {
+    final elem147 = list_type;
+    if (elem147 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      final temp = this.list_type;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, temp.length));
-      for(var elem84 in temp) {
-        oprot.writeInt64(elem84);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem147.length));
+      for(var elem148 in elem147) {
+        oprot.writeInt64(elem148);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (this.set_type != null) {
+    final elem149 = set_type;
+    if (elem149 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      final temp = this.set_type;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, temp.length));
-      for(var elem85 in temp) {
-        oprot.writeInt64(elem85);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem149.length));
+      for(var elem150 in elem149) {
+        oprot.writeInt64(elem150);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -726,14 +739,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem86 = iprot.readListBegin();
-            final elem89 = <fixnum.Int64>[];
-            for(int elem88 = 0; elem88 < elem86.length; ++elem88) {
-              fixnum.Int64 elem87 = iprot.readInt64();
-              elem89.add(elem87);
+            thrift.TList elem151 = iprot.readListBegin();
+            final elem154 = <fixnum.Int64>[];
+            for(int elem153 = 0; elem153 < elem151.length; ++elem153) {
+              fixnum.Int64 elem152 = iprot.readInt64();
+              elem154.add(elem152);
             }
             iprot.readListEnd();
-            this.success = elem89;
+            this.success = elem154;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -784,8 +797,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            this.success = t_validStructs.Thing();
-            success.read(iprot);
+            final tmp_success = t_validStructs.Thing();
+            this.success = tmp_success;
+            tmp_success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -868,9 +882,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.a != null) {
+    final elem155 = a;
+    if (elem155 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      this.a.write(oprot);
+      elem155.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -894,8 +909,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            this.success = t_subdir_include_ns.A();
-            success.read(iprot);
+            final tmp_success = t_subdir_include_ns.A();
+            this.success = tmp_success;
+            tmp_success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -927,9 +943,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.newMessage != null) {
+    final elem156 = newMessage;
+    if (elem156 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(this.newMessage);
+      oprot.writeString(elem156);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -985,9 +1002,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.messageArgs != null) {
+    final elem157 = messageArgs;
+    if (elem157 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(this.messageArgs);
+      oprot.writeString(elem157);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1043,9 +1061,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.messageResult != null) {
+    final elem158 = messageResult;
+    if (elem158 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(this.messageResult);
+      oprot.writeString(elem158);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_foo_service.dart
@@ -419,20 +419,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem151 = num;
+    final elem143 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem151);
+    oprot.writeI32(elem143);
     oprot.writeFieldEnd();
-    final elem152 = str;
-    if (elem152 != null) {
+    final elem144 = str;
+    if (elem144 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem152);
+      oprot.writeString(elem144);
       oprot.writeFieldEnd();
     }
-    final elem153 = event;
-    if (elem153 != null) {
+    final elem145 = event;
+    if (elem145 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem153.write(oprot);
+      elem145.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -465,18 +465,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem154 = t_variety.AwesomeException();
-            this.awe = elem154;
-            elem154.read(iprot);
+            final elem146 = t_variety.AwesomeException();
+            this.awe = elem146;
+            elem146.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            final elem155 = t_actual_base_dart.api_exception();
-            this.api = elem155;
-            elem155.read(iprot);
+            final elem147 = t_actual_base_dart.api_exception();
+            this.api = elem147;
+            elem147.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -510,18 +510,17 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem156 = id;
+    final elem148 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(elem156);
+    oprot.writeInt64(elem148);
     oprot.writeFieldEnd();
-    final elem157 = req;
-    if (elem157 != null) {
+    final elem149 = req;
+    if (elem149 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem157.length));
-      for(var elem158 in elem157.keys) {
-        final elem159 = elem157[elem158];
-        oprot.writeI32(elem158);
-        oprot.writeString(elem159);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem149.length));
+      for(var entry in elem149.entries) {
+        oprot.writeI32(entry.key);
+        oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -548,16 +547,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem160 = bin;
-    if (elem160 != null) {
+    final elem150 = bin;
+    if (elem150 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem160);
+      oprot.writeBinary(elem150);
       oprot.writeFieldEnd();
     }
-    final elem161 = str;
-    if (elem161 != null) {
+    final elem151 = str;
+    if (elem151 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem161);
+      oprot.writeString(elem151);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -589,9 +588,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem162 = t_actual_base_dart.api_exception();
-            this.api = elem162;
-            elem162.read(iprot);
+            final elem152 = t_actual_base_dart.api_exception();
+            this.api = elem152;
+            elem152.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -627,17 +626,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem163 = opt_num;
+    final elem153 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem163);
+    oprot.writeI32(elem153);
     oprot.writeFieldEnd();
-    final elem164 = default_num;
+    final elem154 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem164);
+    oprot.writeI32(elem154);
     oprot.writeFieldEnd();
-    final elem165 = req_num;
+    final elem155 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem165);
+    oprot.writeI32(elem155);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -698,22 +697,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem166 = list_type;
-    if (elem166 != null) {
+    final elem156 = list_type;
+    if (elem156 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem166.length));
-      for(var elem167 in elem166) {
-        oprot.writeInt64(elem167);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem156.length));
+      for(var elem157 in elem156) {
+        oprot.writeInt64(elem157);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem168 = set_type;
-    if (elem168 != null) {
+    final elem158 = set_type;
+    if (elem158 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem168.length));
-      for(var elem169 in elem168) {
-        oprot.writeInt64(elem169);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem158.length));
+      for(var elem159 in elem158) {
+        oprot.writeInt64(elem159);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -739,14 +738,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem170 = iprot.readListBegin();
-            final elem173 = <fixnum.Int64>[];
-            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
-              fixnum.Int64 elem171 = iprot.readInt64();
-              elem173.add(elem171);
+            thrift.TList elem160 = iprot.readListBegin();
+            final elem163 = <fixnum.Int64>[];
+            for(int elem162 = 0; elem162 < elem160.length; ++elem162) {
+              fixnum.Int64 elem161 = iprot.readInt64();
+              elem163.add(elem161);
             }
             iprot.readListEnd();
-            this.success = elem173;
+            this.success = elem163;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -797,9 +796,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem174 = t_validStructs.Thing();
-            this.success = elem174;
-            elem174.read(iprot);
+            final elem164 = t_validStructs.Thing();
+            this.success = elem164;
+            elem164.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -882,10 +881,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem175 = a;
-    if (elem175 != null) {
+    final elem165 = a;
+    if (elem165 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem175.write(oprot);
+      elem165.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -909,9 +908,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem176 = t_subdir_include_ns.A();
-            this.success = elem176;
-            elem176.read(iprot);
+            final elem166 = t_subdir_include_ns.A();
+            this.success = elem166;
+            elem166.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -943,10 +942,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem177 = newMessage;
-    if (elem177 != null) {
+    final elem167 = newMessage;
+    if (elem167 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem177);
+      oprot.writeString(elem167);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1002,10 +1001,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem178 = messageArgs;
-    if (elem178 != null) {
+    final elem168 = messageArgs;
+    if (elem168 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem178);
+      oprot.writeString(elem168);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1061,10 +1060,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem179 = messageResult;
-    if (elem179 != null) {
+    final elem169 = messageResult;
+    if (elem169 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem179);
+      oprot.writeString(elem169);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_foo_service.dart
@@ -419,20 +419,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem140 = num;
+    final elem151 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem140);
+    oprot.writeI32(elem151);
     oprot.writeFieldEnd();
-    final elem141 = str;
-    if (elem141 != null) {
+    final elem152 = str;
+    if (elem152 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem141);
+      oprot.writeString(elem152);
       oprot.writeFieldEnd();
     }
-    final elem142 = event;
-    if (elem142 != null) {
+    final elem153 = event;
+    if (elem153 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem142.write(oprot);
+      elem153.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -465,18 +465,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_awe = t_variety.AwesomeException();
-            this.awe = tmp_awe;
-            tmp_awe.read(iprot);
+            final elem154 = t_variety.AwesomeException();
+            this.awe = elem154;
+            elem154.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_api = t_actual_base_dart.api_exception();
-            this.api = tmp_api;
-            tmp_api.read(iprot);
+            final elem155 = t_actual_base_dart.api_exception();
+            this.api = elem155;
+            elem155.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -510,18 +510,18 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem143 = id;
+    final elem156 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(elem143);
+    oprot.writeInt64(elem156);
     oprot.writeFieldEnd();
-    final elem144 = req;
-    if (elem144 != null) {
+    final elem157 = req;
+    if (elem157 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem144.length));
-      for(var elem145 in elem144.keys) {
-        final elem146 = elem144[elem145];
-        oprot.writeI32(elem145);
-        oprot.writeString(elem146);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem157.length));
+      for(var elem158 in elem157.keys) {
+        final elem159 = elem157[elem158];
+        oprot.writeI32(elem158);
+        oprot.writeString(elem159);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -548,16 +548,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem147 = bin;
-    if (elem147 != null) {
+    final elem160 = bin;
+    if (elem160 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem147);
+      oprot.writeBinary(elem160);
       oprot.writeFieldEnd();
     }
-    final elem148 = str;
-    if (elem148 != null) {
+    final elem161 = str;
+    if (elem161 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem148);
+      oprot.writeString(elem161);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -589,9 +589,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_api = t_actual_base_dart.api_exception();
-            this.api = tmp_api;
-            tmp_api.read(iprot);
+            final elem162 = t_actual_base_dart.api_exception();
+            this.api = elem162;
+            elem162.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -627,17 +627,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem149 = opt_num;
+    final elem163 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem149);
+    oprot.writeI32(elem163);
     oprot.writeFieldEnd();
-    final elem150 = default_num;
+    final elem164 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem150);
+    oprot.writeI32(elem164);
     oprot.writeFieldEnd();
-    final elem151 = req_num;
+    final elem165 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem151);
+    oprot.writeI32(elem165);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -698,22 +698,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem152 = list_type;
-    if (elem152 != null) {
+    final elem166 = list_type;
+    if (elem166 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem152.length));
-      for(var elem153 in elem152) {
-        oprot.writeInt64(elem153);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem166.length));
+      for(var elem167 in elem166) {
+        oprot.writeInt64(elem167);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem154 = set_type;
-    if (elem154 != null) {
+    final elem168 = set_type;
+    if (elem168 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem154.length));
-      for(var elem155 in elem154) {
-        oprot.writeInt64(elem155);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem168.length));
+      for(var elem169 in elem168) {
+        oprot.writeInt64(elem169);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -739,14 +739,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem156 = iprot.readListBegin();
-            final elem159 = <fixnum.Int64>[];
-            for(int elem158 = 0; elem158 < elem156.length; ++elem158) {
-              fixnum.Int64 elem157 = iprot.readInt64();
-              elem159.add(elem157);
+            thrift.TList elem170 = iprot.readListBegin();
+            final elem173 = <fixnum.Int64>[];
+            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
+              fixnum.Int64 elem171 = iprot.readInt64();
+              elem173.add(elem171);
             }
             iprot.readListEnd();
-            this.success = elem159;
+            this.success = elem173;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -797,9 +797,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_success = t_validStructs.Thing();
-            this.success = tmp_success;
-            tmp_success.read(iprot);
+            final elem174 = t_validStructs.Thing();
+            this.success = elem174;
+            elem174.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -882,10 +882,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem160 = a;
-    if (elem160 != null) {
+    final elem175 = a;
+    if (elem175 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem160.write(oprot);
+      elem175.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -909,9 +909,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_success = t_subdir_include_ns.A();
-            this.success = tmp_success;
-            tmp_success.read(iprot);
+            final elem176 = t_subdir_include_ns.A();
+            this.success = elem176;
+            elem176.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -943,10 +943,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem161 = newMessage;
-    if (elem161 != null) {
+    final elem177 = newMessage;
+    if (elem177 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem161);
+      oprot.writeString(elem177);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1002,10 +1002,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem162 = messageArgs;
-    if (elem162 != null) {
+    final elem178 = messageArgs;
+    if (elem178 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem162);
+      oprot.writeString(elem178);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1061,10 +1061,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem163 = messageResult;
-    if (elem163 != null) {
+    final elem179 = messageResult;
+    if (elem179 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem163);
+      oprot.writeString(elem179);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_foo_service.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart.int64/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_test_base.dart
@@ -72,9 +72,9 @@ class TestBase implements thrift.TBase {
       switch (field.id) {
         case BASE_STRUCT:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_base_struct = t_actual_base_dart.thing();
-            this.base_struct = tmp_base_struct;
-            tmp_base_struct.read(iprot);
+            final elem0 = t_actual_base_dart.thing();
+            this.base_struct = elem0;
+            elem0.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -95,10 +95,10 @@ class TestBase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem0 = base_struct;
-    if (elem0 != null) {
+    final elem1 = base_struct;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_BASE_STRUCT_FIELD_DESC);
-      elem0.write(oprot);
+      elem1.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_test_base.dart
@@ -72,8 +72,9 @@ class TestBase implements thrift.TBase {
       switch (field.id) {
         case BASE_STRUCT:
           if (field.type == thrift.TType.STRUCT) {
-            this.base_struct = t_actual_base_dart.thing();
-            base_struct.read(iprot);
+            final tmp_base_struct = t_actual_base_dart.thing();
+            this.base_struct = tmp_base_struct;
+            tmp_base_struct.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -94,9 +95,10 @@ class TestBase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.base_struct != null) {
+    final elem0 = base_struct;
+    if (elem0 != null) {
       oprot.writeFieldBegin(_BASE_STRUCT_FIELD_DESC);
-      this.base_struct.write(oprot);
+      elem0.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_test_base.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.int64/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_test_lowercase.dart
@@ -104,8 +104,9 @@ class TestLowercase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem1 = lowercaseInt;
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
-    oprot.writeI32(this.lowercaseInt);
+    oprot.writeI32(elem1);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_test_lowercase.dart
@@ -104,9 +104,9 @@ class TestLowercase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem1 = lowercaseInt;
+    final elem2 = lowercaseInt;
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
-    oprot.writeI32(elem1);
+    oprot.writeI32(elem2);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_test_lowercase.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
@@ -526,16 +526,18 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
-            this.ev1 = t_variety.Event();
-            ev1.read(iprot);
+            final tmp_ev1 = t_variety.Event();
+            this.ev1 = tmp_ev1;
+            tmp_ev1.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
-            this.ev2 = t_variety.Event();
-            ev2.read(iprot);
+            final tmp_ev2 = t_variety.Event();
+            this.ev2 = tmp_ev2;
+            tmp_ev2.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -564,14 +566,14 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LISTFIELD:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem0 = iprot.readListBegin();
-            final elem3 = <int>[];
-            for(int elem2 = 0; elem2 < elem0.length; ++elem2) {
-              int elem1 = iprot.readI32();
-              elem3.add(elem1);
+            thrift.TList elem5 = iprot.readListBegin();
+            final elem8 = <int>[];
+            for(int elem7 = 0; elem7 < elem5.length; ++elem7) {
+              int elem6 = iprot.readI32();
+              elem8.add(elem6);
             }
             iprot.readListEnd();
-            this.listfield = elem3;
+            this.listfield = elem8;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -614,57 +616,57 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LIST2:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem4 = iprot.readListBegin();
-            final elem7 = <int>[];
-            for(int elem6 = 0; elem6 < elem4.length; ++elem6) {
-              int elem5 = iprot.readI32();
-              elem7.add(elem5);
+            thrift.TList elem9 = iprot.readListBegin();
+            final elem12 = <int>[];
+            for(int elem11 = 0; elem11 < elem9.length; ++elem11) {
+              int elem10 = iprot.readI32();
+              elem12.add(elem10);
             }
             iprot.readListEnd();
-            this.list2 = elem7;
+            this.list2 = elem12;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST3:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem8 = iprot.readListBegin();
-            final elem11 = <int>[];
-            for(int elem10 = 0; elem10 < elem8.length; ++elem10) {
-              int elem9 = iprot.readI32();
-              elem11.add(elem9);
+            thrift.TList elem13 = iprot.readListBegin();
+            final elem16 = <int>[];
+            for(int elem15 = 0; elem15 < elem13.length; ++elem15) {
+              int elem14 = iprot.readI32();
+              elem16.add(elem14);
             }
             iprot.readListEnd();
-            this.list3 = elem11;
+            this.list3 = elem16;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST4:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem12 = iprot.readListBegin();
-            final elem15 = <int>[];
-            for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
-              int elem13 = iprot.readI32();
-              elem15.add(elem13);
+            thrift.TList elem17 = iprot.readListBegin();
+            final elem20 = <int>[];
+            for(int elem19 = 0; elem19 < elem17.length; ++elem19) {
+              int elem18 = iprot.readI32();
+              elem20.add(elem18);
             }
             iprot.readListEnd();
-            this.list4 = elem15;
+            this.list4 = elem20;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case A_MAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem16 = iprot.readMapBegin();
-            final elem19 = <String, String>{};
-            for(int elem18 = 0; elem18 < elem16.length; ++elem18) {
-              String elem20 = iprot.readString();
-              String elem17 = iprot.readString();
-              elem19[elem20] = elem17;
+            thrift.TMap elem21 = iprot.readMapBegin();
+            final elem24 = <String, String>{};
+            for(int elem23 = 0; elem23 < elem21.length; ++elem23) {
+              String elem25 = iprot.readString();
+              String elem22 = iprot.readString();
+              elem24[elem25] = elem22;
             }
             iprot.readMapEnd();
-            this.a_map = elem19;
+            this.a_map = elem24;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -701,113 +703,127 @@ class TestingDefaults implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem26 = iD2;
     if (isSetID2()) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
-      oprot.writeInt64(this.iD2);
+      oprot.writeInt64(elem26);
       oprot.writeFieldEnd();
     }
-    if (this.ev1 != null) {
+    final elem27 = ev1;
+    if (elem27 != null) {
       oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      this.ev1.write(oprot);
+      elem27.write(oprot);
       oprot.writeFieldEnd();
     }
-    if (this.ev2 != null) {
+    final elem28 = ev2;
+    if (elem28 != null) {
       oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      this.ev2.write(oprot);
+      elem28.write(oprot);
       oprot.writeFieldEnd();
     }
+    final elem29 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(this.iD);
+    oprot.writeInt64(elem29);
     oprot.writeFieldEnd();
-    if (this.thing != null) {
+    final elem30 = thing;
+    if (elem30 != null) {
       oprot.writeFieldBegin(_THING_FIELD_DESC);
-      oprot.writeString(this.thing);
+      oprot.writeString(elem30);
       oprot.writeFieldEnd();
     }
-    if (isSetThing2() && this.thing2 != null) {
+    final elem31 = thing2;
+    if (isSetThing2() && elem31 != null) {
       oprot.writeFieldBegin(_THING2_FIELD_DESC);
-      oprot.writeString(this.thing2);
+      oprot.writeString(elem31);
       oprot.writeFieldEnd();
     }
-    if (this.listfield != null) {
+    final elem32 = listfield;
+    if (elem32 != null) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
-      final temp = this.listfield;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem21 in temp) {
-        oprot.writeI32(elem21);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem32.length));
+      for(var elem33 in elem32) {
+        oprot.writeI32(elem33);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem34 = iD3;
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
-    oprot.writeInt64(this.iD3);
+    oprot.writeInt64(elem34);
     oprot.writeFieldEnd();
-    if (this.bin_field != null) {
+    final elem35 = bin_field;
+    if (elem35 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_FIELD_DESC);
-      oprot.writeBinary(this.bin_field);
+      oprot.writeBinary(elem35);
       oprot.writeFieldEnd();
     }
-    if (isSetBin_field2() && this.bin_field2 != null) {
+    final elem36 = bin_field2;
+    if (isSetBin_field2() && elem36 != null) {
       oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
-      oprot.writeBinary(this.bin_field2);
+      oprot.writeBinary(elem36);
       oprot.writeFieldEnd();
     }
-    if (this.bin_field3 != null) {
+    final elem37 = bin_field3;
+    if (elem37 != null) {
       oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
-      oprot.writeBinary(this.bin_field3);
+      oprot.writeBinary(elem37);
       oprot.writeFieldEnd();
     }
-    if (isSetBin_field4() && this.bin_field4 != null) {
+    final elem38 = bin_field4;
+    if (isSetBin_field4() && elem38 != null) {
       oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
-      oprot.writeBinary(this.bin_field4);
+      oprot.writeBinary(elem38);
       oprot.writeFieldEnd();
     }
-    if (isSetList2() && this.list2 != null) {
+    final elem39 = list2;
+    if (isSetList2() && elem39 != null) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
-      final temp = this.list2;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem22 in temp) {
-        oprot.writeI32(elem22);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem39.length));
+      for(var elem40 in elem39) {
+        oprot.writeI32(elem40);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetList3() && this.list3 != null) {
+    final elem41 = list3;
+    if (isSetList3() && elem41 != null) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
-      final temp = this.list3;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem23 in temp) {
-        oprot.writeI32(elem23);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem41.length));
+      for(var elem42 in elem41) {
+        oprot.writeI32(elem42);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (this.list4 != null) {
+    final elem43 = list4;
+    if (elem43 != null) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
-      final temp = this.list4;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem24 in temp) {
-        oprot.writeI32(elem24);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem43.length));
+      for(var elem44 in elem43) {
+        oprot.writeI32(elem44);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetA_map() && this.a_map != null) {
+    final elem45 = a_map;
+    if (isSetA_map() && elem45 != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
-      final temp = this.a_map;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, temp.length));
-      for(var elem25 in temp.keys) {
-        oprot.writeString(elem25);
-        oprot.writeString(temp[elem25]);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem45.length));
+      for(var elem46 in elem45.keys) {
+        final val = elem45[elem46];
+        oprot.writeString(elem46);
+        oprot.writeString(val);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
+    final elem47 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(this.status);
+    oprot.writeI32(elem47);
     oprot.writeFieldEnd();
+    final elem48 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(this.base_status);
+    oprot.writeI32(elem48);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
@@ -809,21 +809,20 @@ class TestingDefaults implements thrift.TBase {
     if (isSetA_map() && elem48 != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
       oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem48.length));
-      for(var elem49 in elem48.keys) {
-        final elem50 = elem48[elem49];
-        oprot.writeString(elem49);
-        oprot.writeString(elem50);
+      for(var entry in elem48.entries) {
+        oprot.writeString(entry.key);
+        oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem51 = status;
+    final elem49 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem51);
+    oprot.writeI32(elem49);
     oprot.writeFieldEnd();
-    final elem52 = base_status;
+    final elem50 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(elem52);
+    oprot.writeI32(elem50);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
@@ -810,20 +810,20 @@ class TestingDefaults implements thrift.TBase {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
       oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem45.length));
       for(var elem46 in elem45.keys) {
-        final val = elem45[elem46];
+        final elem47 = elem45[elem46];
         oprot.writeString(elem46);
-        oprot.writeString(val);
+        oprot.writeString(elem47);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem47 = status;
+    final elem48 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem47);
-    oprot.writeFieldEnd();
-    final elem48 = base_status;
-    oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
     oprot.writeI32(elem48);
+    oprot.writeFieldEnd();
+    final elem49 = base_status;
+    oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
+    oprot.writeI32(elem49);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
@@ -526,18 +526,18 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_ev1 = t_variety.Event();
-            this.ev1 = tmp_ev1;
-            tmp_ev1.read(iprot);
+            final elem6 = t_variety.Event();
+            this.ev1 = elem6;
+            elem6.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_ev2 = t_variety.Event();
-            this.ev2 = tmp_ev2;
-            tmp_ev2.read(iprot);
+            final elem7 = t_variety.Event();
+            this.ev2 = elem7;
+            elem7.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -566,14 +566,14 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LISTFIELD:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem5 = iprot.readListBegin();
-            final elem8 = <int>[];
-            for(int elem7 = 0; elem7 < elem5.length; ++elem7) {
-              int elem6 = iprot.readI32();
-              elem8.add(elem6);
+            thrift.TList elem8 = iprot.readListBegin();
+            final elem11 = <int>[];
+            for(int elem10 = 0; elem10 < elem8.length; ++elem10) {
+              int elem9 = iprot.readI32();
+              elem11.add(elem9);
             }
             iprot.readListEnd();
-            this.listfield = elem8;
+            this.listfield = elem11;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -616,57 +616,57 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LIST2:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem9 = iprot.readListBegin();
-            final elem12 = <int>[];
-            for(int elem11 = 0; elem11 < elem9.length; ++elem11) {
-              int elem10 = iprot.readI32();
-              elem12.add(elem10);
+            thrift.TList elem12 = iprot.readListBegin();
+            final elem15 = <int>[];
+            for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
+              int elem13 = iprot.readI32();
+              elem15.add(elem13);
             }
             iprot.readListEnd();
-            this.list2 = elem12;
+            this.list2 = elem15;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST3:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem13 = iprot.readListBegin();
-            final elem16 = <int>[];
-            for(int elem15 = 0; elem15 < elem13.length; ++elem15) {
-              int elem14 = iprot.readI32();
-              elem16.add(elem14);
+            thrift.TList elem16 = iprot.readListBegin();
+            final elem19 = <int>[];
+            for(int elem18 = 0; elem18 < elem16.length; ++elem18) {
+              int elem17 = iprot.readI32();
+              elem19.add(elem17);
             }
             iprot.readListEnd();
-            this.list3 = elem16;
+            this.list3 = elem19;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST4:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem17 = iprot.readListBegin();
-            final elem20 = <int>[];
-            for(int elem19 = 0; elem19 < elem17.length; ++elem19) {
-              int elem18 = iprot.readI32();
-              elem20.add(elem18);
+            thrift.TList elem20 = iprot.readListBegin();
+            final elem23 = <int>[];
+            for(int elem22 = 0; elem22 < elem20.length; ++elem22) {
+              int elem21 = iprot.readI32();
+              elem23.add(elem21);
             }
             iprot.readListEnd();
-            this.list4 = elem20;
+            this.list4 = elem23;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case A_MAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem21 = iprot.readMapBegin();
-            final elem24 = <String, String>{};
-            for(int elem23 = 0; elem23 < elem21.length; ++elem23) {
+            thrift.TMap elem24 = iprot.readMapBegin();
+            final elem27 = <String, String>{};
+            for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
+              String elem28 = iprot.readString();
               String elem25 = iprot.readString();
-              String elem22 = iprot.readString();
-              elem24[elem25] = elem22;
+              elem27[elem28] = elem25;
             }
             iprot.readMapEnd();
-            this.a_map = elem24;
+            this.a_map = elem27;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -703,127 +703,127 @@ class TestingDefaults implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem26 = iD2;
+    final elem29 = iD2;
     if (isSetID2()) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
-      oprot.writeInt64(elem26);
+      oprot.writeInt64(elem29);
       oprot.writeFieldEnd();
     }
-    final elem27 = ev1;
-    if (elem27 != null) {
-      oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      elem27.write(oprot);
-      oprot.writeFieldEnd();
-    }
-    final elem28 = ev2;
-    if (elem28 != null) {
-      oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      elem28.write(oprot);
-      oprot.writeFieldEnd();
-    }
-    final elem29 = iD;
-    oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(elem29);
-    oprot.writeFieldEnd();
-    final elem30 = thing;
+    final elem30 = ev1;
     if (elem30 != null) {
+      oprot.writeFieldBegin(_EV1_FIELD_DESC);
+      elem30.write(oprot);
+      oprot.writeFieldEnd();
+    }
+    final elem31 = ev2;
+    if (elem31 != null) {
+      oprot.writeFieldBegin(_EV2_FIELD_DESC);
+      elem31.write(oprot);
+      oprot.writeFieldEnd();
+    }
+    final elem32 = iD;
+    oprot.writeFieldBegin(_ID_FIELD_DESC);
+    oprot.writeInt64(elem32);
+    oprot.writeFieldEnd();
+    final elem33 = thing;
+    if (elem33 != null) {
       oprot.writeFieldBegin(_THING_FIELD_DESC);
-      oprot.writeString(elem30);
+      oprot.writeString(elem33);
       oprot.writeFieldEnd();
     }
-    final elem31 = thing2;
-    if (isSetThing2() && elem31 != null) {
+    final elem34 = thing2;
+    if (isSetThing2() && elem34 != null) {
       oprot.writeFieldBegin(_THING2_FIELD_DESC);
-      oprot.writeString(elem31);
+      oprot.writeString(elem34);
       oprot.writeFieldEnd();
     }
-    final elem32 = listfield;
-    if (elem32 != null) {
+    final elem35 = listfield;
+    if (elem35 != null) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem32.length));
-      for(var elem33 in elem32) {
-        oprot.writeI32(elem33);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem35.length));
+      for(var elem36 in elem35) {
+        oprot.writeI32(elem36);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem34 = iD3;
+    final elem37 = iD3;
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
-    oprot.writeInt64(elem34);
+    oprot.writeInt64(elem37);
     oprot.writeFieldEnd();
-    final elem35 = bin_field;
-    if (elem35 != null) {
+    final elem38 = bin_field;
+    if (elem38 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_FIELD_DESC);
-      oprot.writeBinary(elem35);
-      oprot.writeFieldEnd();
-    }
-    final elem36 = bin_field2;
-    if (isSetBin_field2() && elem36 != null) {
-      oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
-      oprot.writeBinary(elem36);
-      oprot.writeFieldEnd();
-    }
-    final elem37 = bin_field3;
-    if (elem37 != null) {
-      oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
-      oprot.writeBinary(elem37);
-      oprot.writeFieldEnd();
-    }
-    final elem38 = bin_field4;
-    if (isSetBin_field4() && elem38 != null) {
-      oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
       oprot.writeBinary(elem38);
       oprot.writeFieldEnd();
     }
-    final elem39 = list2;
-    if (isSetList2() && elem39 != null) {
+    final elem39 = bin_field2;
+    if (isSetBin_field2() && elem39 != null) {
+      oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
+      oprot.writeBinary(elem39);
+      oprot.writeFieldEnd();
+    }
+    final elem40 = bin_field3;
+    if (elem40 != null) {
+      oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
+      oprot.writeBinary(elem40);
+      oprot.writeFieldEnd();
+    }
+    final elem41 = bin_field4;
+    if (isSetBin_field4() && elem41 != null) {
+      oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
+      oprot.writeBinary(elem41);
+      oprot.writeFieldEnd();
+    }
+    final elem42 = list2;
+    if (isSetList2() && elem42 != null) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem39.length));
-      for(var elem40 in elem39) {
-        oprot.writeI32(elem40);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem42.length));
+      for(var elem43 in elem42) {
+        oprot.writeI32(elem43);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem41 = list3;
-    if (isSetList3() && elem41 != null) {
+    final elem44 = list3;
+    if (isSetList3() && elem44 != null) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem41.length));
-      for(var elem42 in elem41) {
-        oprot.writeI32(elem42);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem44.length));
+      for(var elem45 in elem44) {
+        oprot.writeI32(elem45);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem43 = list4;
-    if (elem43 != null) {
+    final elem46 = list4;
+    if (elem46 != null) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem43.length));
-      for(var elem44 in elem43) {
-        oprot.writeI32(elem44);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem46.length));
+      for(var elem47 in elem46) {
+        oprot.writeI32(elem47);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem45 = a_map;
-    if (isSetA_map() && elem45 != null) {
+    final elem48 = a_map;
+    if (isSetA_map() && elem48 != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem45.length));
-      for(var elem46 in elem45.keys) {
-        final elem47 = elem45[elem46];
-        oprot.writeString(elem46);
-        oprot.writeString(elem47);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem48.length));
+      for(var elem49 in elem48.keys) {
+        final elem50 = elem48[elem49];
+        oprot.writeString(elem49);
+        oprot.writeString(elem50);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem48 = status;
+    final elem51 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem48);
+    oprot.writeI32(elem51);
     oprot.writeFieldEnd();
-    final elem49 = base_status;
+    final elem52 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(elem49);
+    oprot.writeI32(elem52);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
@@ -301,15 +301,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem77 = iprot.readMapBegin();
-            final elem80 = <int, String>{};
-            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
-              int elem81 = iprot.readI32();
-              String elem78 = iprot.readString();
-              elem80[elem81] = elem78;
+            thrift.TMap elem119 = iprot.readMapBegin();
+            final elem122 = <int, String>{};
+            for(int elem121 = 0; elem121 < elem119.length; ++elem121) {
+              int elem123 = iprot.readI32();
+              String elem120 = iprot.readString();
+              elem122[elem123] = elem120;
             }
             iprot.readMapEnd();
-            this.requests = elem80;
+            this.requests = elem122;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -354,52 +354,59 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem124 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeInt64(this.anID);
+      oprot.writeInt64(elem124);
       oprot.writeFieldEnd();
     }
-    if (isSetAString() && this.aString != null) {
+    final elem125 = aString;
+    if (isSetAString() && elem125 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(this.aString);
+      oprot.writeString(elem125);
       oprot.writeFieldEnd();
     }
+    final elem126 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(this.someotherthing);
+      oprot.writeI32(elem126);
       oprot.writeFieldEnd();
     }
+    final elem127 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(this.anInt16);
+      oprot.writeI16(elem127);
       oprot.writeFieldEnd();
     }
-    if (isSetRequests() && this.requests != null) {
+    final elem128 = requests;
+    if (isSetRequests() && elem128 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      final temp = this.requests;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, temp.length));
-      for(var elem82 in temp.keys) {
-        oprot.writeI32(elem82);
-        oprot.writeString(temp[elem82]);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem128.length));
+      for(var elem129 in elem128.keys) {
+        final val = elem128[elem129];
+        oprot.writeI32(elem129);
+        oprot.writeString(val);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetBin_field_in_union() && this.bin_field_in_union != null) {
+    final elem130 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem130 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(this.bin_field_in_union);
+      oprot.writeBinary(elem130);
       oprot.writeFieldEnd();
     }
+    final elem131 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      // ignore: deprecated_member_use
-      oprot.writeBool(this.depr);
+      oprot.writeBool(elem131);
       oprot.writeFieldEnd();
     }
+    final elem132 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(this.wHOA_BUDDY);
+      oprot.writeBool(elem132);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
@@ -301,15 +301,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem133 = iprot.readMapBegin();
-            final elem136 = <int, String>{};
-            for(int elem135 = 0; elem135 < elem133.length; ++elem135) {
-              int elem137 = iprot.readI32();
-              String elem134 = iprot.readString();
-              elem136[elem137] = elem134;
+            thrift.TMap elem127 = iprot.readMapBegin();
+            final elem130 = <int, String>{};
+            for(int elem129 = 0; elem129 < elem127.length; ++elem129) {
+              int elem131 = iprot.readI32();
+              String elem128 = iprot.readString();
+              elem130[elem131] = elem128;
             }
             iprot.readMapEnd();
-            this.requests = elem136;
+            this.requests = elem130;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -354,59 +354,58 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem138 = anID;
+    final elem132 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeInt64(elem138);
+      oprot.writeInt64(elem132);
       oprot.writeFieldEnd();
     }
-    final elem139 = aString;
-    if (isSetAString() && elem139 != null) {
+    final elem133 = aString;
+    if (isSetAString() && elem133 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem139);
+      oprot.writeString(elem133);
       oprot.writeFieldEnd();
     }
-    final elem140 = someotherthing;
+    final elem134 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem140);
+      oprot.writeI32(elem134);
       oprot.writeFieldEnd();
     }
-    final elem141 = anInt16;
+    final elem135 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem141);
+      oprot.writeI16(elem135);
       oprot.writeFieldEnd();
     }
-    final elem142 = requests;
-    if (isSetRequests() && elem142 != null) {
+    final elem136 = requests;
+    if (isSetRequests() && elem136 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem142.length));
-      for(var elem143 in elem142.keys) {
-        final elem144 = elem142[elem143];
-        oprot.writeI32(elem143);
-        oprot.writeString(elem144);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem136.length));
+      for(var entry in elem136.entries) {
+        oprot.writeI32(entry.key);
+        oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem145 = bin_field_in_union;
-    if (isSetBin_field_in_union() && elem145 != null) {
+    final elem137 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem137 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem145);
+      oprot.writeBinary(elem137);
       oprot.writeFieldEnd();
     }
-    final elem146 = depr;
+    final elem138 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem146);
+      oprot.writeBool(elem138);
       oprot.writeFieldEnd();
     }
-    final elem147 = wHOA_BUDDY;
+    final elem139 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem147);
+      oprot.writeBool(elem139);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
@@ -301,15 +301,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem122 = iprot.readMapBegin();
-            final elem125 = <int, String>{};
-            for(int elem124 = 0; elem124 < elem122.length; ++elem124) {
-              int elem126 = iprot.readI32();
-              String elem123 = iprot.readString();
-              elem125[elem126] = elem123;
+            thrift.TMap elem133 = iprot.readMapBegin();
+            final elem136 = <int, String>{};
+            for(int elem135 = 0; elem135 < elem133.length; ++elem135) {
+              int elem137 = iprot.readI32();
+              String elem134 = iprot.readString();
+              elem136[elem137] = elem134;
             }
             iprot.readMapEnd();
-            this.requests = elem125;
+            this.requests = elem136;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -354,59 +354,59 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem127 = anID;
+    final elem138 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeInt64(elem127);
+      oprot.writeInt64(elem138);
       oprot.writeFieldEnd();
     }
-    final elem128 = aString;
-    if (isSetAString() && elem128 != null) {
+    final elem139 = aString;
+    if (isSetAString() && elem139 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem128);
+      oprot.writeString(elem139);
       oprot.writeFieldEnd();
     }
-    final elem129 = someotherthing;
+    final elem140 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem129);
+      oprot.writeI32(elem140);
       oprot.writeFieldEnd();
     }
-    final elem130 = anInt16;
+    final elem141 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem130);
+      oprot.writeI16(elem141);
       oprot.writeFieldEnd();
     }
-    final elem131 = requests;
-    if (isSetRequests() && elem131 != null) {
+    final elem142 = requests;
+    if (isSetRequests() && elem142 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem131.length));
-      for(var elem132 in elem131.keys) {
-        final elem133 = elem131[elem132];
-        oprot.writeI32(elem132);
-        oprot.writeString(elem133);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem142.length));
+      for(var elem143 in elem142.keys) {
+        final elem144 = elem142[elem143];
+        oprot.writeI32(elem143);
+        oprot.writeString(elem144);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem134 = bin_field_in_union;
-    if (isSetBin_field_in_union() && elem134 != null) {
+    final elem145 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem145 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem134);
+      oprot.writeBinary(elem145);
       oprot.writeFieldEnd();
     }
-    final elem135 = depr;
+    final elem146 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem135);
+      oprot.writeBool(elem146);
       oprot.writeFieldEnd();
     }
-    final elem136 = wHOA_BUDDY;
+    final elem147 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem136);
+      oprot.writeBool(elem147);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
@@ -301,15 +301,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem119 = iprot.readMapBegin();
-            final elem122 = <int, String>{};
-            for(int elem121 = 0; elem121 < elem119.length; ++elem121) {
-              int elem123 = iprot.readI32();
-              String elem120 = iprot.readString();
-              elem122[elem123] = elem120;
+            thrift.TMap elem122 = iprot.readMapBegin();
+            final elem125 = <int, String>{};
+            for(int elem124 = 0; elem124 < elem122.length; ++elem124) {
+              int elem126 = iprot.readI32();
+              String elem123 = iprot.readString();
+              elem125[elem126] = elem123;
             }
             iprot.readMapEnd();
-            this.requests = elem122;
+            this.requests = elem125;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -354,59 +354,59 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem124 = anID;
+    final elem127 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeInt64(elem124);
+      oprot.writeInt64(elem127);
       oprot.writeFieldEnd();
     }
-    final elem125 = aString;
-    if (isSetAString() && elem125 != null) {
+    final elem128 = aString;
+    if (isSetAString() && elem128 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem125);
+      oprot.writeString(elem128);
       oprot.writeFieldEnd();
     }
-    final elem126 = someotherthing;
+    final elem129 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem126);
+      oprot.writeI32(elem129);
       oprot.writeFieldEnd();
     }
-    final elem127 = anInt16;
+    final elem130 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem127);
+      oprot.writeI16(elem130);
       oprot.writeFieldEnd();
     }
-    final elem128 = requests;
-    if (isSetRequests() && elem128 != null) {
+    final elem131 = requests;
+    if (isSetRequests() && elem131 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem128.length));
-      for(var elem129 in elem128.keys) {
-        final val = elem128[elem129];
-        oprot.writeI32(elem129);
-        oprot.writeString(val);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem131.length));
+      for(var elem132 in elem131.keys) {
+        final elem133 = elem131[elem132];
+        oprot.writeI32(elem132);
+        oprot.writeString(elem133);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem130 = bin_field_in_union;
-    if (isSetBin_field_in_union() && elem130 != null) {
+    final elem134 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem134 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem130);
+      oprot.writeBinary(elem134);
       oprot.writeFieldEnd();
     }
-    final elem131 = depr;
+    final elem135 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem131);
+      oprot.writeBool(elem135);
       oprot.writeFieldEnd();
     }
-    final elem132 = wHOA_BUDDY;
+    final elem136 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem132);
+      oprot.writeBool(elem136);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.int64/variety/f_variety_constants.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_variety_constants.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:convert' show utf8;
 import 'package:fixnum/fixnum.dart' as fixnum;
 import 'dart:typed_data' show Uint8List;

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_actual_base_dart_constants.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_actual_base_dart_constants.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:convert' show utf8;
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_api_exception.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_api_exception.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_base_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_base_foo_service.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_nested_thing.dart
@@ -67,15 +67,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem99 = iprot.readListBegin();
-            final elem102 = <t_actual_base_dart.thing>[];
-            for(int elem101 = 0; elem101 < elem99.length; ++elem101) {
-              t_actual_base_dart.thing elem100 = t_actual_base_dart.thing();
-              elem100.read(iprot);
-              elem102.add(elem100);
+            thrift.TList elem170 = iprot.readListBegin();
+            final elem173 = <t_actual_base_dart.thing>[];
+            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
+              final tmp_elem171 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem171 = tmp_elem171;
+              tmp_elem171.read(iprot);
+              elem173.add(elem171);
             }
             iprot.readListEnd();
-            this.things = elem102;
+            this.things = elem173;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -96,12 +97,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.things != null) {
+    final elem174 = things;
+    if (elem174 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      final temp = this.things!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
-      for(var elem103 in temp) {
-        elem103.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem174.length));
+      for(var elem175 in elem174) {
+        elem175.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_nested_thing.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';
@@ -74,7 +71,7 @@ class nested_thing implements thrift.TBase {
             final elem102 = <t_actual_base_dart.thing>[];
             for(int elem101 = 0; elem101 < elem99.length; ++elem101) {
               t_actual_base_dart.thing elem100 = t_actual_base_dart.thing();
-              elem100?.read(iprot);
+              elem100.read(iprot);
               elem102.add(elem100);
             }
             iprot.readListEnd();
@@ -102,9 +99,9 @@ class nested_thing implements thrift.TBase {
     if (this.things != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
       final temp = this.things!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp!.length));
-      for(var elem103 in temp!) {
-        elem103?.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
+      for(var elem103 in temp) {
+        elem103.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_nested_thing.dart
@@ -67,16 +67,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem176 = iprot.readListBegin();
-            final elem179 = <t_actual_base_dart.thing>[];
-            for(int elem178 = 0; elem178 < elem176.length; ++elem178) {
-              final tmp_elem177 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem177 = tmp_elem177;
-              tmp_elem177.read(iprot);
-              elem179.add(elem177);
+            thrift.TList elem194 = iprot.readListBegin();
+            final elem198 = <t_actual_base_dart.thing>[];
+            for(int elem197 = 0; elem197 < elem194.length; ++elem197) {
+              final elem196 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem195 = elem196;
+              elem196.read(iprot);
+              elem198.add(elem195);
             }
             iprot.readListEnd();
-            this.things = elem179;
+            this.things = elem198;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -97,12 +97,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem180 = things;
-    if (elem180 != null) {
+    final elem199 = things;
+    if (elem199 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem180.length));
-      for(var elem181 in elem180) {
-        elem181.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem199.length));
+      for(var elem200 in elem199) {
+        elem200.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_nested_thing.dart
@@ -67,16 +67,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem194 = iprot.readListBegin();
-            final elem198 = <t_actual_base_dart.thing>[];
-            for(int elem197 = 0; elem197 < elem194.length; ++elem197) {
-              final elem196 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem195 = elem196;
-              elem196.read(iprot);
-              elem198.add(elem195);
+            thrift.TList elem182 = iprot.readListBegin();
+            final elem186 = <t_actual_base_dart.thing>[];
+            for(int elem185 = 0; elem185 < elem182.length; ++elem185) {
+              final elem184 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem183 = elem184;
+              elem184.read(iprot);
+              elem186.add(elem183);
             }
             iprot.readListEnd();
-            this.things = elem198;
+            this.things = elem186;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -97,12 +97,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem199 = things;
-    if (elem199 != null) {
+    final elem187 = things;
+    if (elem187 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem199.length));
-      for(var elem200 in elem199) {
-        elem200.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem187.length));
+      for(var elem188 in elem187) {
+        elem188.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_nested_thing.dart
@@ -67,16 +67,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem170 = iprot.readListBegin();
-            final elem173 = <t_actual_base_dart.thing>[];
-            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
-              final tmp_elem171 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem171 = tmp_elem171;
-              tmp_elem171.read(iprot);
-              elem173.add(elem171);
+            thrift.TList elem176 = iprot.readListBegin();
+            final elem179 = <t_actual_base_dart.thing>[];
+            for(int elem178 = 0; elem178 < elem176.length; ++elem178) {
+              final tmp_elem177 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem177 = tmp_elem177;
+              tmp_elem177.read(iprot);
+              elem179.add(elem177);
             }
             iprot.readListEnd();
-            this.things = elem173;
+            this.things = elem179;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -97,12 +97,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem174 = things;
-    if (elem174 != null) {
+    final elem180 = things;
+    if (elem180 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem174.length));
-      for(var elem175 in elem174) {
-        elem175.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem180.length));
+      for(var elem181 in elem180) {
+        elem181.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
@@ -126,12 +126,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem168 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(this.an_id);
+    oprot.writeI32(elem168);
     oprot.writeFieldEnd();
-    if (this.a_string != null) {
+    final elem169 = a_string;
+    if (elem169 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(this.a_string);
+      oprot.writeString(elem169);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
@@ -126,14 +126,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem168 = an_id;
+    final elem174 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem168);
+    oprot.writeI32(elem174);
     oprot.writeFieldEnd();
-    final elem169 = a_string;
-    if (elem169 != null) {
+    final elem175 = a_string;
+    if (elem175 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem169);
+      oprot.writeString(elem175);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
@@ -126,14 +126,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem174 = an_id;
+    final elem192 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem174);
+    oprot.writeI32(elem192);
     oprot.writeFieldEnd();
-    final elem175 = a_string;
-    if (elem175 != null) {
+    final elem193 = a_string;
+    if (elem193 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem175);
+      oprot.writeString(elem193);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
@@ -126,14 +126,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem192 = an_id;
+    final elem180 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem192);
+    oprot.writeI32(elem180);
     oprot.writeFieldEnd();
-    final elem193 = a_string;
-    if (elem193 != null) {
+    final elem181 = a_string;
+    if (elem181 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem193);
+      oprot.writeString(elem181);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
@@ -184,19 +184,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem148 = iD;
+    final elem140 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem148);
+    oprot.writeI64(elem140);
     oprot.writeFieldEnd();
-    final elem149 = reason;
-    if (elem149 != null) {
+    final elem141 = reason;
+    if (elem141 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem149);
+      oprot.writeString(elem141);
       oprot.writeFieldEnd();
     }
-    final elem150 = depr;
+    final elem142 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem150);
+    oprot.writeBool(elem142);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
@@ -184,19 +184,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem137 = iD;
+    final elem148 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem137);
+    oprot.writeI64(elem148);
     oprot.writeFieldEnd();
-    final elem138 = reason;
-    if (elem138 != null) {
+    final elem149 = reason;
+    if (elem149 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem138);
+      oprot.writeString(elem149);
       oprot.writeFieldEnd();
     }
-    final elem139 = depr;
+    final elem150 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem139);
+    oprot.writeBool(elem150);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
@@ -184,19 +184,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem133 = iD;
+    final elem137 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem133);
+    oprot.writeI64(elem137);
     oprot.writeFieldEnd();
-    final elem134 = reason;
-    if (elem134 != null) {
+    final elem138 = reason;
+    if (elem138 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem134);
+      oprot.writeString(elem138);
       oprot.writeFieldEnd();
     }
-    final elem135 = depr;
+    final elem139 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem135);
+    oprot.writeBool(elem139);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
@@ -184,17 +184,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem133 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(this.iD);
+    oprot.writeI64(elem133);
     oprot.writeFieldEnd();
-    if (this.reason != null) {
+    final elem134 = reason;
+    if (elem134 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(this.reason);
+      oprot.writeString(elem134);
       oprot.writeFieldEnd();
     }
+    final elem135 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    // ignore: deprecated_member_use
-    oprot.writeBool(this.depr);
+    oprot.writeBool(elem135);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_event.dart
@@ -180,19 +180,19 @@ class Event implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem2 = iD;
+    final elem3 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem2);
+    oprot.writeI64(elem3);
     oprot.writeFieldEnd();
-    final elem3 = message;
-    if (elem3 != null) {
+    final elem4 = message;
+    if (elem4 != null) {
       oprot.writeFieldBegin(_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem3);
+      oprot.writeString(elem4);
       oprot.writeFieldEnd();
     }
-    final elem4 = yES_NO;
+    final elem5 = yES_NO;
     oprot.writeFieldBegin(_YE_S__NO_FIELD_DESC);
-    oprot.writeBool(elem4);
+    oprot.writeBool(elem5);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_event.dart
@@ -180,16 +180,19 @@ class Event implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem2 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(this.iD);
+    oprot.writeI64(elem2);
     oprot.writeFieldEnd();
-    if (this.message != null) {
+    final elem3 = message;
+    if (elem3 != null) {
       oprot.writeFieldBegin(_MESSAGE_FIELD_DESC);
-      oprot.writeString(this.message);
+      oprot.writeString(elem3);
       oprot.writeFieldEnd();
     }
+    final elem4 = yES_NO;
     oprot.writeFieldBegin(_YE_S__NO_FIELD_DESC);
-    oprot.writeBool(this.yES_NO);
+    oprot.writeBool(elem4);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_event.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
@@ -462,88 +462,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            this.ev = t_variety.Event();
-            ev.read(iprot);
+            final tmp_ev = t_variety.Event();
+            this.ev = tmp_ev;
+            tmp_ev.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem26 = iprot.readListBegin();
-            final elem29 = <t_variety.Event>[];
-            for(int elem28 = 0; elem28 < elem26.length; ++elem28) {
-              t_variety.Event elem27 = t_variety.Event();
-              elem27.read(iprot);
-              elem29.add(elem27);
+            thrift.TList elem49 = iprot.readListBegin();
+            final elem52 = <t_variety.Event>[];
+            for(int elem51 = 0; elem51 < elem49.length; ++elem51) {
+              final tmp_elem50 = t_variety.Event();
+              t_variety.Event elem50 = tmp_elem50;
+              tmp_elem50.read(iprot);
+              elem52.add(elem50);
             }
             iprot.readListEnd();
-            this.events = elem29;
+            this.events = elem52;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem30 = iprot.readSetBegin();
-            final elem33 = <t_variety.Event>{};
-            for(int elem32 = 0; elem32 < elem30.length; ++elem32) {
-              t_variety.Event elem31 = t_variety.Event();
-              elem31.read(iprot);
-              elem33.add(elem31);
+            thrift.TSet elem53 = iprot.readSetBegin();
+            final elem56 = <t_variety.Event>{};
+            for(int elem55 = 0; elem55 < elem53.length; ++elem55) {
+              final tmp_elem54 = t_variety.Event();
+              t_variety.Event elem54 = tmp_elem54;
+              tmp_elem54.read(iprot);
+              elem56.add(elem54);
             }
             iprot.readSetEnd();
-            this.events2 = elem33;
+            this.events2 = elem56;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem34 = iprot.readMapBegin();
-            final elem37 = <int, t_variety.Event>{};
-            for(int elem36 = 0; elem36 < elem34.length; ++elem36) {
-              int elem38 = iprot.readI64();
-              t_variety.Event elem35 = t_variety.Event();
-              elem35.read(iprot);
-              elem37[elem38] = elem35;
+            thrift.TMap elem57 = iprot.readMapBegin();
+            final elem60 = <int, t_variety.Event>{};
+            for(int elem59 = 0; elem59 < elem57.length; ++elem59) {
+              int elem61 = iprot.readI64();
+              final tmp_elem58 = t_variety.Event();
+              t_variety.Event elem58 = tmp_elem58;
+              tmp_elem58.read(iprot);
+              elem60[elem61] = elem58;
             }
             iprot.readMapEnd();
-            this.eventMap = elem37;
+            this.eventMap = elem60;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem39 = iprot.readListBegin();
-            final elem45 = <List<int>>[];
-            for(int elem44 = 0; elem44 < elem39.length; ++elem44) {
-              thrift.TList elem41 = iprot.readListBegin();
-              final elem40 = <int>[];
-              for(int elem43 = 0; elem43 < elem41.length; ++elem43) {
-                int elem42 = iprot.readI32();
-                elem40.add(elem42);
+            thrift.TList elem62 = iprot.readListBegin();
+            final elem68 = <List<int>>[];
+            for(int elem67 = 0; elem67 < elem62.length; ++elem67) {
+              thrift.TList elem64 = iprot.readListBegin();
+              final elem63 = <int>[];
+              for(int elem66 = 0; elem66 < elem64.length; ++elem66) {
+                int elem65 = iprot.readI32();
+                elem63.add(elem65);
               }
               iprot.readListEnd();
-              elem45.add(elem40);
+              elem68.add(elem63);
             }
             iprot.readListEnd();
-            this.nums = elem45;
+            this.nums = elem68;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem46 = iprot.readListBegin();
-            final elem49 = <int>[];
-            for(int elem48 = 0; elem48 < elem46.length; ++elem48) {
-              int elem47 = iprot.readI32();
-              elem49.add(elem47);
+            thrift.TList elem69 = iprot.readListBegin();
+            final elem72 = <int>[];
+            for(int elem71 = 0; elem71 < elem69.length; ++elem71) {
+              int elem70 = iprot.readI32();
+              elem72.add(elem70);
             }
             iprot.readListEnd();
-            this.enums = elem49;
+            this.enums = elem72;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -558,8 +562,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            this.a_union = t_variety.TestingUnions();
-            a_union.read(iprot);
+            final tmp_a_union = t_variety.TestingUnions();
+            this.a_union = tmp_a_union;
+            tmp_a_union.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -590,62 +595,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem50 = iprot.readListBegin();
+            thrift.TList elem73 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem53 = <bool>[];
-            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
-              bool elem51 = iprot.readBool();
+            final elem76 = <bool>[];
+            for(int elem75 = 0; elem75 < elem73.length; ++elem75) {
+              bool elem74 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem53.add(elem51);
+              elem76.add(elem74);
             }
             iprot.readListEnd();
-            this.deprList = elem53;
+            this.deprList = elem76;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem54 = iprot.readListBegin();
-            final elem57 = <t_variety.Event>[];
-            for(int elem56 = 0; elem56 < elem54.length; ++elem56) {
-              t_variety.Event elem55 = t_variety.Event();
-              elem55.read(iprot);
-              elem57.add(elem55);
+            thrift.TList elem77 = iprot.readListBegin();
+            final elem80 = <t_variety.Event>[];
+            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
+              final tmp_elem78 = t_variety.Event();
+              t_variety.Event elem78 = tmp_elem78;
+              tmp_elem78.read(iprot);
+              elem80.add(elem78);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem57;
+            this.eventsDefault = elem80;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem58 = iprot.readMapBegin();
-            final elem61 = <int, t_variety.Event>{};
-            for(int elem60 = 0; elem60 < elem58.length; ++elem60) {
-              int elem62 = iprot.readI64();
-              t_variety.Event elem59 = t_variety.Event();
-              elem59.read(iprot);
-              elem61[elem62] = elem59;
+            thrift.TMap elem81 = iprot.readMapBegin();
+            final elem84 = <int, t_variety.Event>{};
+            for(int elem83 = 0; elem83 < elem81.length; ++elem83) {
+              int elem85 = iprot.readI64();
+              final tmp_elem82 = t_variety.Event();
+              t_variety.Event elem82 = tmp_elem82;
+              tmp_elem82.read(iprot);
+              elem84[elem85] = elem82;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem61;
+            this.eventMapDefault = elem84;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem63 = iprot.readSetBegin();
-            final elem66 = <t_variety.Event>{};
-            for(int elem65 = 0; elem65 < elem63.length; ++elem65) {
-              t_variety.Event elem64 = t_variety.Event();
-              elem64.read(iprot);
-              elem66.add(elem64);
+            thrift.TSet elem86 = iprot.readSetBegin();
+            final elem89 = <t_variety.Event>{};
+            for(int elem88 = 0; elem88 < elem86.length; ++elem88) {
+              final tmp_elem87 = t_variety.Event();
+              t_variety.Event elem87 = tmp_elem87;
+              tmp_elem87.read(iprot);
+              elem89.add(elem87);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem66;
+            this.eventSetDefault = elem89;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -666,135 +674,140 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem90 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(this.iD);
+      oprot.writeI64(elem90);
       oprot.writeFieldEnd();
     }
-    if (this.ev != null) {
+    final elem91 = ev;
+    if (elem91 != null) {
       oprot.writeFieldBegin(_EV_FIELD_DESC);
-      this.ev.write(oprot);
+      elem91.write(oprot);
       oprot.writeFieldEnd();
     }
-    if (this.events != null) {
+    final elem92 = events;
+    if (elem92 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      final temp = this.events!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
-      for(var elem67 in temp) {
-        elem67.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem92.length));
+      for(var elem93 in elem92) {
+        elem93.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (this.events2 != null) {
+    final elem94 = events2;
+    if (elem94 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      final temp = this.events2!;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, temp.length));
-      for(var elem68 in temp) {
-        elem68.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem94.length));
+      for(var elem95 in elem94) {
+        elem95.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    if (this.eventMap != null) {
+    final elem96 = eventMap;
+    if (elem96 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      final temp = this.eventMap!;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, temp.length));
-      for(var elem69 in temp.keys) {
-        oprot.writeI64(elem69);
-        temp[elem69].write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem96.length));
+      for(var elem97 in elem96.keys) {
+        final val = elem96[elem97]!;
+        oprot.writeI64(elem97);
+        val.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    if (this.nums != null) {
+    final elem98 = nums;
+    if (elem98 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      final temp = this.nums!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, temp.length));
-      for(var elem70 in temp) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem70.length));
-        for(var elem71 in elem70) {
-          oprot.writeI32(elem71);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem98.length));
+      for(var elem99 in elem98) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem99.length));
+        for(var elem100 in elem99) {
+          oprot.writeI32(elem100);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (this.enums != null) {
+    final elem101 = enums;
+    if (elem101 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      final temp = this.enums!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem72 in temp) {
-        oprot.writeI32(elem72);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
+      for(var elem102 in elem101) {
+        oprot.writeI32(elem102);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem103 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(this.aBoolField);
+    oprot.writeBool(elem103);
     oprot.writeFieldEnd();
-    if (this.a_union != null) {
+    final elem104 = a_union;
+    if (elem104 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      this.a_union.write(oprot);
+      elem104.write(oprot);
       oprot.writeFieldEnd();
     }
-    if (this.typedefOfTypedef != null) {
+    final elem105 = typedefOfTypedef;
+    if (elem105 != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(this.typedefOfTypedef);
+      oprot.writeString(elem105);
       oprot.writeFieldEnd();
     }
+    final elem106 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    // ignore: deprecated_member_use
-    oprot.writeBool(this.depr);
+    oprot.writeBool(elem106);
     oprot.writeFieldEnd();
+    final elem107 = deprBinary;
     // ignore: deprecated_member_use
-    if (this.deprBinary != null) {
+    if (elem107 != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      // ignore: deprecated_member_use
-      oprot.writeBinary(this.deprBinary);
+      oprot.writeBinary(elem107);
       oprot.writeFieldEnd();
     }
+    final elem108 = deprList;
     // ignore: deprecated_member_use
-    if (this.deprList != null) {
+    if (elem108 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      // ignore: deprecated_member_use
-      final temp = this.deprList!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, temp.length));
-      // ignore: deprecated_member_use
-      for(var elem73 in temp) {
-        oprot.writeBool(elem73);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem108.length));
+      for(var elem109 in elem108) {
+        oprot.writeBool(elem109);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetEventsDefault() && this.eventsDefault != null) {
+    final elem110 = eventsDefault;
+    if (isSetEventsDefault() && elem110 != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      final temp = this.eventsDefault!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
-      for(var elem74 in temp) {
-        elem74.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem110.length));
+      for(var elem111 in elem110) {
+        elem111.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetEventMapDefault() && this.eventMapDefault != null) {
+    final elem112 = eventMapDefault;
+    if (isSetEventMapDefault() && elem112 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      final temp = this.eventMapDefault!;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, temp.length));
-      for(var elem75 in temp.keys) {
-        oprot.writeI64(elem75);
-        temp[elem75].write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem112.length));
+      for(var elem113 in elem112.keys) {
+        final val = elem112[elem113]!;
+        oprot.writeI64(elem113);
+        val.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetEventSetDefault() && this.eventSetDefault != null) {
+    final elem114 = eventSetDefault;
+    if (isSetEventSetDefault() && elem114 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      final temp = this.eventSetDefault!;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, temp.length));
-      for(var elem76 in temp) {
-        elem76.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem114.length));
+      for(var elem115 in elem114) {
+        elem115.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
@@ -462,92 +462,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_ev = t_variety.Event();
-            this.ev = tmp_ev;
-            tmp_ev.read(iprot);
+            final elem53 = t_variety.Event();
+            this.ev = elem53;
+            elem53.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem50 = iprot.readListBegin();
-            final elem53 = <t_variety.Event>[];
-            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
-              final tmp_elem51 = t_variety.Event();
-              t_variety.Event elem51 = tmp_elem51;
-              tmp_elem51.read(iprot);
-              elem53.add(elem51);
+            thrift.TList elem54 = iprot.readListBegin();
+            final elem58 = <t_variety.Event>[];
+            for(int elem57 = 0; elem57 < elem54.length; ++elem57) {
+              final elem56 = t_variety.Event();
+              t_variety.Event elem55 = elem56;
+              elem56.read(iprot);
+              elem58.add(elem55);
             }
             iprot.readListEnd();
-            this.events = elem53;
+            this.events = elem58;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem54 = iprot.readSetBegin();
-            final elem57 = <t_variety.Event>{};
-            for(int elem56 = 0; elem56 < elem54.length; ++elem56) {
-              final tmp_elem55 = t_variety.Event();
-              t_variety.Event elem55 = tmp_elem55;
-              tmp_elem55.read(iprot);
-              elem57.add(elem55);
+            thrift.TSet elem59 = iprot.readSetBegin();
+            final elem63 = <t_variety.Event>{};
+            for(int elem62 = 0; elem62 < elem59.length; ++elem62) {
+              final elem61 = t_variety.Event();
+              t_variety.Event elem60 = elem61;
+              elem61.read(iprot);
+              elem63.add(elem60);
             }
             iprot.readSetEnd();
-            this.events2 = elem57;
+            this.events2 = elem63;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem58 = iprot.readMapBegin();
-            final elem61 = <int, t_variety.Event>{};
-            for(int elem60 = 0; elem60 < elem58.length; ++elem60) {
-              int elem62 = iprot.readI64();
-              final tmp_elem59 = t_variety.Event();
-              t_variety.Event elem59 = tmp_elem59;
-              tmp_elem59.read(iprot);
-              elem61[elem62] = elem59;
+            thrift.TMap elem64 = iprot.readMapBegin();
+            final elem68 = <int, t_variety.Event>{};
+            for(int elem67 = 0; elem67 < elem64.length; ++elem67) {
+              int elem69 = iprot.readI64();
+              final elem66 = t_variety.Event();
+              t_variety.Event elem65 = elem66;
+              elem66.read(iprot);
+              elem68[elem69] = elem65;
             }
             iprot.readMapEnd();
-            this.eventMap = elem61;
+            this.eventMap = elem68;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem63 = iprot.readListBegin();
-            final elem69 = <List<int>>[];
-            for(int elem68 = 0; elem68 < elem63.length; ++elem68) {
-              thrift.TList elem65 = iprot.readListBegin();
-              final elem64 = <int>[];
-              for(int elem67 = 0; elem67 < elem65.length; ++elem67) {
-                int elem66 = iprot.readI32();
-                elem64.add(elem66);
+            thrift.TList elem70 = iprot.readListBegin();
+            final elem76 = <List<int>>[];
+            for(int elem75 = 0; elem75 < elem70.length; ++elem75) {
+              thrift.TList elem72 = iprot.readListBegin();
+              final elem71 = <int>[];
+              for(int elem74 = 0; elem74 < elem72.length; ++elem74) {
+                int elem73 = iprot.readI32();
+                elem71.add(elem73);
               }
               iprot.readListEnd();
-              elem69.add(elem64);
+              elem76.add(elem71);
             }
             iprot.readListEnd();
-            this.nums = elem69;
+            this.nums = elem76;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem70 = iprot.readListBegin();
-            final elem73 = <int>[];
-            for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
-              int elem71 = iprot.readI32();
-              elem73.add(elem71);
+            thrift.TList elem77 = iprot.readListBegin();
+            final elem80 = <int>[];
+            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
+              int elem78 = iprot.readI32();
+              elem80.add(elem78);
             }
             iprot.readListEnd();
-            this.enums = elem73;
+            this.enums = elem80;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -562,9 +562,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_a_union = t_variety.TestingUnions();
-            this.a_union = tmp_a_union;
-            tmp_a_union.read(iprot);
+            final elem81 = t_variety.TestingUnions();
+            this.a_union = elem81;
+            elem81.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -595,65 +595,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem74 = iprot.readListBegin();
+            thrift.TList elem82 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem77 = <bool>[];
-            for(int elem76 = 0; elem76 < elem74.length; ++elem76) {
-              bool elem75 = iprot.readBool();
+            final elem85 = <bool>[];
+            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
+              bool elem83 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem77.add(elem75);
+              elem85.add(elem83);
             }
             iprot.readListEnd();
-            this.deprList = elem77;
+            this.deprList = elem85;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem78 = iprot.readListBegin();
-            final elem81 = <t_variety.Event>[];
-            for(int elem80 = 0; elem80 < elem78.length; ++elem80) {
-              final tmp_elem79 = t_variety.Event();
-              t_variety.Event elem79 = tmp_elem79;
-              tmp_elem79.read(iprot);
-              elem81.add(elem79);
+            thrift.TList elem86 = iprot.readListBegin();
+            final elem90 = <t_variety.Event>[];
+            for(int elem89 = 0; elem89 < elem86.length; ++elem89) {
+              final elem88 = t_variety.Event();
+              t_variety.Event elem87 = elem88;
+              elem88.read(iprot);
+              elem90.add(elem87);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem81;
+            this.eventsDefault = elem90;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem82 = iprot.readMapBegin();
-            final elem85 = <int, t_variety.Event>{};
-            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
-              int elem86 = iprot.readI64();
-              final tmp_elem83 = t_variety.Event();
-              t_variety.Event elem83 = tmp_elem83;
-              tmp_elem83.read(iprot);
-              elem85[elem86] = elem83;
+            thrift.TMap elem91 = iprot.readMapBegin();
+            final elem95 = <int, t_variety.Event>{};
+            for(int elem94 = 0; elem94 < elem91.length; ++elem94) {
+              int elem96 = iprot.readI64();
+              final elem93 = t_variety.Event();
+              t_variety.Event elem92 = elem93;
+              elem93.read(iprot);
+              elem95[elem96] = elem92;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem85;
+            this.eventMapDefault = elem95;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem87 = iprot.readSetBegin();
-            final elem90 = <t_variety.Event>{};
-            for(int elem89 = 0; elem89 < elem87.length; ++elem89) {
-              final tmp_elem88 = t_variety.Event();
-              t_variety.Event elem88 = tmp_elem88;
-              tmp_elem88.read(iprot);
-              elem90.add(elem88);
+            thrift.TSet elem97 = iprot.readSetBegin();
+            final elem101 = <t_variety.Event>{};
+            for(int elem100 = 0; elem100 < elem97.length; ++elem100) {
+              final elem99 = t_variety.Event();
+              t_variety.Event elem98 = elem99;
+              elem99.read(iprot);
+              elem101.add(elem98);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem90;
+            this.eventSetDefault = elem101;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -674,140 +674,140 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem91 = iD;
+    final elem102 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(elem91);
+      oprot.writeI64(elem102);
       oprot.writeFieldEnd();
     }
-    final elem92 = ev;
-    if (elem92 != null) {
+    final elem103 = ev;
+    if (elem103 != null) {
       oprot.writeFieldBegin(_EV_FIELD_DESC);
-      elem92.write(oprot);
+      elem103.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem93 = events;
-    if (elem93 != null) {
+    final elem104 = events;
+    if (elem104 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem93.length));
-      for(var elem94 in elem93) {
-        elem94.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem104.length));
+      for(var elem105 in elem104) {
+        elem105.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem95 = events2;
-    if (elem95 != null) {
+    final elem106 = events2;
+    if (elem106 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem95.length));
-      for(var elem96 in elem95) {
-        elem96.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem106.length));
+      for(var elem107 in elem106) {
+        elem107.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem97 = eventMap;
-    if (elem97 != null) {
+    final elem108 = eventMap;
+    if (elem108 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem97.length));
-      for(var elem98 in elem97.keys) {
-        final elem99 = elem97[elem98]!;
-        oprot.writeI64(elem98);
-        elem99.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem108.length));
+      for(var elem109 in elem108.keys) {
+        final elem110 = elem108[elem109]!;
+        oprot.writeI64(elem109);
+        elem110.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem100 = nums;
-    if (elem100 != null) {
+    final elem111 = nums;
+    if (elem111 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem100.length));
-      for(var elem101 in elem100) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
-        for(var elem102 in elem101) {
-          oprot.writeI32(elem102);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem111.length));
+      for(var elem112 in elem111) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem112.length));
+        for(var elem113 in elem112) {
+          oprot.writeI32(elem113);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem103 = enums;
-    if (elem103 != null) {
+    final elem114 = enums;
+    if (elem114 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem103.length));
-      for(var elem104 in elem103) {
-        oprot.writeI32(elem104);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem114.length));
+      for(var elem115 in elem114) {
+        oprot.writeI32(elem115);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem105 = aBoolField;
+    final elem116 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem105);
+    oprot.writeBool(elem116);
     oprot.writeFieldEnd();
-    final elem106 = a_union;
-    if (elem106 != null) {
+    final elem117 = a_union;
+    if (elem117 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem106.write(oprot);
+      elem117.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem107 = typedefOfTypedef;
-    if (elem107 != null) {
+    final elem118 = typedefOfTypedef;
+    if (elem118 != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem107);
+      oprot.writeString(elem118);
       oprot.writeFieldEnd();
     }
-    final elem108 = depr;
+    final elem119 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem108);
+    oprot.writeBool(elem119);
     oprot.writeFieldEnd();
-    final elem109 = deprBinary;
+    final elem120 = deprBinary;
     // ignore: deprecated_member_use
-    if (elem109 != null) {
+    if (elem120 != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem109);
+      oprot.writeBinary(elem120);
       oprot.writeFieldEnd();
     }
-    final elem110 = deprList;
+    final elem121 = deprList;
     // ignore: deprecated_member_use
-    if (elem110 != null) {
+    if (elem121 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem110.length));
-      for(var elem111 in elem110) {
-        oprot.writeBool(elem111);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem121.length));
+      for(var elem122 in elem121) {
+        oprot.writeBool(elem122);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem112 = eventsDefault;
-    if (isSetEventsDefault() && elem112 != null) {
+    final elem123 = eventsDefault;
+    if (isSetEventsDefault() && elem123 != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem112.length));
-      for(var elem113 in elem112) {
-        elem113.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem123.length));
+      for(var elem124 in elem123) {
+        elem124.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem114 = eventMapDefault;
-    if (isSetEventMapDefault() && elem114 != null) {
+    final elem125 = eventMapDefault;
+    if (isSetEventMapDefault() && elem125 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem114.length));
-      for(var elem115 in elem114.keys) {
-        final elem116 = elem114[elem115]!;
-        oprot.writeI64(elem115);
-        elem116.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem125.length));
+      for(var elem126 in elem125.keys) {
+        final elem127 = elem125[elem126]!;
+        oprot.writeI64(elem126);
+        elem127.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem117 = eventSetDefault;
-    if (isSetEventSetDefault() && elem117 != null) {
+    final elem128 = eventSetDefault;
+    if (isSetEventSetDefault() && elem128 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem117.length));
-      for(var elem118 in elem117) {
-        elem118.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem128.length));
+      for(var elem129 in elem128) {
+        elem129.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
@@ -462,92 +462,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            final elem53 = t_variety.Event();
-            this.ev = elem53;
-            elem53.read(iprot);
+            final elem51 = t_variety.Event();
+            this.ev = elem51;
+            elem51.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem54 = iprot.readListBegin();
-            final elem58 = <t_variety.Event>[];
-            for(int elem57 = 0; elem57 < elem54.length; ++elem57) {
-              final elem56 = t_variety.Event();
-              t_variety.Event elem55 = elem56;
-              elem56.read(iprot);
-              elem58.add(elem55);
+            thrift.TList elem52 = iprot.readListBegin();
+            final elem56 = <t_variety.Event>[];
+            for(int elem55 = 0; elem55 < elem52.length; ++elem55) {
+              final elem54 = t_variety.Event();
+              t_variety.Event elem53 = elem54;
+              elem54.read(iprot);
+              elem56.add(elem53);
             }
             iprot.readListEnd();
-            this.events = elem58;
+            this.events = elem56;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem59 = iprot.readSetBegin();
-            final elem63 = <t_variety.Event>{};
-            for(int elem62 = 0; elem62 < elem59.length; ++elem62) {
-              final elem61 = t_variety.Event();
-              t_variety.Event elem60 = elem61;
-              elem61.read(iprot);
-              elem63.add(elem60);
+            thrift.TSet elem57 = iprot.readSetBegin();
+            final elem61 = <t_variety.Event>{};
+            for(int elem60 = 0; elem60 < elem57.length; ++elem60) {
+              final elem59 = t_variety.Event();
+              t_variety.Event elem58 = elem59;
+              elem59.read(iprot);
+              elem61.add(elem58);
             }
             iprot.readSetEnd();
-            this.events2 = elem63;
+            this.events2 = elem61;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem64 = iprot.readMapBegin();
-            final elem68 = <int, t_variety.Event>{};
-            for(int elem67 = 0; elem67 < elem64.length; ++elem67) {
-              int elem69 = iprot.readI64();
-              final elem66 = t_variety.Event();
-              t_variety.Event elem65 = elem66;
-              elem66.read(iprot);
-              elem68[elem69] = elem65;
+            thrift.TMap elem62 = iprot.readMapBegin();
+            final elem66 = <int, t_variety.Event>{};
+            for(int elem65 = 0; elem65 < elem62.length; ++elem65) {
+              int elem67 = iprot.readI64();
+              final elem64 = t_variety.Event();
+              t_variety.Event elem63 = elem64;
+              elem64.read(iprot);
+              elem66[elem67] = elem63;
             }
             iprot.readMapEnd();
-            this.eventMap = elem68;
+            this.eventMap = elem66;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem70 = iprot.readListBegin();
-            final elem76 = <List<int>>[];
-            for(int elem75 = 0; elem75 < elem70.length; ++elem75) {
-              thrift.TList elem72 = iprot.readListBegin();
-              final elem71 = <int>[];
-              for(int elem74 = 0; elem74 < elem72.length; ++elem74) {
-                int elem73 = iprot.readI32();
-                elem71.add(elem73);
+            thrift.TList elem68 = iprot.readListBegin();
+            final elem74 = <List<int>>[];
+            for(int elem73 = 0; elem73 < elem68.length; ++elem73) {
+              thrift.TList elem70 = iprot.readListBegin();
+              final elem69 = <int>[];
+              for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
+                int elem71 = iprot.readI32();
+                elem69.add(elem71);
               }
               iprot.readListEnd();
-              elem76.add(elem71);
+              elem74.add(elem69);
             }
             iprot.readListEnd();
-            this.nums = elem76;
+            this.nums = elem74;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem77 = iprot.readListBegin();
-            final elem80 = <int>[];
-            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
-              int elem78 = iprot.readI32();
-              elem80.add(elem78);
+            thrift.TList elem75 = iprot.readListBegin();
+            final elem78 = <int>[];
+            for(int elem77 = 0; elem77 < elem75.length; ++elem77) {
+              int elem76 = iprot.readI32();
+              elem78.add(elem76);
             }
             iprot.readListEnd();
-            this.enums = elem80;
+            this.enums = elem78;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -562,9 +562,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            final elem81 = t_variety.TestingUnions();
-            this.a_union = elem81;
-            elem81.read(iprot);
+            final elem79 = t_variety.TestingUnions();
+            this.a_union = elem79;
+            elem79.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -595,65 +595,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem82 = iprot.readListBegin();
+            thrift.TList elem80 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem85 = <bool>[];
-            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
-              bool elem83 = iprot.readBool();
+            final elem83 = <bool>[];
+            for(int elem82 = 0; elem82 < elem80.length; ++elem82) {
+              bool elem81 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem85.add(elem83);
+              elem83.add(elem81);
             }
             iprot.readListEnd();
-            this.deprList = elem85;
+            this.deprList = elem83;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem86 = iprot.readListBegin();
-            final elem90 = <t_variety.Event>[];
-            for(int elem89 = 0; elem89 < elem86.length; ++elem89) {
-              final elem88 = t_variety.Event();
-              t_variety.Event elem87 = elem88;
-              elem88.read(iprot);
-              elem90.add(elem87);
+            thrift.TList elem84 = iprot.readListBegin();
+            final elem88 = <t_variety.Event>[];
+            for(int elem87 = 0; elem87 < elem84.length; ++elem87) {
+              final elem86 = t_variety.Event();
+              t_variety.Event elem85 = elem86;
+              elem86.read(iprot);
+              elem88.add(elem85);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem90;
+            this.eventsDefault = elem88;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem91 = iprot.readMapBegin();
-            final elem95 = <int, t_variety.Event>{};
-            for(int elem94 = 0; elem94 < elem91.length; ++elem94) {
-              int elem96 = iprot.readI64();
-              final elem93 = t_variety.Event();
-              t_variety.Event elem92 = elem93;
-              elem93.read(iprot);
-              elem95[elem96] = elem92;
+            thrift.TMap elem89 = iprot.readMapBegin();
+            final elem93 = <int, t_variety.Event>{};
+            for(int elem92 = 0; elem92 < elem89.length; ++elem92) {
+              int elem94 = iprot.readI64();
+              final elem91 = t_variety.Event();
+              t_variety.Event elem90 = elem91;
+              elem91.read(iprot);
+              elem93[elem94] = elem90;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem95;
+            this.eventMapDefault = elem93;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem97 = iprot.readSetBegin();
-            final elem101 = <t_variety.Event>{};
-            for(int elem100 = 0; elem100 < elem97.length; ++elem100) {
-              final elem99 = t_variety.Event();
-              t_variety.Event elem98 = elem99;
-              elem99.read(iprot);
-              elem101.add(elem98);
+            thrift.TSet elem95 = iprot.readSetBegin();
+            final elem99 = <t_variety.Event>{};
+            for(int elem98 = 0; elem98 < elem95.length; ++elem98) {
+              final elem97 = t_variety.Event();
+              t_variety.Event elem96 = elem97;
+              elem97.read(iprot);
+              elem99.add(elem96);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem101;
+            this.eventSetDefault = elem99;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -674,140 +674,138 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem102 = iD;
+    final elem100 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(elem102);
+      oprot.writeI64(elem100);
       oprot.writeFieldEnd();
     }
-    final elem103 = ev;
-    if (elem103 != null) {
+    final elem101 = ev;
+    if (elem101 != null) {
       oprot.writeFieldBegin(_EV_FIELD_DESC);
-      elem103.write(oprot);
+      elem101.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem104 = events;
-    if (elem104 != null) {
+    final elem102 = events;
+    if (elem102 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem104.length));
-      for(var elem105 in elem104) {
-        elem105.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem102.length));
+      for(var elem103 in elem102) {
+        elem103.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem106 = events2;
-    if (elem106 != null) {
+    final elem104 = events2;
+    if (elem104 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem106.length));
-      for(var elem107 in elem106) {
-        elem107.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem104.length));
+      for(var elem105 in elem104) {
+        elem105.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem108 = eventMap;
-    if (elem108 != null) {
+    final elem106 = eventMap;
+    if (elem106 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem108.length));
-      for(var elem109 in elem108.keys) {
-        final elem110 = elem108[elem109]!;
-        oprot.writeI64(elem109);
-        elem110.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem106.length));
+      for(var entry in elem106.entries) {
+        oprot.writeI64(entry.key);
+        entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem111 = nums;
-    if (elem111 != null) {
+    final elem107 = nums;
+    if (elem107 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem111.length));
-      for(var elem112 in elem111) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem112.length));
-        for(var elem113 in elem112) {
-          oprot.writeI32(elem113);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem107.length));
+      for(var elem108 in elem107) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem108.length));
+        for(var elem109 in elem108) {
+          oprot.writeI32(elem109);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem114 = enums;
-    if (elem114 != null) {
+    final elem110 = enums;
+    if (elem110 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem114.length));
-      for(var elem115 in elem114) {
-        oprot.writeI32(elem115);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem110.length));
+      for(var elem111 in elem110) {
+        oprot.writeI32(elem111);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem116 = aBoolField;
+    final elem112 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem116);
+    oprot.writeBool(elem112);
     oprot.writeFieldEnd();
-    final elem117 = a_union;
-    if (elem117 != null) {
+    final elem113 = a_union;
+    if (elem113 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem117.write(oprot);
+      elem113.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem118 = typedefOfTypedef;
-    if (elem118 != null) {
+    final elem114 = typedefOfTypedef;
+    if (elem114 != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem118);
+      oprot.writeString(elem114);
       oprot.writeFieldEnd();
     }
-    final elem119 = depr;
+    final elem115 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem119);
+    oprot.writeBool(elem115);
     oprot.writeFieldEnd();
-    final elem120 = deprBinary;
+    final elem116 = deprBinary;
     // ignore: deprecated_member_use
-    if (elem120 != null) {
+    if (elem116 != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem120);
+      oprot.writeBinary(elem116);
       oprot.writeFieldEnd();
     }
-    final elem121 = deprList;
+    final elem117 = deprList;
     // ignore: deprecated_member_use
-    if (elem121 != null) {
+    if (elem117 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem121.length));
-      for(var elem122 in elem121) {
-        oprot.writeBool(elem122);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem117.length));
+      for(var elem118 in elem117) {
+        oprot.writeBool(elem118);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem123 = eventsDefault;
-    if (isSetEventsDefault() && elem123 != null) {
+    final elem119 = eventsDefault;
+    if (isSetEventsDefault() && elem119 != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem123.length));
-      for(var elem124 in elem123) {
-        elem124.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem119.length));
+      for(var elem120 in elem119) {
+        elem120.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem125 = eventMapDefault;
-    if (isSetEventMapDefault() && elem125 != null) {
+    final elem121 = eventMapDefault;
+    if (isSetEventMapDefault() && elem121 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem125.length));
-      for(var elem126 in elem125.keys) {
-        final elem127 = elem125[elem126]!;
-        oprot.writeI64(elem126);
-        elem127.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem121.length));
+      for(var entry in elem121.entries) {
+        oprot.writeI64(entry.key);
+        entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem128 = eventSetDefault;
-    if (isSetEventSetDefault() && elem128 != null) {
+    final elem122 = eventSetDefault;
+    if (isSetEventSetDefault() && elem122 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem128.length));
-      for(var elem129 in elem128) {
-        elem129.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem122.length));
+      for(var elem123 in elem122) {
+        elem123.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
@@ -471,83 +471,83 @@ class EventWrapper implements thrift.TBase {
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem49 = iprot.readListBegin();
-            final elem52 = <t_variety.Event>[];
-            for(int elem51 = 0; elem51 < elem49.length; ++elem51) {
-              final tmp_elem50 = t_variety.Event();
-              t_variety.Event elem50 = tmp_elem50;
-              tmp_elem50.read(iprot);
-              elem52.add(elem50);
+            thrift.TList elem50 = iprot.readListBegin();
+            final elem53 = <t_variety.Event>[];
+            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
+              final tmp_elem51 = t_variety.Event();
+              t_variety.Event elem51 = tmp_elem51;
+              tmp_elem51.read(iprot);
+              elem53.add(elem51);
             }
             iprot.readListEnd();
-            this.events = elem52;
+            this.events = elem53;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem53 = iprot.readSetBegin();
-            final elem56 = <t_variety.Event>{};
-            for(int elem55 = 0; elem55 < elem53.length; ++elem55) {
-              final tmp_elem54 = t_variety.Event();
-              t_variety.Event elem54 = tmp_elem54;
-              tmp_elem54.read(iprot);
-              elem56.add(elem54);
+            thrift.TSet elem54 = iprot.readSetBegin();
+            final elem57 = <t_variety.Event>{};
+            for(int elem56 = 0; elem56 < elem54.length; ++elem56) {
+              final tmp_elem55 = t_variety.Event();
+              t_variety.Event elem55 = tmp_elem55;
+              tmp_elem55.read(iprot);
+              elem57.add(elem55);
             }
             iprot.readSetEnd();
-            this.events2 = elem56;
+            this.events2 = elem57;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem57 = iprot.readMapBegin();
-            final elem60 = <int, t_variety.Event>{};
-            for(int elem59 = 0; elem59 < elem57.length; ++elem59) {
-              int elem61 = iprot.readI64();
-              final tmp_elem58 = t_variety.Event();
-              t_variety.Event elem58 = tmp_elem58;
-              tmp_elem58.read(iprot);
-              elem60[elem61] = elem58;
+            thrift.TMap elem58 = iprot.readMapBegin();
+            final elem61 = <int, t_variety.Event>{};
+            for(int elem60 = 0; elem60 < elem58.length; ++elem60) {
+              int elem62 = iprot.readI64();
+              final tmp_elem59 = t_variety.Event();
+              t_variety.Event elem59 = tmp_elem59;
+              tmp_elem59.read(iprot);
+              elem61[elem62] = elem59;
             }
             iprot.readMapEnd();
-            this.eventMap = elem60;
+            this.eventMap = elem61;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem62 = iprot.readListBegin();
-            final elem68 = <List<int>>[];
-            for(int elem67 = 0; elem67 < elem62.length; ++elem67) {
-              thrift.TList elem64 = iprot.readListBegin();
-              final elem63 = <int>[];
-              for(int elem66 = 0; elem66 < elem64.length; ++elem66) {
-                int elem65 = iprot.readI32();
-                elem63.add(elem65);
+            thrift.TList elem63 = iprot.readListBegin();
+            final elem69 = <List<int>>[];
+            for(int elem68 = 0; elem68 < elem63.length; ++elem68) {
+              thrift.TList elem65 = iprot.readListBegin();
+              final elem64 = <int>[];
+              for(int elem67 = 0; elem67 < elem65.length; ++elem67) {
+                int elem66 = iprot.readI32();
+                elem64.add(elem66);
               }
               iprot.readListEnd();
-              elem68.add(elem63);
+              elem69.add(elem64);
             }
             iprot.readListEnd();
-            this.nums = elem68;
+            this.nums = elem69;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem69 = iprot.readListBegin();
-            final elem72 = <int>[];
-            for(int elem71 = 0; elem71 < elem69.length; ++elem71) {
-              int elem70 = iprot.readI32();
-              elem72.add(elem70);
+            thrift.TList elem70 = iprot.readListBegin();
+            final elem73 = <int>[];
+            for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
+              int elem71 = iprot.readI32();
+              elem73.add(elem71);
             }
             iprot.readListEnd();
-            this.enums = elem72;
+            this.enums = elem73;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -595,65 +595,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem73 = iprot.readListBegin();
+            thrift.TList elem74 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem76 = <bool>[];
-            for(int elem75 = 0; elem75 < elem73.length; ++elem75) {
-              bool elem74 = iprot.readBool();
+            final elem77 = <bool>[];
+            for(int elem76 = 0; elem76 < elem74.length; ++elem76) {
+              bool elem75 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem76.add(elem74);
+              elem77.add(elem75);
             }
             iprot.readListEnd();
-            this.deprList = elem76;
+            this.deprList = elem77;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem77 = iprot.readListBegin();
-            final elem80 = <t_variety.Event>[];
-            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
-              final tmp_elem78 = t_variety.Event();
-              t_variety.Event elem78 = tmp_elem78;
-              tmp_elem78.read(iprot);
-              elem80.add(elem78);
+            thrift.TList elem78 = iprot.readListBegin();
+            final elem81 = <t_variety.Event>[];
+            for(int elem80 = 0; elem80 < elem78.length; ++elem80) {
+              final tmp_elem79 = t_variety.Event();
+              t_variety.Event elem79 = tmp_elem79;
+              tmp_elem79.read(iprot);
+              elem81.add(elem79);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem80;
+            this.eventsDefault = elem81;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem81 = iprot.readMapBegin();
-            final elem84 = <int, t_variety.Event>{};
-            for(int elem83 = 0; elem83 < elem81.length; ++elem83) {
-              int elem85 = iprot.readI64();
-              final tmp_elem82 = t_variety.Event();
-              t_variety.Event elem82 = tmp_elem82;
-              tmp_elem82.read(iprot);
-              elem84[elem85] = elem82;
+            thrift.TMap elem82 = iprot.readMapBegin();
+            final elem85 = <int, t_variety.Event>{};
+            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
+              int elem86 = iprot.readI64();
+              final tmp_elem83 = t_variety.Event();
+              t_variety.Event elem83 = tmp_elem83;
+              tmp_elem83.read(iprot);
+              elem85[elem86] = elem83;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem84;
+            this.eventMapDefault = elem85;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem86 = iprot.readSetBegin();
-            final elem89 = <t_variety.Event>{};
-            for(int elem88 = 0; elem88 < elem86.length; ++elem88) {
-              final tmp_elem87 = t_variety.Event();
-              t_variety.Event elem87 = tmp_elem87;
-              tmp_elem87.read(iprot);
-              elem89.add(elem87);
+            thrift.TSet elem87 = iprot.readSetBegin();
+            final elem90 = <t_variety.Event>{};
+            for(int elem89 = 0; elem89 < elem87.length; ++elem89) {
+              final tmp_elem88 = t_variety.Event();
+              t_variety.Event elem88 = tmp_elem88;
+              tmp_elem88.read(iprot);
+              elem90.add(elem88);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem89;
+            this.eventSetDefault = elem90;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -674,140 +674,140 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem90 = iD;
+    final elem91 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(elem90);
+      oprot.writeI64(elem91);
       oprot.writeFieldEnd();
     }
-    final elem91 = ev;
-    if (elem91 != null) {
-      oprot.writeFieldBegin(_EV_FIELD_DESC);
-      elem91.write(oprot);
-      oprot.writeFieldEnd();
-    }
-    final elem92 = events;
+    final elem92 = ev;
     if (elem92 != null) {
+      oprot.writeFieldBegin(_EV_FIELD_DESC);
+      elem92.write(oprot);
+      oprot.writeFieldEnd();
+    }
+    final elem93 = events;
+    if (elem93 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem92.length));
-      for(var elem93 in elem92) {
-        elem93.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem93.length));
+      for(var elem94 in elem93) {
+        elem94.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem94 = events2;
-    if (elem94 != null) {
+    final elem95 = events2;
+    if (elem95 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem94.length));
-      for(var elem95 in elem94) {
-        elem95.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem95.length));
+      for(var elem96 in elem95) {
+        elem96.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem96 = eventMap;
-    if (elem96 != null) {
+    final elem97 = eventMap;
+    if (elem97 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem96.length));
-      for(var elem97 in elem96.keys) {
-        final val = elem96[elem97]!;
-        oprot.writeI64(elem97);
-        val.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem97.length));
+      for(var elem98 in elem97.keys) {
+        final elem99 = elem97[elem98]!;
+        oprot.writeI64(elem98);
+        elem99.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem98 = nums;
-    if (elem98 != null) {
+    final elem100 = nums;
+    if (elem100 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem98.length));
-      for(var elem99 in elem98) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem99.length));
-        for(var elem100 in elem99) {
-          oprot.writeI32(elem100);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem100.length));
+      for(var elem101 in elem100) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
+        for(var elem102 in elem101) {
+          oprot.writeI32(elem102);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem101 = enums;
-    if (elem101 != null) {
+    final elem103 = enums;
+    if (elem103 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
-      for(var elem102 in elem101) {
-        oprot.writeI32(elem102);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem103.length));
+      for(var elem104 in elem103) {
+        oprot.writeI32(elem104);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem103 = aBoolField;
+    final elem105 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem103);
+    oprot.writeBool(elem105);
     oprot.writeFieldEnd();
-    final elem104 = a_union;
-    if (elem104 != null) {
+    final elem106 = a_union;
+    if (elem106 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem104.write(oprot);
+      elem106.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem105 = typedefOfTypedef;
-    if (elem105 != null) {
-      oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem105);
-      oprot.writeFieldEnd();
-    }
-    final elem106 = depr;
-    oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem106);
-    oprot.writeFieldEnd();
-    final elem107 = deprBinary;
-    // ignore: deprecated_member_use
+    final elem107 = typedefOfTypedef;
     if (elem107 != null) {
-      oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem107);
+      oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
+      oprot.writeString(elem107);
       oprot.writeFieldEnd();
     }
-    final elem108 = deprList;
+    final elem108 = depr;
+    oprot.writeFieldBegin(_DEPR_FIELD_DESC);
+    oprot.writeBool(elem108);
+    oprot.writeFieldEnd();
+    final elem109 = deprBinary;
     // ignore: deprecated_member_use
-    if (elem108 != null) {
+    if (elem109 != null) {
+      oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
+      oprot.writeBinary(elem109);
+      oprot.writeFieldEnd();
+    }
+    final elem110 = deprList;
+    // ignore: deprecated_member_use
+    if (elem110 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem108.length));
-      for(var elem109 in elem108) {
-        oprot.writeBool(elem109);
-      }
-      oprot.writeListEnd();
-      oprot.writeFieldEnd();
-    }
-    final elem110 = eventsDefault;
-    if (isSetEventsDefault() && elem110 != null) {
-      oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem110.length));
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem110.length));
       for(var elem111 in elem110) {
-        elem111.write(oprot);
+        oprot.writeBool(elem111);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem112 = eventMapDefault;
-    if (isSetEventMapDefault() && elem112 != null) {
+    final elem112 = eventsDefault;
+    if (isSetEventsDefault() && elem112 != null) {
+      oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem112.length));
+      for(var elem113 in elem112) {
+        elem113.write(oprot);
+      }
+      oprot.writeListEnd();
+      oprot.writeFieldEnd();
+    }
+    final elem114 = eventMapDefault;
+    if (isSetEventMapDefault() && elem114 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem112.length));
-      for(var elem113 in elem112.keys) {
-        final val = elem112[elem113]!;
-        oprot.writeI64(elem113);
-        val.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem114.length));
+      for(var elem115 in elem114.keys) {
+        final elem116 = elem114[elem115]!;
+        oprot.writeI64(elem115);
+        elem116.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem114 = eventSetDefault;
-    if (isSetEventSetDefault() && elem114 != null) {
+    final elem117 = eventSetDefault;
+    if (isSetEventSetDefault() && elem117 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem114.length));
-      for(var elem115 in elem114) {
-        elem115.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem117.length));
+      for(var elem118 in elem117) {
+        elem118.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';
@@ -466,7 +463,7 @@ class EventWrapper implements thrift.TBase {
         case EV:
           if (field.type == thrift.TType.STRUCT) {
             this.ev = t_variety.Event();
-            ev?.read(iprot);
+            ev.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -477,7 +474,7 @@ class EventWrapper implements thrift.TBase {
             final elem29 = <t_variety.Event>[];
             for(int elem28 = 0; elem28 < elem26.length; ++elem28) {
               t_variety.Event elem27 = t_variety.Event();
-              elem27?.read(iprot);
+              elem27.read(iprot);
               elem29.add(elem27);
             }
             iprot.readListEnd();
@@ -492,7 +489,7 @@ class EventWrapper implements thrift.TBase {
             final elem33 = <t_variety.Event>{};
             for(int elem32 = 0; elem32 < elem30.length; ++elem32) {
               t_variety.Event elem31 = t_variety.Event();
-              elem31?.read(iprot);
+              elem31.read(iprot);
               elem33.add(elem31);
             }
             iprot.readSetEnd();
@@ -508,7 +505,7 @@ class EventWrapper implements thrift.TBase {
             for(int elem36 = 0; elem36 < elem34.length; ++elem36) {
               int elem38 = iprot.readI64();
               t_variety.Event elem35 = t_variety.Event();
-              elem35?.read(iprot);
+              elem35.read(iprot);
               elem37[elem38] = elem35;
             }
             iprot.readMapEnd();
@@ -562,7 +559,7 @@ class EventWrapper implements thrift.TBase {
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
             this.a_union = t_variety.TestingUnions();
-            a_union?.read(iprot);
+            a_union.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -613,7 +610,7 @@ class EventWrapper implements thrift.TBase {
             final elem57 = <t_variety.Event>[];
             for(int elem56 = 0; elem56 < elem54.length; ++elem56) {
               t_variety.Event elem55 = t_variety.Event();
-              elem55?.read(iprot);
+              elem55.read(iprot);
               elem57.add(elem55);
             }
             iprot.readListEnd();
@@ -629,7 +626,7 @@ class EventWrapper implements thrift.TBase {
             for(int elem60 = 0; elem60 < elem58.length; ++elem60) {
               int elem62 = iprot.readI64();
               t_variety.Event elem59 = t_variety.Event();
-              elem59?.read(iprot);
+              elem59.read(iprot);
               elem61[elem62] = elem59;
             }
             iprot.readMapEnd();
@@ -644,7 +641,7 @@ class EventWrapper implements thrift.TBase {
             final elem66 = <t_variety.Event>{};
             for(int elem65 = 0; elem65 < elem63.length; ++elem65) {
               t_variety.Event elem64 = t_variety.Event();
-              elem64?.read(iprot);
+              elem64.read(iprot);
               elem66.add(elem64);
             }
             iprot.readSetEnd();
@@ -676,15 +673,15 @@ class EventWrapper implements thrift.TBase {
     }
     if (this.ev != null) {
       oprot.writeFieldBegin(_EV_FIELD_DESC);
-      this.ev?.write(oprot);
+      this.ev.write(oprot);
       oprot.writeFieldEnd();
     }
     if (this.events != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
       final temp = this.events!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp!.length));
-      for(var elem67 in temp!) {
-        elem67?.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
+      for(var elem67 in temp) {
+        elem67.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
@@ -692,9 +689,9 @@ class EventWrapper implements thrift.TBase {
     if (this.events2 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
       final temp = this.events2!;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, temp!.length));
-      for(var elem68 in temp!) {
-        elem68?.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, temp.length));
+      for(var elem68 in temp) {
+        elem68.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -702,10 +699,10 @@ class EventWrapper implements thrift.TBase {
     if (this.eventMap != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
       final temp = this.eventMap!;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, temp!.length));
-      for(var elem69 in temp!.keys) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, temp.length));
+      for(var elem69 in temp.keys) {
         oprot.writeI64(elem69);
-        temp[elem69]?.write(oprot);
+        temp[elem69].write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -713,10 +710,10 @@ class EventWrapper implements thrift.TBase {
     if (this.nums != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
       final temp = this.nums!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, temp!.length));
-      for(var elem70 in temp!) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem70!.length));
-        for(var elem71 in elem70!) {
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, temp.length));
+      for(var elem70 in temp) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem70.length));
+        for(var elem71 in elem70) {
           oprot.writeI32(elem71);
         }
         oprot.writeListEnd();
@@ -727,8 +724,8 @@ class EventWrapper implements thrift.TBase {
     if (this.enums != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
       final temp = this.enums!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp!.length));
-      for(var elem72 in temp!) {
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
+      for(var elem72 in temp) {
         oprot.writeI32(elem72);
       }
       oprot.writeListEnd();
@@ -739,7 +736,7 @@ class EventWrapper implements thrift.TBase {
     oprot.writeFieldEnd();
     if (this.a_union != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      this.a_union?.write(oprot);
+      this.a_union.write(oprot);
       oprot.writeFieldEnd();
     }
     if (this.typedefOfTypedef != null) {
@@ -763,9 +760,9 @@ class EventWrapper implements thrift.TBase {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
       // ignore: deprecated_member_use
       final temp = this.deprList!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, temp!.length));
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, temp.length));
       // ignore: deprecated_member_use
-      for(var elem73 in temp!) {
+      for(var elem73 in temp) {
         oprot.writeBool(elem73);
       }
       oprot.writeListEnd();
@@ -774,9 +771,9 @@ class EventWrapper implements thrift.TBase {
     if (isSetEventsDefault() && this.eventsDefault != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
       final temp = this.eventsDefault!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp!.length));
-      for(var elem74 in temp!) {
-        elem74?.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
+      for(var elem74 in temp) {
+        elem74.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
@@ -784,10 +781,10 @@ class EventWrapper implements thrift.TBase {
     if (isSetEventMapDefault() && this.eventMapDefault != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
       final temp = this.eventMapDefault!;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, temp!.length));
-      for(var elem75 in temp!.keys) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, temp.length));
+      for(var elem75 in temp.keys) {
         oprot.writeI64(elem75);
-        temp[elem75]?.write(oprot);
+        temp[elem75].write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -795,9 +792,9 @@ class EventWrapper implements thrift.TBase {
     if (isSetEventSetDefault() && this.eventSetDefault != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
       final temp = this.eventSetDefault!;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, temp!.length));
-      for(var elem76 in temp!) {
-        elem76?.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, temp.length));
+      for(var elem76 in temp) {
+        elem76.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_events_scope.dart
@@ -123,12 +123,11 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem180 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem180.length));
-      for(var elem181 in elem180.keys) {
-        final elem182 = elem180[elem181]!;
-        oprot.writeI64(elem181);
-        elem182.write(oprot);
+    for(var elem170 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem170.length));
+      for(var entry in elem170.entries) {
+        oprot.writeI64(entry.key);
+        entry.value.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -176,9 +175,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final elem183 = t_variety.Event();
-      t_variety.Event req = elem183;
-      elem183.read(iprot);
+      final elem171 = t_variety.Event();
+      t_variety.Event req = elem171;
+      elem171.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -265,20 +264,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem184 = iprot.readListBegin();
+      thrift.TList elem172 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem191 = 0; elem191 < elem184.length; ++elem191) {
-        thrift.TMap elem186 = iprot.readMapBegin();
-        final elem185 = <int, t_variety.Event>{};
-        for(int elem189 = 0; elem189 < elem186.length; ++elem189) {
-          int elem190 = iprot.readI64();
-          final elem188 = t_variety.Event();
-          t_variety.Event elem187 = elem188;
-          elem188.read(iprot);
-          elem185[elem190] = elem187;
+      for(int elem179 = 0; elem179 < elem172.length; ++elem179) {
+        thrift.TMap elem174 = iprot.readMapBegin();
+        final elem173 = <int, t_variety.Event>{};
+        for(int elem177 = 0; elem177 < elem174.length; ++elem177) {
+          int elem178 = iprot.readI64();
+          final elem176 = t_variety.Event();
+          t_variety.Event elem175 = elem176;
+          elem176.read(iprot);
+          elem173[elem178] = elem175;
         }
         iprot.readMapEnd();
-        req.add(elem185);
+        req.add(elem173);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_events_scope.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
@@ -64,11 +62,9 @@ class EventsPublisher {
     var msg = thrift.TMessage(op, thrift.TMessageType.CALL, 0);
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
-    req?.write(oprot);
+    req.write(oprot);
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures, use_of_void_result
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 
 
@@ -88,9 +84,7 @@ class EventsPublisher {
     oprot.writeMessageBegin(msg);
     oprot.writeI64(req);
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures, use_of_void_result
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 
 
@@ -110,9 +104,7 @@ class EventsPublisher {
     oprot.writeMessageBegin(msg);
     oprot.writeString(req);
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures, use_of_void_result
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 
 
@@ -130,20 +122,18 @@ class EventsPublisher {
     var msg = thrift.TMessage(op, thrift.TMessageType.CALL, 0);
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
-    oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req!.length));
-    for(var elem90 in req!) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem90!.length));
-      for(var elem91 in elem90!.keys) {
+    oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
+    for(var elem90 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem90.length));
+      for(var elem91 in elem90.keys) {
         oprot.writeI64(elem91);
-        elem90[elem91]?.write(oprot);
+        elem90[elem91].write(oprot);
       }
       oprot.writeMapEnd();
     }
     oprot.writeListEnd();
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures, use_of_void_result
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 }
 
@@ -186,7 +176,7 @@ class EventsSubscriber {
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
       t_variety.Event req = t_variety.Event();
-      req?.read(iprot);
+      req.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -281,7 +271,7 @@ class EventsSubscriber {
         for(int elem96 = 0; elem96 < elem94.length; ++elem96) {
           int elem97 = iprot.readI64();
           t_variety.Event elem95 = t_variety.Event();
-          elem95?.read(iprot);
+          elem95.read(iprot);
           elem93[elem97] = elem95;
         }
         iprot.readMapEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_events_scope.dart
@@ -123,12 +123,12 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem159 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem159.length));
-      for(var elem160 in elem159.keys) {
-        final val = elem159[elem160]!;
-        oprot.writeI64(elem160);
-        val.write(oprot);
+    for(var elem164 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem164.length));
+      for(var elem165 in elem164.keys) {
+        final elem166 = elem164[elem165]!;
+        oprot.writeI64(elem165);
+        elem166.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -265,20 +265,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem161 = iprot.readListBegin();
+      thrift.TList elem167 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem167 = 0; elem167 < elem161.length; ++elem167) {
-        thrift.TMap elem163 = iprot.readMapBegin();
-        final elem162 = <int, t_variety.Event>{};
-        for(int elem165 = 0; elem165 < elem163.length; ++elem165) {
-          int elem166 = iprot.readI64();
-          final tmp_elem164 = t_variety.Event();
-          t_variety.Event elem164 = tmp_elem164;
-          tmp_elem164.read(iprot);
-          elem162[elem166] = elem164;
+      for(int elem173 = 0; elem173 < elem167.length; ++elem173) {
+        thrift.TMap elem169 = iprot.readMapBegin();
+        final elem168 = <int, t_variety.Event>{};
+        for(int elem171 = 0; elem171 < elem169.length; ++elem171) {
+          int elem172 = iprot.readI64();
+          final tmp_elem170 = t_variety.Event();
+          t_variety.Event elem170 = tmp_elem170;
+          tmp_elem170.read(iprot);
+          elem168[elem172] = elem170;
         }
         iprot.readMapEnd();
-        req.add(elem162);
+        req.add(elem168);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_events_scope.dart
@@ -123,11 +123,12 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem90 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem90.length));
-      for(var elem91 in elem90.keys) {
-        oprot.writeI64(elem91);
-        elem90[elem91].write(oprot);
+    for(var elem159 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem159.length));
+      for(var elem160 in elem159.keys) {
+        final val = elem159[elem160]!;
+        oprot.writeI64(elem160);
+        val.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -175,8 +176,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      t_variety.Event req = t_variety.Event();
-      req.read(iprot);
+      final tmp_req = t_variety.Event();
+      t_variety.Event req = tmp_req;
+      tmp_req.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -263,19 +265,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem92 = iprot.readListBegin();
+      thrift.TList elem161 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem98 = 0; elem98 < elem92.length; ++elem98) {
-        thrift.TMap elem94 = iprot.readMapBegin();
-        final elem93 = <int, t_variety.Event>{};
-        for(int elem96 = 0; elem96 < elem94.length; ++elem96) {
-          int elem97 = iprot.readI64();
-          t_variety.Event elem95 = t_variety.Event();
-          elem95.read(iprot);
-          elem93[elem97] = elem95;
+      for(int elem167 = 0; elem167 < elem161.length; ++elem167) {
+        thrift.TMap elem163 = iprot.readMapBegin();
+        final elem162 = <int, t_variety.Event>{};
+        for(int elem165 = 0; elem165 < elem163.length; ++elem165) {
+          int elem166 = iprot.readI64();
+          final tmp_elem164 = t_variety.Event();
+          t_variety.Event elem164 = tmp_elem164;
+          tmp_elem164.read(iprot);
+          elem162[elem166] = elem164;
         }
         iprot.readMapEnd();
-        req.add(elem93);
+        req.add(elem162);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_events_scope.dart
@@ -123,12 +123,12 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem164 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem164.length));
-      for(var elem165 in elem164.keys) {
-        final elem166 = elem164[elem165]!;
-        oprot.writeI64(elem165);
-        elem166.write(oprot);
+    for(var elem180 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem180.length));
+      for(var elem181 in elem180.keys) {
+        final elem182 = elem180[elem181]!;
+        oprot.writeI64(elem181);
+        elem182.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -176,9 +176,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final tmp_req = t_variety.Event();
-      t_variety.Event req = tmp_req;
-      tmp_req.read(iprot);
+      final elem183 = t_variety.Event();
+      t_variety.Event req = elem183;
+      elem183.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -265,20 +265,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem167 = iprot.readListBegin();
+      thrift.TList elem184 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem173 = 0; elem173 < elem167.length; ++elem173) {
-        thrift.TMap elem169 = iprot.readMapBegin();
-        final elem168 = <int, t_variety.Event>{};
-        for(int elem171 = 0; elem171 < elem169.length; ++elem171) {
-          int elem172 = iprot.readI64();
-          final tmp_elem170 = t_variety.Event();
-          t_variety.Event elem170 = tmp_elem170;
-          tmp_elem170.read(iprot);
-          elem168[elem172] = elem170;
+      for(int elem191 = 0; elem191 < elem184.length; ++elem191) {
+        thrift.TMap elem186 = iprot.readMapBegin();
+        final elem185 = <int, t_variety.Event>{};
+        for(int elem189 = 0; elem189 < elem186.length; ++elem189) {
+          int elem190 = iprot.readI64();
+          final elem188 = t_variety.Event();
+          t_variety.Event elem187 = elem188;
+          elem188.read(iprot);
+          elem185[elem190] = elem187;
         }
         iprot.readMapEnd();
-        req.add(elem168);
+        req.add(elem185);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_foo_args.dart
@@ -148,19 +148,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.newMessage != null) {
+    final elem116 = newMessage;
+    if (elem116 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(this.newMessage);
+      oprot.writeString(elem116);
       oprot.writeFieldEnd();
     }
-    if (this.messageArgs != null) {
+    final elem117 = messageArgs;
+    if (elem117 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(this.messageArgs);
+      oprot.writeString(elem117);
       oprot.writeFieldEnd();
     }
-    if (this.messageResult != null) {
+    final elem118 = messageResult;
+    if (elem118 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(this.messageResult);
+      oprot.writeString(elem118);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_foo_args.dart
@@ -148,22 +148,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem130 = newMessage;
-    if (elem130 != null) {
+    final elem124 = newMessage;
+    if (elem124 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem130);
+      oprot.writeString(elem124);
       oprot.writeFieldEnd();
     }
-    final elem131 = messageArgs;
-    if (elem131 != null) {
+    final elem125 = messageArgs;
+    if (elem125 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem131);
+      oprot.writeString(elem125);
       oprot.writeFieldEnd();
     }
-    final elem132 = messageResult;
-    if (elem132 != null) {
+    final elem126 = messageResult;
+    if (elem126 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem132);
+      oprot.writeString(elem126);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_foo_args.dart
@@ -148,22 +148,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem116 = newMessage;
-    if (elem116 != null) {
+    final elem119 = newMessage;
+    if (elem119 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem116);
+      oprot.writeString(elem119);
       oprot.writeFieldEnd();
     }
-    final elem117 = messageArgs;
-    if (elem117 != null) {
+    final elem120 = messageArgs;
+    if (elem120 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem117);
+      oprot.writeString(elem120);
       oprot.writeFieldEnd();
     }
-    final elem118 = messageResult;
-    if (elem118 != null) {
+    final elem121 = messageResult;
+    if (elem121 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem118);
+      oprot.writeString(elem121);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_foo_args.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_foo_args.dart
@@ -148,22 +148,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem119 = newMessage;
-    if (elem119 != null) {
+    final elem130 = newMessage;
+    if (elem130 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem119);
+      oprot.writeString(elem130);
       oprot.writeFieldEnd();
     }
-    final elem120 = messageArgs;
-    if (elem120 != null) {
+    final elem131 = messageArgs;
+    if (elem131 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem120);
+      oprot.writeString(elem131);
       oprot.writeFieldEnd();
     }
-    final elem121 = messageResult;
-    if (elem121 != null) {
+    final elem132 = messageResult;
+    if (elem132 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem121);
+      oprot.writeString(elem132);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_foo_service.dart
@@ -418,20 +418,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem140 = num;
+    final elem151 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem140);
+    oprot.writeI32(elem151);
     oprot.writeFieldEnd();
-    final elem141 = str;
-    if (elem141 != null) {
+    final elem152 = str;
+    if (elem152 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem141);
+      oprot.writeString(elem152);
       oprot.writeFieldEnd();
     }
-    final elem142 = event;
-    if (elem142 != null) {
+    final elem153 = event;
+    if (elem153 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem142.write(oprot);
+      elem153.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -464,18 +464,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_awe = t_variety.AwesomeException();
-            this.awe = tmp_awe;
-            tmp_awe.read(iprot);
+            final elem154 = t_variety.AwesomeException();
+            this.awe = elem154;
+            elem154.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_api = t_actual_base_dart.api_exception();
-            this.api = tmp_api;
-            tmp_api.read(iprot);
+            final elem155 = t_actual_base_dart.api_exception();
+            this.api = elem155;
+            elem155.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -509,18 +509,18 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem143 = id;
+    final elem156 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem143);
+    oprot.writeI64(elem156);
     oprot.writeFieldEnd();
-    final elem144 = req;
-    if (elem144 != null) {
+    final elem157 = req;
+    if (elem157 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem144.length));
-      for(var elem145 in elem144.keys) {
-        final elem146 = elem144[elem145]!;
-        oprot.writeI32(elem145);
-        oprot.writeString(elem146);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem157.length));
+      for(var elem158 in elem157.keys) {
+        final elem159 = elem157[elem158]!;
+        oprot.writeI32(elem158);
+        oprot.writeString(elem159);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -547,16 +547,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem147 = bin;
-    if (elem147 != null) {
+    final elem160 = bin;
+    if (elem160 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem147);
+      oprot.writeBinary(elem160);
       oprot.writeFieldEnd();
     }
-    final elem148 = str;
-    if (elem148 != null) {
+    final elem161 = str;
+    if (elem161 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem148);
+      oprot.writeString(elem161);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -588,9 +588,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_api = t_actual_base_dart.api_exception();
-            this.api = tmp_api;
-            tmp_api.read(iprot);
+            final elem162 = t_actual_base_dart.api_exception();
+            this.api = elem162;
+            elem162.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -626,17 +626,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem149 = opt_num;
+    final elem163 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem149);
+    oprot.writeI32(elem163);
     oprot.writeFieldEnd();
-    final elem150 = default_num;
+    final elem164 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem150);
+    oprot.writeI32(elem164);
     oprot.writeFieldEnd();
-    final elem151 = req_num;
+    final elem165 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem151);
+    oprot.writeI32(elem165);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -697,22 +697,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem152 = list_type;
-    if (elem152 != null) {
+    final elem166 = list_type;
+    if (elem166 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem152.length));
-      for(var elem153 in elem152) {
-        oprot.writeI64(elem153);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem166.length));
+      for(var elem167 in elem166) {
+        oprot.writeI64(elem167);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem154 = set_type;
-    if (elem154 != null) {
+    final elem168 = set_type;
+    if (elem168 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem154.length));
-      for(var elem155 in elem154) {
-        oprot.writeI64(elem155);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem168.length));
+      for(var elem169 in elem168) {
+        oprot.writeI64(elem169);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -738,14 +738,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem156 = iprot.readListBegin();
-            final elem159 = <int>[];
-            for(int elem158 = 0; elem158 < elem156.length; ++elem158) {
-              int elem157 = iprot.readI64();
-              elem159.add(elem157);
+            thrift.TList elem170 = iprot.readListBegin();
+            final elem173 = <int>[];
+            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
+              int elem171 = iprot.readI64();
+              elem173.add(elem171);
             }
             iprot.readListEnd();
-            this.success = elem159;
+            this.success = elem173;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -796,9 +796,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_success = t_validStructs.Thing();
-            this.success = tmp_success;
-            tmp_success.read(iprot);
+            final elem174 = t_validStructs.Thing();
+            this.success = elem174;
+            elem174.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -881,10 +881,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem160 = a;
-    if (elem160 != null) {
+    final elem175 = a;
+    if (elem175 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem160.write(oprot);
+      elem175.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -908,9 +908,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_success = t_subdir_include_ns.A();
-            this.success = tmp_success;
-            tmp_success.read(iprot);
+            final elem176 = t_subdir_include_ns.A();
+            this.success = elem176;
+            elem176.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -942,10 +942,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem161 = newMessage;
-    if (elem161 != null) {
+    final elem177 = newMessage;
+    if (elem177 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem161);
+      oprot.writeString(elem177);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1001,10 +1001,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem162 = messageArgs;
-    if (elem162 != null) {
+    final elem178 = messageArgs;
+    if (elem178 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem162);
+      oprot.writeString(elem178);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1060,10 +1060,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem163 = messageResult;
-    if (elem163 != null) {
+    final elem179 = messageResult;
+    if (elem179 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem163);
+      oprot.writeString(elem179);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_foo_service.dart
@@ -418,20 +418,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem151 = num;
+    final elem143 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem151);
+    oprot.writeI32(elem143);
     oprot.writeFieldEnd();
-    final elem152 = str;
-    if (elem152 != null) {
+    final elem144 = str;
+    if (elem144 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem152);
+      oprot.writeString(elem144);
       oprot.writeFieldEnd();
     }
-    final elem153 = event;
-    if (elem153 != null) {
+    final elem145 = event;
+    if (elem145 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem153.write(oprot);
+      elem145.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -464,18 +464,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem154 = t_variety.AwesomeException();
-            this.awe = elem154;
-            elem154.read(iprot);
+            final elem146 = t_variety.AwesomeException();
+            this.awe = elem146;
+            elem146.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            final elem155 = t_actual_base_dart.api_exception();
-            this.api = elem155;
-            elem155.read(iprot);
+            final elem147 = t_actual_base_dart.api_exception();
+            this.api = elem147;
+            elem147.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -509,18 +509,17 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem156 = id;
+    final elem148 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem156);
+    oprot.writeI64(elem148);
     oprot.writeFieldEnd();
-    final elem157 = req;
-    if (elem157 != null) {
+    final elem149 = req;
+    if (elem149 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem157.length));
-      for(var elem158 in elem157.keys) {
-        final elem159 = elem157[elem158]!;
-        oprot.writeI32(elem158);
-        oprot.writeString(elem159);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem149.length));
+      for(var entry in elem149.entries) {
+        oprot.writeI32(entry.key);
+        oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -547,16 +546,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem160 = bin;
-    if (elem160 != null) {
+    final elem150 = bin;
+    if (elem150 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem160);
+      oprot.writeBinary(elem150);
       oprot.writeFieldEnd();
     }
-    final elem161 = str;
-    if (elem161 != null) {
+    final elem151 = str;
+    if (elem151 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem161);
+      oprot.writeString(elem151);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -588,9 +587,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem162 = t_actual_base_dart.api_exception();
-            this.api = elem162;
-            elem162.read(iprot);
+            final elem152 = t_actual_base_dart.api_exception();
+            this.api = elem152;
+            elem152.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -626,17 +625,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem163 = opt_num;
+    final elem153 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem163);
+    oprot.writeI32(elem153);
     oprot.writeFieldEnd();
-    final elem164 = default_num;
+    final elem154 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem164);
+    oprot.writeI32(elem154);
     oprot.writeFieldEnd();
-    final elem165 = req_num;
+    final elem155 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem165);
+    oprot.writeI32(elem155);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -697,22 +696,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem166 = list_type;
-    if (elem166 != null) {
+    final elem156 = list_type;
+    if (elem156 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem166.length));
-      for(var elem167 in elem166) {
-        oprot.writeI64(elem167);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem156.length));
+      for(var elem157 in elem156) {
+        oprot.writeI64(elem157);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem168 = set_type;
-    if (elem168 != null) {
+    final elem158 = set_type;
+    if (elem158 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem168.length));
-      for(var elem169 in elem168) {
-        oprot.writeI64(elem169);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem158.length));
+      for(var elem159 in elem158) {
+        oprot.writeI64(elem159);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -738,14 +737,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem170 = iprot.readListBegin();
-            final elem173 = <int>[];
-            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
-              int elem171 = iprot.readI64();
-              elem173.add(elem171);
+            thrift.TList elem160 = iprot.readListBegin();
+            final elem163 = <int>[];
+            for(int elem162 = 0; elem162 < elem160.length; ++elem162) {
+              int elem161 = iprot.readI64();
+              elem163.add(elem161);
             }
             iprot.readListEnd();
-            this.success = elem173;
+            this.success = elem163;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -796,9 +795,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem174 = t_validStructs.Thing();
-            this.success = elem174;
-            elem174.read(iprot);
+            final elem164 = t_validStructs.Thing();
+            this.success = elem164;
+            elem164.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -881,10 +880,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem175 = a;
-    if (elem175 != null) {
+    final elem165 = a;
+    if (elem165 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem175.write(oprot);
+      elem165.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -908,9 +907,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem176 = t_subdir_include_ns.A();
-            this.success = elem176;
-            elem176.read(iprot);
+            final elem166 = t_subdir_include_ns.A();
+            this.success = elem166;
+            elem166.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -942,10 +941,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem177 = newMessage;
-    if (elem177 != null) {
+    final elem167 = newMessage;
+    if (elem167 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem177);
+      oprot.writeString(elem167);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1001,10 +1000,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem178 = messageArgs;
-    if (elem178 != null) {
+    final elem168 = messageArgs;
+    if (elem168 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem178);
+      oprot.writeString(elem168);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1060,10 +1059,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem179 = messageResult;
-    if (elem179 != null) {
+    final elem169 = messageResult;
+    if (elem169 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem179);
+      oprot.writeString(elem169);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_foo_service.dart
@@ -418,20 +418,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem136 = num;
+    final elem140 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem136);
+    oprot.writeI32(elem140);
     oprot.writeFieldEnd();
-    final elem137 = str;
-    if (elem137 != null) {
+    final elem141 = str;
+    if (elem141 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem137);
+      oprot.writeString(elem141);
       oprot.writeFieldEnd();
     }
-    final elem138 = event;
-    if (elem138 != null) {
+    final elem142 = event;
+    if (elem142 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem138.write(oprot);
+      elem142.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -509,18 +509,18 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem139 = id;
+    final elem143 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem139);
+    oprot.writeI64(elem143);
     oprot.writeFieldEnd();
-    final elem140 = req;
-    if (elem140 != null) {
+    final elem144 = req;
+    if (elem144 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem140.length));
-      for(var elem141 in elem140.keys) {
-        final val = elem140[elem141]!;
-        oprot.writeI32(elem141);
-        oprot.writeString(val);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem144.length));
+      for(var elem145 in elem144.keys) {
+        final elem146 = elem144[elem145]!;
+        oprot.writeI32(elem145);
+        oprot.writeString(elem146);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -547,16 +547,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem142 = bin;
-    if (elem142 != null) {
+    final elem147 = bin;
+    if (elem147 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem142);
+      oprot.writeBinary(elem147);
       oprot.writeFieldEnd();
     }
-    final elem143 = str;
-    if (elem143 != null) {
+    final elem148 = str;
+    if (elem148 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem143);
+      oprot.writeString(elem148);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -626,17 +626,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem144 = opt_num;
+    final elem149 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem144);
+    oprot.writeI32(elem149);
     oprot.writeFieldEnd();
-    final elem145 = default_num;
+    final elem150 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem145);
+    oprot.writeI32(elem150);
     oprot.writeFieldEnd();
-    final elem146 = req_num;
+    final elem151 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem146);
+    oprot.writeI32(elem151);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -697,22 +697,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem147 = list_type;
-    if (elem147 != null) {
+    final elem152 = list_type;
+    if (elem152 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem147.length));
-      for(var elem148 in elem147) {
-        oprot.writeI64(elem148);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem152.length));
+      for(var elem153 in elem152) {
+        oprot.writeI64(elem153);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem149 = set_type;
-    if (elem149 != null) {
+    final elem154 = set_type;
+    if (elem154 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem149.length));
-      for(var elem150 in elem149) {
-        oprot.writeI64(elem150);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem154.length));
+      for(var elem155 in elem154) {
+        oprot.writeI64(elem155);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -738,14 +738,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem151 = iprot.readListBegin();
-            final elem154 = <int>[];
-            for(int elem153 = 0; elem153 < elem151.length; ++elem153) {
-              int elem152 = iprot.readI64();
-              elem154.add(elem152);
+            thrift.TList elem156 = iprot.readListBegin();
+            final elem159 = <int>[];
+            for(int elem158 = 0; elem158 < elem156.length; ++elem158) {
+              int elem157 = iprot.readI64();
+              elem159.add(elem157);
             }
             iprot.readListEnd();
-            this.success = elem154;
+            this.success = elem159;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -881,10 +881,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem155 = a;
-    if (elem155 != null) {
+    final elem160 = a;
+    if (elem160 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem155.write(oprot);
+      elem160.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -942,10 +942,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem156 = newMessage;
-    if (elem156 != null) {
+    final elem161 = newMessage;
+    if (elem161 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem156);
+      oprot.writeString(elem161);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1001,10 +1001,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem157 = messageArgs;
-    if (elem157 != null) {
+    final elem162 = messageArgs;
+    if (elem162 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem157);
+      oprot.writeString(elem162);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1060,10 +1060,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem158 = messageResult;
-    if (elem158 != null) {
+    final elem163 = messageResult;
+    if (elem163 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem158);
+      oprot.writeString(elem163);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_foo_service.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
@@ -430,7 +428,7 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     }
     if (this.event != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      this.event?.write(oprot);
+      this.event.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -464,7 +462,7 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
         case 1:
           if (field.type == thrift.TType.STRUCT) {
             this.awe = t_variety.AwesomeException();
-            awe?.read(iprot);
+            awe.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -472,7 +470,7 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
         case 2:
           if (field.type == thrift.TType.STRUCT) {
             this.api = t_actual_base_dart.api_exception();
-            api?.read(iprot);
+            api.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -512,8 +510,8 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     if (this.req != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
       final temp = this.req!;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, temp!.length));
-      for(var elem83 in temp!.keys) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, temp.length));
+      for(var elem83 in temp.keys) {
         oprot.writeI32(elem83);
         oprot.writeString(temp[elem83]);
       }
@@ -582,7 +580,7 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
         case 1:
           if (field.type == thrift.TType.STRUCT) {
             this.api = t_actual_base_dart.api_exception();
-            api?.read(iprot);
+            api.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -689,8 +687,8 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     if (this.list_type != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
       final temp = this.list_type!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, temp!.length));
-      for(var elem84 in temp!) {
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, temp.length));
+      for(var elem84 in temp) {
         oprot.writeI64(elem84);
       }
       oprot.writeListEnd();
@@ -699,8 +697,8 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     if (this.set_type != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
       final temp = this.set_type!;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, temp!.length));
-      for(var elem85 in temp!) {
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, temp.length));
+      for(var elem85 in temp) {
         oprot.writeI64(elem85);
       }
       oprot.writeSetEnd();
@@ -786,7 +784,7 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
             this.success = t_validStructs.Thing();
-            success?.read(iprot);
+            success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -871,7 +869,7 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (this.a != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      this.a?.write(oprot);
+      this.a.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -896,7 +894,7 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
             this.success = t_subdir_include_ns.A();
-            success?.read(iprot);
+            success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_foo_service.dart
@@ -418,17 +418,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem136 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(this.num);
+    oprot.writeI32(elem136);
     oprot.writeFieldEnd();
-    if (this.str != null) {
+    final elem137 = str;
+    if (elem137 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(this.str);
+      oprot.writeString(elem137);
       oprot.writeFieldEnd();
     }
-    if (this.event != null) {
+    final elem138 = event;
+    if (elem138 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      this.event.write(oprot);
+      elem138.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -461,16 +464,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            this.awe = t_variety.AwesomeException();
-            awe.read(iprot);
+            final tmp_awe = t_variety.AwesomeException();
+            this.awe = tmp_awe;
+            tmp_awe.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            this.api = t_actual_base_dart.api_exception();
-            api.read(iprot);
+            final tmp_api = t_actual_base_dart.api_exception();
+            this.api = tmp_api;
+            tmp_api.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -504,16 +509,18 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem139 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(this.id);
+    oprot.writeI64(elem139);
     oprot.writeFieldEnd();
-    if (this.req != null) {
+    final elem140 = req;
+    if (elem140 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      final temp = this.req!;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, temp.length));
-      for(var elem83 in temp.keys) {
-        oprot.writeI32(elem83);
-        oprot.writeString(temp[elem83]);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem140.length));
+      for(var elem141 in elem140.keys) {
+        final val = elem140[elem141]!;
+        oprot.writeI32(elem141);
+        oprot.writeString(val);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -540,14 +547,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.bin != null) {
+    final elem142 = bin;
+    if (elem142 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(this.bin);
+      oprot.writeBinary(elem142);
       oprot.writeFieldEnd();
     }
-    if (this.str != null) {
+    final elem143 = str;
+    if (elem143 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(this.str);
+      oprot.writeString(elem143);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -579,8 +588,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            this.api = t_actual_base_dart.api_exception();
-            api.read(iprot);
+            final tmp_api = t_actual_base_dart.api_exception();
+            this.api = tmp_api;
+            tmp_api.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -616,14 +626,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem144 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(this.opt_num);
+    oprot.writeI32(elem144);
     oprot.writeFieldEnd();
+    final elem145 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(this.default_num);
+    oprot.writeI32(elem145);
     oprot.writeFieldEnd();
+    final elem146 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(this.req_num);
+    oprot.writeI32(elem146);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -684,22 +697,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.list_type != null) {
+    final elem147 = list_type;
+    if (elem147 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      final temp = this.list_type!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, temp.length));
-      for(var elem84 in temp) {
-        oprot.writeI64(elem84);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem147.length));
+      for(var elem148 in elem147) {
+        oprot.writeI64(elem148);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (this.set_type != null) {
+    final elem149 = set_type;
+    if (elem149 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      final temp = this.set_type!;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, temp.length));
-      for(var elem85 in temp) {
-        oprot.writeI64(elem85);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem149.length));
+      for(var elem150 in elem149) {
+        oprot.writeI64(elem150);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -725,14 +738,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem86 = iprot.readListBegin();
-            final elem89 = <int>[];
-            for(int elem88 = 0; elem88 < elem86.length; ++elem88) {
-              int elem87 = iprot.readI64();
-              elem89.add(elem87);
+            thrift.TList elem151 = iprot.readListBegin();
+            final elem154 = <int>[];
+            for(int elem153 = 0; elem153 < elem151.length; ++elem153) {
+              int elem152 = iprot.readI64();
+              elem154.add(elem152);
             }
             iprot.readListEnd();
-            this.success = elem89;
+            this.success = elem154;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -783,8 +796,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            this.success = t_validStructs.Thing();
-            success.read(iprot);
+            final tmp_success = t_validStructs.Thing();
+            this.success = tmp_success;
+            tmp_success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -867,9 +881,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.a != null) {
+    final elem155 = a;
+    if (elem155 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      this.a.write(oprot);
+      elem155.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -893,8 +908,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            this.success = t_subdir_include_ns.A();
-            success.read(iprot);
+            final tmp_success = t_subdir_include_ns.A();
+            this.success = tmp_success;
+            tmp_success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -926,9 +942,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.newMessage != null) {
+    final elem156 = newMessage;
+    if (elem156 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(this.newMessage);
+      oprot.writeString(elem156);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -984,9 +1001,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.messageArgs != null) {
+    final elem157 = messageArgs;
+    if (elem157 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(this.messageArgs);
+      oprot.writeString(elem157);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1042,9 +1060,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.messageResult != null) {
+    final elem158 = messageResult;
+    if (elem158 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(this.messageResult);
+      oprot.writeString(elem158);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_test_base.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';
@@ -75,7 +72,7 @@ class TestBase implements thrift.TBase {
         case BASE_STRUCT:
           if (field.type == thrift.TType.STRUCT) {
             this.base_struct = t_actual_base_dart.thing();
-            base_struct?.read(iprot);
+            base_struct.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -98,7 +95,7 @@ class TestBase implements thrift.TBase {
     oprot.writeStructBegin(_STRUCT_DESC);
     if (this.base_struct != null) {
       oprot.writeFieldBegin(_BASE_STRUCT_FIELD_DESC);
-      this.base_struct?.write(oprot);
+      this.base_struct.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_test_base.dart
@@ -71,8 +71,9 @@ class TestBase implements thrift.TBase {
       switch (field.id) {
         case BASE_STRUCT:
           if (field.type == thrift.TType.STRUCT) {
-            this.base_struct = t_actual_base_dart.thing();
-            base_struct.read(iprot);
+            final tmp_base_struct = t_actual_base_dart.thing();
+            this.base_struct = tmp_base_struct;
+            tmp_base_struct.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -93,9 +94,10 @@ class TestBase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.base_struct != null) {
+    final elem0 = base_struct;
+    if (elem0 != null) {
       oprot.writeFieldBegin(_BASE_STRUCT_FIELD_DESC);
-      this.base_struct.write(oprot);
+      elem0.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_test_base.dart
@@ -71,9 +71,9 @@ class TestBase implements thrift.TBase {
       switch (field.id) {
         case BASE_STRUCT:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_base_struct = t_actual_base_dart.thing();
-            this.base_struct = tmp_base_struct;
-            tmp_base_struct.read(iprot);
+            final elem0 = t_actual_base_dart.thing();
+            this.base_struct = elem0;
+            elem0.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -94,10 +94,10 @@ class TestBase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem0 = base_struct;
-    if (elem0 != null) {
+    final elem1 = base_struct;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_BASE_STRUCT_FIELD_DESC);
-      elem0.write(oprot);
+      elem1.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_test_lowercase.dart
@@ -103,8 +103,9 @@ class TestLowercase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem1 = lowercaseInt;
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
-    oprot.writeI32(this.lowercaseInt);
+    oprot.writeI32(elem1);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_test_lowercase.dart
@@ -103,9 +103,9 @@ class TestLowercase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem1 = lowercaseInt;
+    final elem2 = lowercaseInt;
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
-    oprot.writeI32(elem1);
+    oprot.writeI32(elem2);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_test_lowercase.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
@@ -525,18 +525,18 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_ev1 = t_variety.Event();
-            this.ev1 = tmp_ev1;
-            tmp_ev1.read(iprot);
+            final elem6 = t_variety.Event();
+            this.ev1 = elem6;
+            elem6.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_ev2 = t_variety.Event();
-            this.ev2 = tmp_ev2;
-            tmp_ev2.read(iprot);
+            final elem7 = t_variety.Event();
+            this.ev2 = elem7;
+            elem7.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -565,14 +565,14 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LISTFIELD:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem5 = iprot.readListBegin();
-            final elem8 = <int>[];
-            for(int elem7 = 0; elem7 < elem5.length; ++elem7) {
-              int elem6 = iprot.readI32();
-              elem8.add(elem6);
+            thrift.TList elem8 = iprot.readListBegin();
+            final elem11 = <int>[];
+            for(int elem10 = 0; elem10 < elem8.length; ++elem10) {
+              int elem9 = iprot.readI32();
+              elem11.add(elem9);
             }
             iprot.readListEnd();
-            this.listfield = elem8;
+            this.listfield = elem11;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -615,57 +615,57 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LIST2:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem9 = iprot.readListBegin();
-            final elem12 = <int>[];
-            for(int elem11 = 0; elem11 < elem9.length; ++elem11) {
-              int elem10 = iprot.readI32();
-              elem12.add(elem10);
+            thrift.TList elem12 = iprot.readListBegin();
+            final elem15 = <int>[];
+            for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
+              int elem13 = iprot.readI32();
+              elem15.add(elem13);
             }
             iprot.readListEnd();
-            this.list2 = elem12;
+            this.list2 = elem15;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST3:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem13 = iprot.readListBegin();
-            final elem16 = <int>[];
-            for(int elem15 = 0; elem15 < elem13.length; ++elem15) {
-              int elem14 = iprot.readI32();
-              elem16.add(elem14);
+            thrift.TList elem16 = iprot.readListBegin();
+            final elem19 = <int>[];
+            for(int elem18 = 0; elem18 < elem16.length; ++elem18) {
+              int elem17 = iprot.readI32();
+              elem19.add(elem17);
             }
             iprot.readListEnd();
-            this.list3 = elem16;
+            this.list3 = elem19;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST4:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem17 = iprot.readListBegin();
-            final elem20 = <int>[];
-            for(int elem19 = 0; elem19 < elem17.length; ++elem19) {
-              int elem18 = iprot.readI32();
-              elem20.add(elem18);
+            thrift.TList elem20 = iprot.readListBegin();
+            final elem23 = <int>[];
+            for(int elem22 = 0; elem22 < elem20.length; ++elem22) {
+              int elem21 = iprot.readI32();
+              elem23.add(elem21);
             }
             iprot.readListEnd();
-            this.list4 = elem20;
+            this.list4 = elem23;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case A_MAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem21 = iprot.readMapBegin();
-            final elem24 = <String, String>{};
-            for(int elem23 = 0; elem23 < elem21.length; ++elem23) {
+            thrift.TMap elem24 = iprot.readMapBegin();
+            final elem27 = <String, String>{};
+            for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
+              String elem28 = iprot.readString();
               String elem25 = iprot.readString();
-              String elem22 = iprot.readString();
-              elem24[elem25] = elem22;
+              elem27[elem28] = elem25;
             }
             iprot.readMapEnd();
-            this.a_map = elem24;
+            this.a_map = elem27;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -702,127 +702,127 @@ class TestingDefaults implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem26 = iD2;
+    final elem29 = iD2;
     if (isSetID2()) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
-      oprot.writeI64(elem26);
+      oprot.writeI64(elem29);
       oprot.writeFieldEnd();
     }
-    final elem27 = ev1;
-    if (elem27 != null) {
-      oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      elem27.write(oprot);
-      oprot.writeFieldEnd();
-    }
-    final elem28 = ev2;
-    if (elem28 != null) {
-      oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      elem28.write(oprot);
-      oprot.writeFieldEnd();
-    }
-    final elem29 = iD;
-    oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem29);
-    oprot.writeFieldEnd();
-    final elem30 = thing;
+    final elem30 = ev1;
     if (elem30 != null) {
+      oprot.writeFieldBegin(_EV1_FIELD_DESC);
+      elem30.write(oprot);
+      oprot.writeFieldEnd();
+    }
+    final elem31 = ev2;
+    if (elem31 != null) {
+      oprot.writeFieldBegin(_EV2_FIELD_DESC);
+      elem31.write(oprot);
+      oprot.writeFieldEnd();
+    }
+    final elem32 = iD;
+    oprot.writeFieldBegin(_ID_FIELD_DESC);
+    oprot.writeI64(elem32);
+    oprot.writeFieldEnd();
+    final elem33 = thing;
+    if (elem33 != null) {
       oprot.writeFieldBegin(_THING_FIELD_DESC);
-      oprot.writeString(elem30);
+      oprot.writeString(elem33);
       oprot.writeFieldEnd();
     }
-    final elem31 = thing2;
-    if (isSetThing2() && elem31 != null) {
+    final elem34 = thing2;
+    if (isSetThing2() && elem34 != null) {
       oprot.writeFieldBegin(_THING2_FIELD_DESC);
-      oprot.writeString(elem31);
+      oprot.writeString(elem34);
       oprot.writeFieldEnd();
     }
-    final elem32 = listfield;
-    if (elem32 != null) {
+    final elem35 = listfield;
+    if (elem35 != null) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem32.length));
-      for(var elem33 in elem32) {
-        oprot.writeI32(elem33);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem35.length));
+      for(var elem36 in elem35) {
+        oprot.writeI32(elem36);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem34 = iD3;
+    final elem37 = iD3;
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
-    oprot.writeI64(elem34);
+    oprot.writeI64(elem37);
     oprot.writeFieldEnd();
-    final elem35 = bin_field;
-    if (elem35 != null) {
+    final elem38 = bin_field;
+    if (elem38 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_FIELD_DESC);
-      oprot.writeBinary(elem35);
-      oprot.writeFieldEnd();
-    }
-    final elem36 = bin_field2;
-    if (isSetBin_field2() && elem36 != null) {
-      oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
-      oprot.writeBinary(elem36);
-      oprot.writeFieldEnd();
-    }
-    final elem37 = bin_field3;
-    if (elem37 != null) {
-      oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
-      oprot.writeBinary(elem37);
-      oprot.writeFieldEnd();
-    }
-    final elem38 = bin_field4;
-    if (isSetBin_field4() && elem38 != null) {
-      oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
       oprot.writeBinary(elem38);
       oprot.writeFieldEnd();
     }
-    final elem39 = list2;
-    if (isSetList2() && elem39 != null) {
+    final elem39 = bin_field2;
+    if (isSetBin_field2() && elem39 != null) {
+      oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
+      oprot.writeBinary(elem39);
+      oprot.writeFieldEnd();
+    }
+    final elem40 = bin_field3;
+    if (elem40 != null) {
+      oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
+      oprot.writeBinary(elem40);
+      oprot.writeFieldEnd();
+    }
+    final elem41 = bin_field4;
+    if (isSetBin_field4() && elem41 != null) {
+      oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
+      oprot.writeBinary(elem41);
+      oprot.writeFieldEnd();
+    }
+    final elem42 = list2;
+    if (isSetList2() && elem42 != null) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem39.length));
-      for(var elem40 in elem39) {
-        oprot.writeI32(elem40);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem42.length));
+      for(var elem43 in elem42) {
+        oprot.writeI32(elem43);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem41 = list3;
-    if (isSetList3() && elem41 != null) {
+    final elem44 = list3;
+    if (isSetList3() && elem44 != null) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem41.length));
-      for(var elem42 in elem41) {
-        oprot.writeI32(elem42);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem44.length));
+      for(var elem45 in elem44) {
+        oprot.writeI32(elem45);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem43 = list4;
-    if (elem43 != null) {
+    final elem46 = list4;
+    if (elem46 != null) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem43.length));
-      for(var elem44 in elem43) {
-        oprot.writeI32(elem44);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem46.length));
+      for(var elem47 in elem46) {
+        oprot.writeI32(elem47);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem45 = a_map;
-    if (isSetA_map() && elem45 != null) {
+    final elem48 = a_map;
+    if (isSetA_map() && elem48 != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem45.length));
-      for(var elem46 in elem45.keys) {
-        final elem47 = elem45[elem46]!;
-        oprot.writeString(elem46);
-        oprot.writeString(elem47);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem48.length));
+      for(var elem49 in elem48.keys) {
+        final elem50 = elem48[elem49]!;
+        oprot.writeString(elem49);
+        oprot.writeString(elem50);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem48 = status;
+    final elem51 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem48);
+    oprot.writeI32(elem51);
     oprot.writeFieldEnd();
-    final elem49 = base_status;
+    final elem52 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(elem49);
+    oprot.writeI32(elem52);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
@@ -525,16 +525,18 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
-            this.ev1 = t_variety.Event();
-            ev1.read(iprot);
+            final tmp_ev1 = t_variety.Event();
+            this.ev1 = tmp_ev1;
+            tmp_ev1.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
-            this.ev2 = t_variety.Event();
-            ev2.read(iprot);
+            final tmp_ev2 = t_variety.Event();
+            this.ev2 = tmp_ev2;
+            tmp_ev2.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -563,14 +565,14 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LISTFIELD:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem0 = iprot.readListBegin();
-            final elem3 = <int>[];
-            for(int elem2 = 0; elem2 < elem0.length; ++elem2) {
-              int elem1 = iprot.readI32();
-              elem3.add(elem1);
+            thrift.TList elem5 = iprot.readListBegin();
+            final elem8 = <int>[];
+            for(int elem7 = 0; elem7 < elem5.length; ++elem7) {
+              int elem6 = iprot.readI32();
+              elem8.add(elem6);
             }
             iprot.readListEnd();
-            this.listfield = elem3;
+            this.listfield = elem8;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -613,57 +615,57 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LIST2:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem4 = iprot.readListBegin();
-            final elem7 = <int>[];
-            for(int elem6 = 0; elem6 < elem4.length; ++elem6) {
-              int elem5 = iprot.readI32();
-              elem7.add(elem5);
+            thrift.TList elem9 = iprot.readListBegin();
+            final elem12 = <int>[];
+            for(int elem11 = 0; elem11 < elem9.length; ++elem11) {
+              int elem10 = iprot.readI32();
+              elem12.add(elem10);
             }
             iprot.readListEnd();
-            this.list2 = elem7;
+            this.list2 = elem12;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST3:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem8 = iprot.readListBegin();
-            final elem11 = <int>[];
-            for(int elem10 = 0; elem10 < elem8.length; ++elem10) {
-              int elem9 = iprot.readI32();
-              elem11.add(elem9);
+            thrift.TList elem13 = iprot.readListBegin();
+            final elem16 = <int>[];
+            for(int elem15 = 0; elem15 < elem13.length; ++elem15) {
+              int elem14 = iprot.readI32();
+              elem16.add(elem14);
             }
             iprot.readListEnd();
-            this.list3 = elem11;
+            this.list3 = elem16;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST4:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem12 = iprot.readListBegin();
-            final elem15 = <int>[];
-            for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
-              int elem13 = iprot.readI32();
-              elem15.add(elem13);
+            thrift.TList elem17 = iprot.readListBegin();
+            final elem20 = <int>[];
+            for(int elem19 = 0; elem19 < elem17.length; ++elem19) {
+              int elem18 = iprot.readI32();
+              elem20.add(elem18);
             }
             iprot.readListEnd();
-            this.list4 = elem15;
+            this.list4 = elem20;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case A_MAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem16 = iprot.readMapBegin();
-            final elem19 = <String, String>{};
-            for(int elem18 = 0; elem18 < elem16.length; ++elem18) {
-              String elem20 = iprot.readString();
-              String elem17 = iprot.readString();
-              elem19[elem20] = elem17;
+            thrift.TMap elem21 = iprot.readMapBegin();
+            final elem24 = <String, String>{};
+            for(int elem23 = 0; elem23 < elem21.length; ++elem23) {
+              String elem25 = iprot.readString();
+              String elem22 = iprot.readString();
+              elem24[elem25] = elem22;
             }
             iprot.readMapEnd();
-            this.a_map = elem19;
+            this.a_map = elem24;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -700,113 +702,127 @@ class TestingDefaults implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem26 = iD2;
     if (isSetID2()) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
-      oprot.writeI64(this.iD2);
+      oprot.writeI64(elem26);
       oprot.writeFieldEnd();
     }
-    if (this.ev1 != null) {
+    final elem27 = ev1;
+    if (elem27 != null) {
       oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      this.ev1.write(oprot);
+      elem27.write(oprot);
       oprot.writeFieldEnd();
     }
-    if (this.ev2 != null) {
+    final elem28 = ev2;
+    if (elem28 != null) {
       oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      this.ev2.write(oprot);
+      elem28.write(oprot);
       oprot.writeFieldEnd();
     }
+    final elem29 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(this.iD);
+    oprot.writeI64(elem29);
     oprot.writeFieldEnd();
-    if (this.thing != null) {
+    final elem30 = thing;
+    if (elem30 != null) {
       oprot.writeFieldBegin(_THING_FIELD_DESC);
-      oprot.writeString(this.thing);
+      oprot.writeString(elem30);
       oprot.writeFieldEnd();
     }
-    if (isSetThing2() && this.thing2 != null) {
+    final elem31 = thing2;
+    if (isSetThing2() && elem31 != null) {
       oprot.writeFieldBegin(_THING2_FIELD_DESC);
-      oprot.writeString(this.thing2);
+      oprot.writeString(elem31);
       oprot.writeFieldEnd();
     }
-    if (this.listfield != null) {
+    final elem32 = listfield;
+    if (elem32 != null) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
-      final temp = this.listfield!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem21 in temp) {
-        oprot.writeI32(elem21);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem32.length));
+      for(var elem33 in elem32) {
+        oprot.writeI32(elem33);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem34 = iD3;
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
-    oprot.writeI64(this.iD3);
+    oprot.writeI64(elem34);
     oprot.writeFieldEnd();
-    if (this.bin_field != null) {
+    final elem35 = bin_field;
+    if (elem35 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_FIELD_DESC);
-      oprot.writeBinary(this.bin_field);
+      oprot.writeBinary(elem35);
       oprot.writeFieldEnd();
     }
-    if (isSetBin_field2() && this.bin_field2 != null) {
+    final elem36 = bin_field2;
+    if (isSetBin_field2() && elem36 != null) {
       oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
-      oprot.writeBinary(this.bin_field2);
+      oprot.writeBinary(elem36);
       oprot.writeFieldEnd();
     }
-    if (this.bin_field3 != null) {
+    final elem37 = bin_field3;
+    if (elem37 != null) {
       oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
-      oprot.writeBinary(this.bin_field3);
+      oprot.writeBinary(elem37);
       oprot.writeFieldEnd();
     }
-    if (isSetBin_field4() && this.bin_field4 != null) {
+    final elem38 = bin_field4;
+    if (isSetBin_field4() && elem38 != null) {
       oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
-      oprot.writeBinary(this.bin_field4);
+      oprot.writeBinary(elem38);
       oprot.writeFieldEnd();
     }
-    if (isSetList2() && this.list2 != null) {
+    final elem39 = list2;
+    if (isSetList2() && elem39 != null) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
-      final temp = this.list2!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem22 in temp) {
-        oprot.writeI32(elem22);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem39.length));
+      for(var elem40 in elem39) {
+        oprot.writeI32(elem40);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetList3() && this.list3 != null) {
+    final elem41 = list3;
+    if (isSetList3() && elem41 != null) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
-      final temp = this.list3!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem23 in temp) {
-        oprot.writeI32(elem23);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem41.length));
+      for(var elem42 in elem41) {
+        oprot.writeI32(elem42);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (this.list4 != null) {
+    final elem43 = list4;
+    if (elem43 != null) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
-      final temp = this.list4!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem24 in temp) {
-        oprot.writeI32(elem24);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem43.length));
+      for(var elem44 in elem43) {
+        oprot.writeI32(elem44);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetA_map() && this.a_map != null) {
+    final elem45 = a_map;
+    if (isSetA_map() && elem45 != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
-      final temp = this.a_map!;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, temp.length));
-      for(var elem25 in temp.keys) {
-        oprot.writeString(elem25);
-        oprot.writeString(temp[elem25]);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem45.length));
+      for(var elem46 in elem45.keys) {
+        final val = elem45[elem46]!;
+        oprot.writeString(elem46);
+        oprot.writeString(val);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
+    final elem47 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(this.status);
+    oprot.writeI32(elem47);
     oprot.writeFieldEnd();
+    final elem48 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(this.base_status);
+    oprot.writeI32(elem48);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
@@ -809,20 +809,20 @@ class TestingDefaults implements thrift.TBase {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
       oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem45.length));
       for(var elem46 in elem45.keys) {
-        final val = elem45[elem46]!;
+        final elem47 = elem45[elem46]!;
         oprot.writeString(elem46);
-        oprot.writeString(val);
+        oprot.writeString(elem47);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem47 = status;
+    final elem48 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem47);
-    oprot.writeFieldEnd();
-    final elem48 = base_status;
-    oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
     oprot.writeI32(elem48);
+    oprot.writeFieldEnd();
+    final elem49 = base_status;
+    oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
+    oprot.writeI32(elem49);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
@@ -808,21 +808,20 @@ class TestingDefaults implements thrift.TBase {
     if (isSetA_map() && elem48 != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
       oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem48.length));
-      for(var elem49 in elem48.keys) {
-        final elem50 = elem48[elem49]!;
-        oprot.writeString(elem49);
-        oprot.writeString(elem50);
+      for(var entry in elem48.entries) {
+        oprot.writeString(entry.key);
+        oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem51 = status;
+    final elem49 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem51);
+    oprot.writeI32(elem49);
     oprot.writeFieldEnd();
-    final elem52 = base_status;
+    final elem50 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(elem52);
+    oprot.writeI32(elem50);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';
@@ -529,7 +526,7 @@ class TestingDefaults implements thrift.TBase {
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
             this.ev1 = t_variety.Event();
-            ev1?.read(iprot);
+            ev1.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -537,7 +534,7 @@ class TestingDefaults implements thrift.TBase {
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
             this.ev2 = t_variety.Event();
-            ev2?.read(iprot);
+            ev2.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -710,12 +707,12 @@ class TestingDefaults implements thrift.TBase {
     }
     if (this.ev1 != null) {
       oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      this.ev1?.write(oprot);
+      this.ev1.write(oprot);
       oprot.writeFieldEnd();
     }
     if (this.ev2 != null) {
       oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      this.ev2?.write(oprot);
+      this.ev2.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldBegin(_ID_FIELD_DESC);
@@ -734,8 +731,8 @@ class TestingDefaults implements thrift.TBase {
     if (this.listfield != null) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
       final temp = this.listfield!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp!.length));
-      for(var elem21 in temp!) {
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
+      for(var elem21 in temp) {
         oprot.writeI32(elem21);
       }
       oprot.writeListEnd();
@@ -767,8 +764,8 @@ class TestingDefaults implements thrift.TBase {
     if (isSetList2() && this.list2 != null) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
       final temp = this.list2!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp!.length));
-      for(var elem22 in temp!) {
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
+      for(var elem22 in temp) {
         oprot.writeI32(elem22);
       }
       oprot.writeListEnd();
@@ -777,8 +774,8 @@ class TestingDefaults implements thrift.TBase {
     if (isSetList3() && this.list3 != null) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
       final temp = this.list3!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp!.length));
-      for(var elem23 in temp!) {
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
+      for(var elem23 in temp) {
         oprot.writeI32(elem23);
       }
       oprot.writeListEnd();
@@ -787,8 +784,8 @@ class TestingDefaults implements thrift.TBase {
     if (this.list4 != null) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
       final temp = this.list4!;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp!.length));
-      for(var elem24 in temp!) {
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
+      for(var elem24 in temp) {
         oprot.writeI32(elem24);
       }
       oprot.writeListEnd();
@@ -797,8 +794,8 @@ class TestingDefaults implements thrift.TBase {
     if (isSetA_map() && this.a_map != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
       final temp = this.a_map!;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, temp!.length));
-      for(var elem25 in temp!.keys) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, temp.length));
+      for(var elem25 in temp.keys) {
         oprot.writeString(elem25);
         oprot.writeString(temp[elem25]);
       }

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
@@ -300,15 +300,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem119 = iprot.readMapBegin();
-            final elem122 = <int, String>{};
-            for(int elem121 = 0; elem121 < elem119.length; ++elem121) {
-              int elem123 = iprot.readI32();
-              String elem120 = iprot.readString();
-              elem122[elem123] = elem120;
+            thrift.TMap elem122 = iprot.readMapBegin();
+            final elem125 = <int, String>{};
+            for(int elem124 = 0; elem124 < elem122.length; ++elem124) {
+              int elem126 = iprot.readI32();
+              String elem123 = iprot.readString();
+              elem125[elem126] = elem123;
             }
             iprot.readMapEnd();
-            this.requests = elem122;
+            this.requests = elem125;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -353,59 +353,59 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem124 = anID;
+    final elem127 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(elem124);
+      oprot.writeI64(elem127);
       oprot.writeFieldEnd();
     }
-    final elem125 = aString;
-    if (isSetAString() && elem125 != null) {
+    final elem128 = aString;
+    if (isSetAString() && elem128 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem125);
+      oprot.writeString(elem128);
       oprot.writeFieldEnd();
     }
-    final elem126 = someotherthing;
+    final elem129 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem126);
+      oprot.writeI32(elem129);
       oprot.writeFieldEnd();
     }
-    final elem127 = anInt16;
+    final elem130 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem127);
+      oprot.writeI16(elem130);
       oprot.writeFieldEnd();
     }
-    final elem128 = requests;
-    if (isSetRequests() && elem128 != null) {
+    final elem131 = requests;
+    if (isSetRequests() && elem131 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem128.length));
-      for(var elem129 in elem128.keys) {
-        final val = elem128[elem129]!;
-        oprot.writeI32(elem129);
-        oprot.writeString(val);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem131.length));
+      for(var elem132 in elem131.keys) {
+        final elem133 = elem131[elem132]!;
+        oprot.writeI32(elem132);
+        oprot.writeString(elem133);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem130 = bin_field_in_union;
-    if (isSetBin_field_in_union() && elem130 != null) {
+    final elem134 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem134 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem130);
+      oprot.writeBinary(elem134);
       oprot.writeFieldEnd();
     }
-    final elem131 = depr;
+    final elem135 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem131);
+      oprot.writeBool(elem135);
       oprot.writeFieldEnd();
     }
-    final elem132 = wHOA_BUDDY;
+    final elem136 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem132);
+      oprot.writeBool(elem136);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
@@ -300,15 +300,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem122 = iprot.readMapBegin();
-            final elem125 = <int, String>{};
-            for(int elem124 = 0; elem124 < elem122.length; ++elem124) {
-              int elem126 = iprot.readI32();
-              String elem123 = iprot.readString();
-              elem125[elem126] = elem123;
+            thrift.TMap elem133 = iprot.readMapBegin();
+            final elem136 = <int, String>{};
+            for(int elem135 = 0; elem135 < elem133.length; ++elem135) {
+              int elem137 = iprot.readI32();
+              String elem134 = iprot.readString();
+              elem136[elem137] = elem134;
             }
             iprot.readMapEnd();
-            this.requests = elem125;
+            this.requests = elem136;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -353,59 +353,59 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem127 = anID;
+    final elem138 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(elem127);
+      oprot.writeI64(elem138);
       oprot.writeFieldEnd();
     }
-    final elem128 = aString;
-    if (isSetAString() && elem128 != null) {
+    final elem139 = aString;
+    if (isSetAString() && elem139 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem128);
+      oprot.writeString(elem139);
       oprot.writeFieldEnd();
     }
-    final elem129 = someotherthing;
+    final elem140 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem129);
+      oprot.writeI32(elem140);
       oprot.writeFieldEnd();
     }
-    final elem130 = anInt16;
+    final elem141 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem130);
+      oprot.writeI16(elem141);
       oprot.writeFieldEnd();
     }
-    final elem131 = requests;
-    if (isSetRequests() && elem131 != null) {
+    final elem142 = requests;
+    if (isSetRequests() && elem142 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem131.length));
-      for(var elem132 in elem131.keys) {
-        final elem133 = elem131[elem132]!;
-        oprot.writeI32(elem132);
-        oprot.writeString(elem133);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem142.length));
+      for(var elem143 in elem142.keys) {
+        final elem144 = elem142[elem143]!;
+        oprot.writeI32(elem143);
+        oprot.writeString(elem144);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem134 = bin_field_in_union;
-    if (isSetBin_field_in_union() && elem134 != null) {
+    final elem145 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem145 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem134);
+      oprot.writeBinary(elem145);
       oprot.writeFieldEnd();
     }
-    final elem135 = depr;
+    final elem146 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem135);
+      oprot.writeBool(elem146);
       oprot.writeFieldEnd();
     }
-    final elem136 = wHOA_BUDDY;
+    final elem147 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem136);
+      oprot.writeBool(elem147);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
@@ -300,15 +300,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem77 = iprot.readMapBegin();
-            final elem80 = <int, String>{};
-            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
-              int elem81 = iprot.readI32();
-              String elem78 = iprot.readString();
-              elem80[elem81] = elem78;
+            thrift.TMap elem119 = iprot.readMapBegin();
+            final elem122 = <int, String>{};
+            for(int elem121 = 0; elem121 < elem119.length; ++elem121) {
+              int elem123 = iprot.readI32();
+              String elem120 = iprot.readString();
+              elem122[elem123] = elem120;
             }
             iprot.readMapEnd();
-            this.requests = elem80;
+            this.requests = elem122;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -353,52 +353,59 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem124 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(this.anID);
+      oprot.writeI64(elem124);
       oprot.writeFieldEnd();
     }
-    if (isSetAString() && this.aString != null) {
+    final elem125 = aString;
+    if (isSetAString() && elem125 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(this.aString);
+      oprot.writeString(elem125);
       oprot.writeFieldEnd();
     }
+    final elem126 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(this.someotherthing);
+      oprot.writeI32(elem126);
       oprot.writeFieldEnd();
     }
+    final elem127 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(this.anInt16);
+      oprot.writeI16(elem127);
       oprot.writeFieldEnd();
     }
-    if (isSetRequests() && this.requests != null) {
+    final elem128 = requests;
+    if (isSetRequests() && elem128 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      final temp = this.requests!;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, temp.length));
-      for(var elem82 in temp.keys) {
-        oprot.writeI32(elem82);
-        oprot.writeString(temp[elem82]);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem128.length));
+      for(var elem129 in elem128.keys) {
+        final val = elem128[elem129]!;
+        oprot.writeI32(elem129);
+        oprot.writeString(val);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetBin_field_in_union() && this.bin_field_in_union != null) {
+    final elem130 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem130 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(this.bin_field_in_union);
+      oprot.writeBinary(elem130);
       oprot.writeFieldEnd();
     }
+    final elem131 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      // ignore: deprecated_member_use
-      oprot.writeBool(this.depr);
+      oprot.writeBool(elem131);
       oprot.writeFieldEnd();
     }
+    final elem132 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(this.wHOA_BUDDY);
+      oprot.writeBool(elem132);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';
@@ -379,8 +376,8 @@ class TestingUnions implements thrift.TBase {
     if (isSetRequests() && this.requests != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
       final temp = this.requests!;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, temp!.length));
-      for(var elem82 in temp!.keys) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, temp.length));
+      for(var elem82 in temp.keys) {
         oprot.writeI32(elem82);
         oprot.writeString(temp[elem82]);
       }

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
@@ -300,15 +300,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem133 = iprot.readMapBegin();
-            final elem136 = <int, String>{};
-            for(int elem135 = 0; elem135 < elem133.length; ++elem135) {
-              int elem137 = iprot.readI32();
-              String elem134 = iprot.readString();
-              elem136[elem137] = elem134;
+            thrift.TMap elem127 = iprot.readMapBegin();
+            final elem130 = <int, String>{};
+            for(int elem129 = 0; elem129 < elem127.length; ++elem129) {
+              int elem131 = iprot.readI32();
+              String elem128 = iprot.readString();
+              elem130[elem131] = elem128;
             }
             iprot.readMapEnd();
-            this.requests = elem136;
+            this.requests = elem130;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -353,59 +353,58 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem138 = anID;
+    final elem132 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(elem138);
+      oprot.writeI64(elem132);
       oprot.writeFieldEnd();
     }
-    final elem139 = aString;
-    if (isSetAString() && elem139 != null) {
+    final elem133 = aString;
+    if (isSetAString() && elem133 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem139);
+      oprot.writeString(elem133);
       oprot.writeFieldEnd();
     }
-    final elem140 = someotherthing;
+    final elem134 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem140);
+      oprot.writeI32(elem134);
       oprot.writeFieldEnd();
     }
-    final elem141 = anInt16;
+    final elem135 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem141);
+      oprot.writeI16(elem135);
       oprot.writeFieldEnd();
     }
-    final elem142 = requests;
-    if (isSetRequests() && elem142 != null) {
+    final elem136 = requests;
+    if (isSetRequests() && elem136 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem142.length));
-      for(var elem143 in elem142.keys) {
-        final elem144 = elem142[elem143]!;
-        oprot.writeI32(elem143);
-        oprot.writeString(elem144);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem136.length));
+      for(var entry in elem136.entries) {
+        oprot.writeI32(entry.key);
+        oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem145 = bin_field_in_union;
-    if (isSetBin_field_in_union() && elem145 != null) {
+    final elem137 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem137 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem145);
+      oprot.writeBinary(elem137);
       oprot.writeFieldEnd();
     }
-    final elem146 = depr;
+    final elem138 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem146);
+      oprot.writeBool(elem138);
       oprot.writeFieldEnd();
     }
-    final elem147 = wHOA_BUDDY;
+    final elem139 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem147);
+      oprot.writeBool(elem139);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_variety_constants.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_variety_constants.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:convert' show utf8;
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_actual_base_dart_constants.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_actual_base_dart_constants.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:convert' show utf8;
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_api_exception.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_api_exception.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_base_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_base_foo_service.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
@@ -61,16 +61,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem170 = iprot.readListBegin();
-            final elem173 = <t_actual_base_dart.thing>[];
-            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
-              final tmp_elem171 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem171 = tmp_elem171;
-              tmp_elem171.read(iprot);
-              elem173.add(elem171);
+            thrift.TList elem176 = iprot.readListBegin();
+            final elem179 = <t_actual_base_dart.thing>[];
+            for(int elem178 = 0; elem178 < elem176.length; ++elem178) {
+              final tmp_elem177 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem177 = tmp_elem177;
+              tmp_elem177.read(iprot);
+              elem179.add(elem177);
             }
             iprot.readListEnd();
-            this.things = elem173;
+            this.things = elem179;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -91,12 +91,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem174 = things;
+    final elem180 = things;
     if (isSetThings()) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem174.length));
-      for(var elem175 in elem174) {
-        elem175.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem180.length));
+      for(var elem181 in elem180) {
+        elem181.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
@@ -61,16 +61,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem176 = iprot.readListBegin();
-            final elem179 = <t_actual_base_dart.thing>[];
-            for(int elem178 = 0; elem178 < elem176.length; ++elem178) {
-              final tmp_elem177 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem177 = tmp_elem177;
-              tmp_elem177.read(iprot);
-              elem179.add(elem177);
+            thrift.TList elem194 = iprot.readListBegin();
+            final elem198 = <t_actual_base_dart.thing>[];
+            for(int elem197 = 0; elem197 < elem194.length; ++elem197) {
+              final elem196 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem195 = elem196;
+              elem196.read(iprot);
+              elem198.add(elem195);
             }
             iprot.readListEnd();
-            this.things = elem179;
+            this.things = elem198;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -91,12 +91,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem180 = things;
+    final elem199 = things;
     if (isSetThings()) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem180.length));
-      for(var elem181 in elem180) {
-        elem181.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem199.length));
+      for(var elem200 in elem199) {
+        elem200.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
@@ -61,15 +61,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem99 = iprot.readListBegin();
-            final elem102 = <t_actual_base_dart.thing>[];
-            for(int elem101 = 0; elem101 < elem99.length; ++elem101) {
-              t_actual_base_dart.thing elem100 = t_actual_base_dart.thing();
-              elem100.read(iprot);
-              elem102.add(elem100);
+            thrift.TList elem170 = iprot.readListBegin();
+            final elem173 = <t_actual_base_dart.thing>[];
+            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
+              final tmp_elem171 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem171 = tmp_elem171;
+              tmp_elem171.read(iprot);
+              elem173.add(elem171);
             }
             iprot.readListEnd();
-            this.things = elem102;
+            this.things = elem173;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -90,12 +91,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem174 = things;
     if (isSetThings()) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      final temp = this.things;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
-      for(var elem103 in temp) {
-        elem103.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem174.length));
+      for(var elem175 in elem174) {
+        elem175.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
@@ -61,16 +61,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem194 = iprot.readListBegin();
-            final elem198 = <t_actual_base_dart.thing>[];
-            for(int elem197 = 0; elem197 < elem194.length; ++elem197) {
-              final elem196 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem195 = elem196;
-              elem196.read(iprot);
-              elem198.add(elem195);
+            thrift.TList elem182 = iprot.readListBegin();
+            final elem186 = <t_actual_base_dart.thing>[];
+            for(int elem185 = 0; elem185 < elem182.length; ++elem185) {
+              final elem184 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem183 = elem184;
+              elem184.read(iprot);
+              elem186.add(elem183);
             }
             iprot.readListEnd();
-            this.things = elem198;
+            this.things = elem186;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -91,12 +91,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem199 = things;
+    final elem187 = things;
     if (isSetThings()) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem199.length));
-      for(var elem200 in elem199) {
-        elem200.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem187.length));
+      for(var elem188 in elem187) {
+        elem188.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
@@ -103,12 +103,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem168 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(this.an_id);
+    oprot.writeI32(elem168);
     oprot.writeFieldEnd();
+    final elem169 = a_string;
     if (isSetA_string()) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(this.a_string);
+      oprot.writeString(elem169);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
@@ -103,14 +103,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem168 = an_id;
+    final elem174 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem168);
+    oprot.writeI32(elem174);
     oprot.writeFieldEnd();
-    final elem169 = a_string;
+    final elem175 = a_string;
     if (isSetA_string()) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem169);
+      oprot.writeString(elem175);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
@@ -103,14 +103,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem192 = an_id;
+    final elem180 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem192);
+    oprot.writeI32(elem180);
     oprot.writeFieldEnd();
-    final elem193 = a_string;
+    final elem181 = a_string;
     if (isSetA_string()) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem193);
+      oprot.writeString(elem181);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
@@ -103,14 +103,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem174 = an_id;
+    final elem192 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem174);
+    oprot.writeI32(elem192);
     oprot.writeFieldEnd();
-    final elem175 = a_string;
+    final elem193 = a_string;
     if (isSetA_string()) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem175);
+      oprot.writeString(elem193);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
@@ -138,19 +138,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem148 = iD;
+    final elem140 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem148);
+    oprot.writeI64(elem140);
     oprot.writeFieldEnd();
-    final elem149 = reason;
+    final elem141 = reason;
     if (isSetReason()) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem149);
+      oprot.writeString(elem141);
       oprot.writeFieldEnd();
     }
-    final elem150 = depr;
+    final elem142 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem150);
+    oprot.writeBool(elem142);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
@@ -138,19 +138,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem133 = iD;
+    final elem137 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem133);
+    oprot.writeI64(elem137);
     oprot.writeFieldEnd();
-    final elem134 = reason;
+    final elem138 = reason;
     if (isSetReason()) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem134);
+      oprot.writeString(elem138);
       oprot.writeFieldEnd();
     }
-    final elem135 = depr;
+    final elem139 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem135);
+    oprot.writeBool(elem139);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
@@ -138,19 +138,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem137 = iD;
+    final elem148 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem137);
+    oprot.writeI64(elem148);
     oprot.writeFieldEnd();
-    final elem138 = reason;
+    final elem149 = reason;
     if (isSetReason()) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem138);
+      oprot.writeString(elem149);
       oprot.writeFieldEnd();
     }
-    final elem139 = depr;
+    final elem150 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem139);
+    oprot.writeBool(elem150);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
@@ -138,17 +138,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem133 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(this.iD);
+    oprot.writeI64(elem133);
     oprot.writeFieldEnd();
+    final elem134 = reason;
     if (isSetReason()) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(this.reason);
+      oprot.writeString(elem134);
       oprot.writeFieldEnd();
     }
+    final elem135 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    // ignore: deprecated_member_use
-    oprot.writeBool(this.depr);
+    oprot.writeBool(elem135);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_event.dart
@@ -142,16 +142,19 @@ class Event implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem2 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(this.iD);
+    oprot.writeI64(elem2);
     oprot.writeFieldEnd();
+    final elem3 = message;
     if (isSetMessage()) {
       oprot.writeFieldBegin(_MESSAGE_FIELD_DESC);
-      oprot.writeString(this.message);
+      oprot.writeString(elem3);
       oprot.writeFieldEnd();
     }
+    final elem4 = yES_NO;
     oprot.writeFieldBegin(_YE_S__NO_FIELD_DESC);
-    oprot.writeBool(this.yES_NO);
+    oprot.writeBool(elem4);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_event.dart
@@ -142,19 +142,19 @@ class Event implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem2 = iD;
+    final elem3 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem2);
+    oprot.writeI64(elem3);
     oprot.writeFieldEnd();
-    final elem3 = message;
+    final elem4 = message;
     if (isSetMessage()) {
       oprot.writeFieldBegin(_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem3);
+      oprot.writeString(elem4);
       oprot.writeFieldEnd();
     }
-    final elem4 = yES_NO;
+    final elem5 = yES_NO;
     oprot.writeFieldBegin(_YE_S__NO_FIELD_DESC);
-    oprot.writeBool(elem4);
+    oprot.writeBool(elem5);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_event.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
@@ -317,92 +317,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_ev = t_variety.Event();
-            this.ev = tmp_ev;
-            tmp_ev.read(iprot);
+            final elem53 = t_variety.Event();
+            this.ev = elem53;
+            elem53.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem50 = iprot.readListBegin();
-            final elem53 = <t_variety.Event>[];
-            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
-              final tmp_elem51 = t_variety.Event();
-              t_variety.Event elem51 = tmp_elem51;
-              tmp_elem51.read(iprot);
-              elem53.add(elem51);
+            thrift.TList elem54 = iprot.readListBegin();
+            final elem58 = <t_variety.Event>[];
+            for(int elem57 = 0; elem57 < elem54.length; ++elem57) {
+              final elem56 = t_variety.Event();
+              t_variety.Event elem55 = elem56;
+              elem56.read(iprot);
+              elem58.add(elem55);
             }
             iprot.readListEnd();
-            this.events = elem53;
+            this.events = elem58;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem54 = iprot.readSetBegin();
-            final elem57 = <t_variety.Event>{};
-            for(int elem56 = 0; elem56 < elem54.length; ++elem56) {
-              final tmp_elem55 = t_variety.Event();
-              t_variety.Event elem55 = tmp_elem55;
-              tmp_elem55.read(iprot);
-              elem57.add(elem55);
+            thrift.TSet elem59 = iprot.readSetBegin();
+            final elem63 = <t_variety.Event>{};
+            for(int elem62 = 0; elem62 < elem59.length; ++elem62) {
+              final elem61 = t_variety.Event();
+              t_variety.Event elem60 = elem61;
+              elem61.read(iprot);
+              elem63.add(elem60);
             }
             iprot.readSetEnd();
-            this.events2 = elem57;
+            this.events2 = elem63;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem58 = iprot.readMapBegin();
-            final elem61 = <int, t_variety.Event>{};
-            for(int elem60 = 0; elem60 < elem58.length; ++elem60) {
-              int elem62 = iprot.readI64();
-              final tmp_elem59 = t_variety.Event();
-              t_variety.Event elem59 = tmp_elem59;
-              tmp_elem59.read(iprot);
-              elem61[elem62] = elem59;
+            thrift.TMap elem64 = iprot.readMapBegin();
+            final elem68 = <int, t_variety.Event>{};
+            for(int elem67 = 0; elem67 < elem64.length; ++elem67) {
+              int elem69 = iprot.readI64();
+              final elem66 = t_variety.Event();
+              t_variety.Event elem65 = elem66;
+              elem66.read(iprot);
+              elem68[elem69] = elem65;
             }
             iprot.readMapEnd();
-            this.eventMap = elem61;
+            this.eventMap = elem68;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem63 = iprot.readListBegin();
-            final elem69 = <List<int>>[];
-            for(int elem68 = 0; elem68 < elem63.length; ++elem68) {
-              thrift.TList elem65 = iprot.readListBegin();
-              final elem64 = <int>[];
-              for(int elem67 = 0; elem67 < elem65.length; ++elem67) {
-                int elem66 = iprot.readI32();
-                elem64.add(elem66);
+            thrift.TList elem70 = iprot.readListBegin();
+            final elem76 = <List<int>>[];
+            for(int elem75 = 0; elem75 < elem70.length; ++elem75) {
+              thrift.TList elem72 = iprot.readListBegin();
+              final elem71 = <int>[];
+              for(int elem74 = 0; elem74 < elem72.length; ++elem74) {
+                int elem73 = iprot.readI32();
+                elem71.add(elem73);
               }
               iprot.readListEnd();
-              elem69.add(elem64);
+              elem76.add(elem71);
             }
             iprot.readListEnd();
-            this.nums = elem69;
+            this.nums = elem76;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem70 = iprot.readListBegin();
-            final elem73 = <int>[];
-            for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
-              int elem71 = iprot.readI32();
-              elem73.add(elem71);
+            thrift.TList elem77 = iprot.readListBegin();
+            final elem80 = <int>[];
+            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
+              int elem78 = iprot.readI32();
+              elem80.add(elem78);
             }
             iprot.readListEnd();
-            this.enums = elem73;
+            this.enums = elem80;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -416,9 +416,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_a_union = t_variety.TestingUnions();
-            this.a_union = tmp_a_union;
-            tmp_a_union.read(iprot);
+            final elem81 = t_variety.TestingUnions();
+            this.a_union = elem81;
+            elem81.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -448,65 +448,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem74 = iprot.readListBegin();
+            thrift.TList elem82 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem77 = <bool>[];
-            for(int elem76 = 0; elem76 < elem74.length; ++elem76) {
-              bool elem75 = iprot.readBool();
+            final elem85 = <bool>[];
+            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
+              bool elem83 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem77.add(elem75);
+              elem85.add(elem83);
             }
             iprot.readListEnd();
-            this.deprList = elem77;
+            this.deprList = elem85;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem78 = iprot.readListBegin();
-            final elem81 = <t_variety.Event>[];
-            for(int elem80 = 0; elem80 < elem78.length; ++elem80) {
-              final tmp_elem79 = t_variety.Event();
-              t_variety.Event elem79 = tmp_elem79;
-              tmp_elem79.read(iprot);
-              elem81.add(elem79);
+            thrift.TList elem86 = iprot.readListBegin();
+            final elem90 = <t_variety.Event>[];
+            for(int elem89 = 0; elem89 < elem86.length; ++elem89) {
+              final elem88 = t_variety.Event();
+              t_variety.Event elem87 = elem88;
+              elem88.read(iprot);
+              elem90.add(elem87);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem81;
+            this.eventsDefault = elem90;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem82 = iprot.readMapBegin();
-            final elem85 = <int, t_variety.Event>{};
-            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
-              int elem86 = iprot.readI64();
-              final tmp_elem83 = t_variety.Event();
-              t_variety.Event elem83 = tmp_elem83;
-              tmp_elem83.read(iprot);
-              elem85[elem86] = elem83;
+            thrift.TMap elem91 = iprot.readMapBegin();
+            final elem95 = <int, t_variety.Event>{};
+            for(int elem94 = 0; elem94 < elem91.length; ++elem94) {
+              int elem96 = iprot.readI64();
+              final elem93 = t_variety.Event();
+              t_variety.Event elem92 = elem93;
+              elem93.read(iprot);
+              elem95[elem96] = elem92;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem85;
+            this.eventMapDefault = elem95;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem87 = iprot.readSetBegin();
-            final elem90 = <t_variety.Event>{};
-            for(int elem89 = 0; elem89 < elem87.length; ++elem89) {
-              final tmp_elem88 = t_variety.Event();
-              t_variety.Event elem88 = tmp_elem88;
-              tmp_elem88.read(iprot);
-              elem90.add(elem88);
+            thrift.TSet elem97 = iprot.readSetBegin();
+            final elem101 = <t_variety.Event>{};
+            for(int elem100 = 0; elem100 < elem97.length; ++elem100) {
+              final elem99 = t_variety.Event();
+              t_variety.Event elem98 = elem99;
+              elem99.read(iprot);
+              elem101.add(elem98);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem90;
+            this.eventSetDefault = elem101;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -527,138 +527,138 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem91 = iD;
+    final elem102 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(elem91);
+      oprot.writeI64(elem102);
       oprot.writeFieldEnd();
     }
-    final elem92 = ev;
+    final elem103 = ev;
     oprot.writeFieldBegin(_EV_FIELD_DESC);
-    elem92.write(oprot);
+    elem103.write(oprot);
     oprot.writeFieldEnd();
-    final elem93 = events;
+    final elem104 = events;
     if (isSetEvents()) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem93.length));
-      for(var elem94 in elem93) {
-        elem94.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem104.length));
+      for(var elem105 in elem104) {
+        elem105.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem95 = events2;
+    final elem106 = events2;
     if (isSetEvents2()) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem95.length));
-      for(var elem96 in elem95) {
-        elem96.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem106.length));
+      for(var elem107 in elem106) {
+        elem107.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem97 = eventMap;
+    final elem108 = eventMap;
     if (isSetEventMap()) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem97.length));
-      for(var elem98 in elem97.keys) {
-        final elem99 = elem97[elem98];
-        oprot.writeI64(elem98);
-        elem99.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem108.length));
+      for(var elem109 in elem108.keys) {
+        final elem110 = elem108[elem109];
+        oprot.writeI64(elem109);
+        elem110.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem100 = nums;
+    final elem111 = nums;
     if (isSetNums()) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem100.length));
-      for(var elem101 in elem100) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
-        for(var elem102 in elem101) {
-          oprot.writeI32(elem102);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem111.length));
+      for(var elem112 in elem111) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem112.length));
+        for(var elem113 in elem112) {
+          oprot.writeI32(elem113);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem103 = enums;
+    final elem114 = enums;
     if (isSetEnums()) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem103.length));
-      for(var elem104 in elem103) {
-        oprot.writeI32(elem104);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem114.length));
+      for(var elem115 in elem114) {
+        oprot.writeI32(elem115);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem105 = aBoolField;
+    final elem116 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem105);
+    oprot.writeBool(elem116);
     oprot.writeFieldEnd();
-    final elem106 = a_union;
+    final elem117 = a_union;
     if (isSetA_union()) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem106.write(oprot);
+      elem117.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem107 = typedefOfTypedef;
+    final elem118 = typedefOfTypedef;
     if (isSetTypedefOfTypedef()) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem107);
+      oprot.writeString(elem118);
       oprot.writeFieldEnd();
     }
-    final elem108 = depr;
+    final elem119 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem108);
+    oprot.writeBool(elem119);
     oprot.writeFieldEnd();
-    final elem109 = deprBinary;
+    final elem120 = deprBinary;
     // ignore: deprecated_member_use
     if (isSetDeprBinary()) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem109);
+      oprot.writeBinary(elem120);
       oprot.writeFieldEnd();
     }
-    final elem110 = deprList;
+    final elem121 = deprList;
     // ignore: deprecated_member_use
     if (isSetDeprList()) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem110.length));
-      for(var elem111 in elem110) {
-        oprot.writeBool(elem111);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem121.length));
+      for(var elem122 in elem121) {
+        oprot.writeBool(elem122);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem112 = eventsDefault;
+    final elem123 = eventsDefault;
     if (isSetEventsDefault()) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem112.length));
-      for(var elem113 in elem112) {
-        elem113.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem123.length));
+      for(var elem124 in elem123) {
+        elem124.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem114 = eventMapDefault;
+    final elem125 = eventMapDefault;
     if (isSetEventMapDefault()) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem114.length));
-      for(var elem115 in elem114.keys) {
-        final elem116 = elem114[elem115];
-        oprot.writeI64(elem115);
-        elem116.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem125.length));
+      for(var elem126 in elem125.keys) {
+        final elem127 = elem125[elem126];
+        oprot.writeI64(elem126);
+        elem127.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem117 = eventSetDefault;
+    final elem128 = eventSetDefault;
     if (isSetEventSetDefault()) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem117.length));
-      for(var elem118 in elem117) {
-        elem118.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem128.length));
+      for(var elem129 in elem128) {
+        elem129.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
@@ -317,92 +317,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            final elem53 = t_variety.Event();
-            this.ev = elem53;
-            elem53.read(iprot);
+            final elem51 = t_variety.Event();
+            this.ev = elem51;
+            elem51.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem54 = iprot.readListBegin();
-            final elem58 = <t_variety.Event>[];
-            for(int elem57 = 0; elem57 < elem54.length; ++elem57) {
-              final elem56 = t_variety.Event();
-              t_variety.Event elem55 = elem56;
-              elem56.read(iprot);
-              elem58.add(elem55);
+            thrift.TList elem52 = iprot.readListBegin();
+            final elem56 = <t_variety.Event>[];
+            for(int elem55 = 0; elem55 < elem52.length; ++elem55) {
+              final elem54 = t_variety.Event();
+              t_variety.Event elem53 = elem54;
+              elem54.read(iprot);
+              elem56.add(elem53);
             }
             iprot.readListEnd();
-            this.events = elem58;
+            this.events = elem56;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem59 = iprot.readSetBegin();
-            final elem63 = <t_variety.Event>{};
-            for(int elem62 = 0; elem62 < elem59.length; ++elem62) {
-              final elem61 = t_variety.Event();
-              t_variety.Event elem60 = elem61;
-              elem61.read(iprot);
-              elem63.add(elem60);
+            thrift.TSet elem57 = iprot.readSetBegin();
+            final elem61 = <t_variety.Event>{};
+            for(int elem60 = 0; elem60 < elem57.length; ++elem60) {
+              final elem59 = t_variety.Event();
+              t_variety.Event elem58 = elem59;
+              elem59.read(iprot);
+              elem61.add(elem58);
             }
             iprot.readSetEnd();
-            this.events2 = elem63;
+            this.events2 = elem61;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem64 = iprot.readMapBegin();
-            final elem68 = <int, t_variety.Event>{};
-            for(int elem67 = 0; elem67 < elem64.length; ++elem67) {
-              int elem69 = iprot.readI64();
-              final elem66 = t_variety.Event();
-              t_variety.Event elem65 = elem66;
-              elem66.read(iprot);
-              elem68[elem69] = elem65;
+            thrift.TMap elem62 = iprot.readMapBegin();
+            final elem66 = <int, t_variety.Event>{};
+            for(int elem65 = 0; elem65 < elem62.length; ++elem65) {
+              int elem67 = iprot.readI64();
+              final elem64 = t_variety.Event();
+              t_variety.Event elem63 = elem64;
+              elem64.read(iprot);
+              elem66[elem67] = elem63;
             }
             iprot.readMapEnd();
-            this.eventMap = elem68;
+            this.eventMap = elem66;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem70 = iprot.readListBegin();
-            final elem76 = <List<int>>[];
-            for(int elem75 = 0; elem75 < elem70.length; ++elem75) {
-              thrift.TList elem72 = iprot.readListBegin();
-              final elem71 = <int>[];
-              for(int elem74 = 0; elem74 < elem72.length; ++elem74) {
-                int elem73 = iprot.readI32();
-                elem71.add(elem73);
+            thrift.TList elem68 = iprot.readListBegin();
+            final elem74 = <List<int>>[];
+            for(int elem73 = 0; elem73 < elem68.length; ++elem73) {
+              thrift.TList elem70 = iprot.readListBegin();
+              final elem69 = <int>[];
+              for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
+                int elem71 = iprot.readI32();
+                elem69.add(elem71);
               }
               iprot.readListEnd();
-              elem76.add(elem71);
+              elem74.add(elem69);
             }
             iprot.readListEnd();
-            this.nums = elem76;
+            this.nums = elem74;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem77 = iprot.readListBegin();
-            final elem80 = <int>[];
-            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
-              int elem78 = iprot.readI32();
-              elem80.add(elem78);
+            thrift.TList elem75 = iprot.readListBegin();
+            final elem78 = <int>[];
+            for(int elem77 = 0; elem77 < elem75.length; ++elem77) {
+              int elem76 = iprot.readI32();
+              elem78.add(elem76);
             }
             iprot.readListEnd();
-            this.enums = elem80;
+            this.enums = elem78;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -416,9 +416,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            final elem81 = t_variety.TestingUnions();
-            this.a_union = elem81;
-            elem81.read(iprot);
+            final elem79 = t_variety.TestingUnions();
+            this.a_union = elem79;
+            elem79.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -448,65 +448,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem82 = iprot.readListBegin();
+            thrift.TList elem80 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem85 = <bool>[];
-            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
-              bool elem83 = iprot.readBool();
+            final elem83 = <bool>[];
+            for(int elem82 = 0; elem82 < elem80.length; ++elem82) {
+              bool elem81 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem85.add(elem83);
+              elem83.add(elem81);
             }
             iprot.readListEnd();
-            this.deprList = elem85;
+            this.deprList = elem83;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem86 = iprot.readListBegin();
-            final elem90 = <t_variety.Event>[];
-            for(int elem89 = 0; elem89 < elem86.length; ++elem89) {
-              final elem88 = t_variety.Event();
-              t_variety.Event elem87 = elem88;
-              elem88.read(iprot);
-              elem90.add(elem87);
+            thrift.TList elem84 = iprot.readListBegin();
+            final elem88 = <t_variety.Event>[];
+            for(int elem87 = 0; elem87 < elem84.length; ++elem87) {
+              final elem86 = t_variety.Event();
+              t_variety.Event elem85 = elem86;
+              elem86.read(iprot);
+              elem88.add(elem85);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem90;
+            this.eventsDefault = elem88;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem91 = iprot.readMapBegin();
-            final elem95 = <int, t_variety.Event>{};
-            for(int elem94 = 0; elem94 < elem91.length; ++elem94) {
-              int elem96 = iprot.readI64();
-              final elem93 = t_variety.Event();
-              t_variety.Event elem92 = elem93;
-              elem93.read(iprot);
-              elem95[elem96] = elem92;
+            thrift.TMap elem89 = iprot.readMapBegin();
+            final elem93 = <int, t_variety.Event>{};
+            for(int elem92 = 0; elem92 < elem89.length; ++elem92) {
+              int elem94 = iprot.readI64();
+              final elem91 = t_variety.Event();
+              t_variety.Event elem90 = elem91;
+              elem91.read(iprot);
+              elem93[elem94] = elem90;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem95;
+            this.eventMapDefault = elem93;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem97 = iprot.readSetBegin();
-            final elem101 = <t_variety.Event>{};
-            for(int elem100 = 0; elem100 < elem97.length; ++elem100) {
-              final elem99 = t_variety.Event();
-              t_variety.Event elem98 = elem99;
-              elem99.read(iprot);
-              elem101.add(elem98);
+            thrift.TSet elem95 = iprot.readSetBegin();
+            final elem99 = <t_variety.Event>{};
+            for(int elem98 = 0; elem98 < elem95.length; ++elem98) {
+              final elem97 = t_variety.Event();
+              t_variety.Event elem96 = elem97;
+              elem97.read(iprot);
+              elem99.add(elem96);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem101;
+            this.eventSetDefault = elem99;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -527,138 +527,136 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem102 = iD;
+    final elem100 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(elem102);
+      oprot.writeI64(elem100);
       oprot.writeFieldEnd();
     }
-    final elem103 = ev;
+    final elem101 = ev;
     oprot.writeFieldBegin(_EV_FIELD_DESC);
-    elem103.write(oprot);
+    elem101.write(oprot);
     oprot.writeFieldEnd();
-    final elem104 = events;
+    final elem102 = events;
     if (isSetEvents()) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem104.length));
-      for(var elem105 in elem104) {
-        elem105.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem102.length));
+      for(var elem103 in elem102) {
+        elem103.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem106 = events2;
+    final elem104 = events2;
     if (isSetEvents2()) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem106.length));
-      for(var elem107 in elem106) {
-        elem107.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem104.length));
+      for(var elem105 in elem104) {
+        elem105.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem108 = eventMap;
+    final elem106 = eventMap;
     if (isSetEventMap()) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem108.length));
-      for(var elem109 in elem108.keys) {
-        final elem110 = elem108[elem109];
-        oprot.writeI64(elem109);
-        elem110.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem106.length));
+      for(var entry in elem106.entries) {
+        oprot.writeI64(entry.key);
+        entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem111 = nums;
+    final elem107 = nums;
     if (isSetNums()) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem111.length));
-      for(var elem112 in elem111) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem112.length));
-        for(var elem113 in elem112) {
-          oprot.writeI32(elem113);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem107.length));
+      for(var elem108 in elem107) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem108.length));
+        for(var elem109 in elem108) {
+          oprot.writeI32(elem109);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem114 = enums;
+    final elem110 = enums;
     if (isSetEnums()) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem114.length));
-      for(var elem115 in elem114) {
-        oprot.writeI32(elem115);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem110.length));
+      for(var elem111 in elem110) {
+        oprot.writeI32(elem111);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem116 = aBoolField;
+    final elem112 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem116);
+    oprot.writeBool(elem112);
     oprot.writeFieldEnd();
-    final elem117 = a_union;
+    final elem113 = a_union;
     if (isSetA_union()) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem117.write(oprot);
+      elem113.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem118 = typedefOfTypedef;
+    final elem114 = typedefOfTypedef;
     if (isSetTypedefOfTypedef()) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem118);
+      oprot.writeString(elem114);
       oprot.writeFieldEnd();
     }
-    final elem119 = depr;
+    final elem115 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem119);
+    oprot.writeBool(elem115);
     oprot.writeFieldEnd();
-    final elem120 = deprBinary;
+    final elem116 = deprBinary;
     // ignore: deprecated_member_use
     if (isSetDeprBinary()) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem120);
+      oprot.writeBinary(elem116);
       oprot.writeFieldEnd();
     }
-    final elem121 = deprList;
+    final elem117 = deprList;
     // ignore: deprecated_member_use
     if (isSetDeprList()) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem121.length));
-      for(var elem122 in elem121) {
-        oprot.writeBool(elem122);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem117.length));
+      for(var elem118 in elem117) {
+        oprot.writeBool(elem118);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem123 = eventsDefault;
+    final elem119 = eventsDefault;
     if (isSetEventsDefault()) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem123.length));
-      for(var elem124 in elem123) {
-        elem124.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem119.length));
+      for(var elem120 in elem119) {
+        elem120.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem125 = eventMapDefault;
+    final elem121 = eventMapDefault;
     if (isSetEventMapDefault()) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem125.length));
-      for(var elem126 in elem125.keys) {
-        final elem127 = elem125[elem126];
-        oprot.writeI64(elem126);
-        elem127.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem121.length));
+      for(var entry in elem121.entries) {
+        oprot.writeI64(entry.key);
+        entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem128 = eventSetDefault;
+    final elem122 = eventSetDefault;
     if (isSetEventSetDefault()) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem128.length));
-      for(var elem129 in elem128) {
-        elem129.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem122.length));
+      for(var elem123 in elem122) {
+        elem123.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
@@ -326,83 +326,83 @@ class EventWrapper implements thrift.TBase {
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem49 = iprot.readListBegin();
-            final elem52 = <t_variety.Event>[];
-            for(int elem51 = 0; elem51 < elem49.length; ++elem51) {
-              final tmp_elem50 = t_variety.Event();
-              t_variety.Event elem50 = tmp_elem50;
-              tmp_elem50.read(iprot);
-              elem52.add(elem50);
+            thrift.TList elem50 = iprot.readListBegin();
+            final elem53 = <t_variety.Event>[];
+            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
+              final tmp_elem51 = t_variety.Event();
+              t_variety.Event elem51 = tmp_elem51;
+              tmp_elem51.read(iprot);
+              elem53.add(elem51);
             }
             iprot.readListEnd();
-            this.events = elem52;
+            this.events = elem53;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem53 = iprot.readSetBegin();
-            final elem56 = <t_variety.Event>{};
-            for(int elem55 = 0; elem55 < elem53.length; ++elem55) {
-              final tmp_elem54 = t_variety.Event();
-              t_variety.Event elem54 = tmp_elem54;
-              tmp_elem54.read(iprot);
-              elem56.add(elem54);
+            thrift.TSet elem54 = iprot.readSetBegin();
+            final elem57 = <t_variety.Event>{};
+            for(int elem56 = 0; elem56 < elem54.length; ++elem56) {
+              final tmp_elem55 = t_variety.Event();
+              t_variety.Event elem55 = tmp_elem55;
+              tmp_elem55.read(iprot);
+              elem57.add(elem55);
             }
             iprot.readSetEnd();
-            this.events2 = elem56;
+            this.events2 = elem57;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem57 = iprot.readMapBegin();
-            final elem60 = <int, t_variety.Event>{};
-            for(int elem59 = 0; elem59 < elem57.length; ++elem59) {
-              int elem61 = iprot.readI64();
-              final tmp_elem58 = t_variety.Event();
-              t_variety.Event elem58 = tmp_elem58;
-              tmp_elem58.read(iprot);
-              elem60[elem61] = elem58;
+            thrift.TMap elem58 = iprot.readMapBegin();
+            final elem61 = <int, t_variety.Event>{};
+            for(int elem60 = 0; elem60 < elem58.length; ++elem60) {
+              int elem62 = iprot.readI64();
+              final tmp_elem59 = t_variety.Event();
+              t_variety.Event elem59 = tmp_elem59;
+              tmp_elem59.read(iprot);
+              elem61[elem62] = elem59;
             }
             iprot.readMapEnd();
-            this.eventMap = elem60;
+            this.eventMap = elem61;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem62 = iprot.readListBegin();
-            final elem68 = <List<int>>[];
-            for(int elem67 = 0; elem67 < elem62.length; ++elem67) {
-              thrift.TList elem64 = iprot.readListBegin();
-              final elem63 = <int>[];
-              for(int elem66 = 0; elem66 < elem64.length; ++elem66) {
-                int elem65 = iprot.readI32();
-                elem63.add(elem65);
+            thrift.TList elem63 = iprot.readListBegin();
+            final elem69 = <List<int>>[];
+            for(int elem68 = 0; elem68 < elem63.length; ++elem68) {
+              thrift.TList elem65 = iprot.readListBegin();
+              final elem64 = <int>[];
+              for(int elem67 = 0; elem67 < elem65.length; ++elem67) {
+                int elem66 = iprot.readI32();
+                elem64.add(elem66);
               }
               iprot.readListEnd();
-              elem68.add(elem63);
+              elem69.add(elem64);
             }
             iprot.readListEnd();
-            this.nums = elem68;
+            this.nums = elem69;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem69 = iprot.readListBegin();
-            final elem72 = <int>[];
-            for(int elem71 = 0; elem71 < elem69.length; ++elem71) {
-              int elem70 = iprot.readI32();
-              elem72.add(elem70);
+            thrift.TList elem70 = iprot.readListBegin();
+            final elem73 = <int>[];
+            for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
+              int elem71 = iprot.readI32();
+              elem73.add(elem71);
             }
             iprot.readListEnd();
-            this.enums = elem72;
+            this.enums = elem73;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -448,65 +448,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem73 = iprot.readListBegin();
+            thrift.TList elem74 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem76 = <bool>[];
-            for(int elem75 = 0; elem75 < elem73.length; ++elem75) {
-              bool elem74 = iprot.readBool();
+            final elem77 = <bool>[];
+            for(int elem76 = 0; elem76 < elem74.length; ++elem76) {
+              bool elem75 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem76.add(elem74);
+              elem77.add(elem75);
             }
             iprot.readListEnd();
-            this.deprList = elem76;
+            this.deprList = elem77;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem77 = iprot.readListBegin();
-            final elem80 = <t_variety.Event>[];
-            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
-              final tmp_elem78 = t_variety.Event();
-              t_variety.Event elem78 = tmp_elem78;
-              tmp_elem78.read(iprot);
-              elem80.add(elem78);
+            thrift.TList elem78 = iprot.readListBegin();
+            final elem81 = <t_variety.Event>[];
+            for(int elem80 = 0; elem80 < elem78.length; ++elem80) {
+              final tmp_elem79 = t_variety.Event();
+              t_variety.Event elem79 = tmp_elem79;
+              tmp_elem79.read(iprot);
+              elem81.add(elem79);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem80;
+            this.eventsDefault = elem81;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem81 = iprot.readMapBegin();
-            final elem84 = <int, t_variety.Event>{};
-            for(int elem83 = 0; elem83 < elem81.length; ++elem83) {
-              int elem85 = iprot.readI64();
-              final tmp_elem82 = t_variety.Event();
-              t_variety.Event elem82 = tmp_elem82;
-              tmp_elem82.read(iprot);
-              elem84[elem85] = elem82;
+            thrift.TMap elem82 = iprot.readMapBegin();
+            final elem85 = <int, t_variety.Event>{};
+            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
+              int elem86 = iprot.readI64();
+              final tmp_elem83 = t_variety.Event();
+              t_variety.Event elem83 = tmp_elem83;
+              tmp_elem83.read(iprot);
+              elem85[elem86] = elem83;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem84;
+            this.eventMapDefault = elem85;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem86 = iprot.readSetBegin();
-            final elem89 = <t_variety.Event>{};
-            for(int elem88 = 0; elem88 < elem86.length; ++elem88) {
-              final tmp_elem87 = t_variety.Event();
-              t_variety.Event elem87 = tmp_elem87;
-              tmp_elem87.read(iprot);
-              elem89.add(elem87);
+            thrift.TSet elem87 = iprot.readSetBegin();
+            final elem90 = <t_variety.Event>{};
+            for(int elem89 = 0; elem89 < elem87.length; ++elem89) {
+              final tmp_elem88 = t_variety.Event();
+              t_variety.Event elem88 = tmp_elem88;
+              tmp_elem88.read(iprot);
+              elem90.add(elem88);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem89;
+            this.eventSetDefault = elem90;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -527,138 +527,138 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem90 = iD;
+    final elem91 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(elem90);
+      oprot.writeI64(elem91);
       oprot.writeFieldEnd();
     }
-    final elem91 = ev;
+    final elem92 = ev;
     oprot.writeFieldBegin(_EV_FIELD_DESC);
-    elem91.write(oprot);
+    elem92.write(oprot);
     oprot.writeFieldEnd();
-    final elem92 = events;
+    final elem93 = events;
     if (isSetEvents()) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem92.length));
-      for(var elem93 in elem92) {
-        elem93.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem93.length));
+      for(var elem94 in elem93) {
+        elem94.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem94 = events2;
+    final elem95 = events2;
     if (isSetEvents2()) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem94.length));
-      for(var elem95 in elem94) {
-        elem95.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem95.length));
+      for(var elem96 in elem95) {
+        elem96.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem96 = eventMap;
+    final elem97 = eventMap;
     if (isSetEventMap()) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem96.length));
-      for(var elem97 in elem96.keys) {
-        final val = elem96[elem97];
-        oprot.writeI64(elem97);
-        val.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem97.length));
+      for(var elem98 in elem97.keys) {
+        final elem99 = elem97[elem98];
+        oprot.writeI64(elem98);
+        elem99.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem98 = nums;
+    final elem100 = nums;
     if (isSetNums()) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem98.length));
-      for(var elem99 in elem98) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem99.length));
-        for(var elem100 in elem99) {
-          oprot.writeI32(elem100);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem100.length));
+      for(var elem101 in elem100) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
+        for(var elem102 in elem101) {
+          oprot.writeI32(elem102);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem101 = enums;
+    final elem103 = enums;
     if (isSetEnums()) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
-      for(var elem102 in elem101) {
-        oprot.writeI32(elem102);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem103.length));
+      for(var elem104 in elem103) {
+        oprot.writeI32(elem104);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem103 = aBoolField;
+    final elem105 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem103);
+    oprot.writeBool(elem105);
     oprot.writeFieldEnd();
-    final elem104 = a_union;
+    final elem106 = a_union;
     if (isSetA_union()) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem104.write(oprot);
+      elem106.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem105 = typedefOfTypedef;
+    final elem107 = typedefOfTypedef;
     if (isSetTypedefOfTypedef()) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem105);
+      oprot.writeString(elem107);
       oprot.writeFieldEnd();
     }
-    final elem106 = depr;
+    final elem108 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem106);
+    oprot.writeBool(elem108);
     oprot.writeFieldEnd();
-    final elem107 = deprBinary;
+    final elem109 = deprBinary;
     // ignore: deprecated_member_use
     if (isSetDeprBinary()) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem107);
+      oprot.writeBinary(elem109);
       oprot.writeFieldEnd();
     }
-    final elem108 = deprList;
+    final elem110 = deprList;
     // ignore: deprecated_member_use
     if (isSetDeprList()) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem108.length));
-      for(var elem109 in elem108) {
-        oprot.writeBool(elem109);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem110.length));
+      for(var elem111 in elem110) {
+        oprot.writeBool(elem111);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem110 = eventsDefault;
+    final elem112 = eventsDefault;
     if (isSetEventsDefault()) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem110.length));
-      for(var elem111 in elem110) {
-        elem111.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem112.length));
+      for(var elem113 in elem112) {
+        elem113.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem112 = eventMapDefault;
+    final elem114 = eventMapDefault;
     if (isSetEventMapDefault()) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem112.length));
-      for(var elem113 in elem112.keys) {
-        final val = elem112[elem113];
-        oprot.writeI64(elem113);
-        val.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem114.length));
+      for(var elem115 in elem114.keys) {
+        final elem116 = elem114[elem115];
+        oprot.writeI64(elem115);
+        elem116.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem114 = eventSetDefault;
+    final elem117 = eventSetDefault;
     if (isSetEventSetDefault()) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem114.length));
-      for(var elem115 in elem114) {
-        elem115.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem117.length));
+      for(var elem118 in elem117) {
+        elem118.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
@@ -317,88 +317,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            this.ev = t_variety.Event();
-            ev.read(iprot);
+            final tmp_ev = t_variety.Event();
+            this.ev = tmp_ev;
+            tmp_ev.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem26 = iprot.readListBegin();
-            final elem29 = <t_variety.Event>[];
-            for(int elem28 = 0; elem28 < elem26.length; ++elem28) {
-              t_variety.Event elem27 = t_variety.Event();
-              elem27.read(iprot);
-              elem29.add(elem27);
+            thrift.TList elem49 = iprot.readListBegin();
+            final elem52 = <t_variety.Event>[];
+            for(int elem51 = 0; elem51 < elem49.length; ++elem51) {
+              final tmp_elem50 = t_variety.Event();
+              t_variety.Event elem50 = tmp_elem50;
+              tmp_elem50.read(iprot);
+              elem52.add(elem50);
             }
             iprot.readListEnd();
-            this.events = elem29;
+            this.events = elem52;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem30 = iprot.readSetBegin();
-            final elem33 = <t_variety.Event>{};
-            for(int elem32 = 0; elem32 < elem30.length; ++elem32) {
-              t_variety.Event elem31 = t_variety.Event();
-              elem31.read(iprot);
-              elem33.add(elem31);
+            thrift.TSet elem53 = iprot.readSetBegin();
+            final elem56 = <t_variety.Event>{};
+            for(int elem55 = 0; elem55 < elem53.length; ++elem55) {
+              final tmp_elem54 = t_variety.Event();
+              t_variety.Event elem54 = tmp_elem54;
+              tmp_elem54.read(iprot);
+              elem56.add(elem54);
             }
             iprot.readSetEnd();
-            this.events2 = elem33;
+            this.events2 = elem56;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem34 = iprot.readMapBegin();
-            final elem37 = <int, t_variety.Event>{};
-            for(int elem36 = 0; elem36 < elem34.length; ++elem36) {
-              int elem38 = iprot.readI64();
-              t_variety.Event elem35 = t_variety.Event();
-              elem35.read(iprot);
-              elem37[elem38] = elem35;
+            thrift.TMap elem57 = iprot.readMapBegin();
+            final elem60 = <int, t_variety.Event>{};
+            for(int elem59 = 0; elem59 < elem57.length; ++elem59) {
+              int elem61 = iprot.readI64();
+              final tmp_elem58 = t_variety.Event();
+              t_variety.Event elem58 = tmp_elem58;
+              tmp_elem58.read(iprot);
+              elem60[elem61] = elem58;
             }
             iprot.readMapEnd();
-            this.eventMap = elem37;
+            this.eventMap = elem60;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem39 = iprot.readListBegin();
-            final elem45 = <List<int>>[];
-            for(int elem44 = 0; elem44 < elem39.length; ++elem44) {
-              thrift.TList elem41 = iprot.readListBegin();
-              final elem40 = <int>[];
-              for(int elem43 = 0; elem43 < elem41.length; ++elem43) {
-                int elem42 = iprot.readI32();
-                elem40.add(elem42);
+            thrift.TList elem62 = iprot.readListBegin();
+            final elem68 = <List<int>>[];
+            for(int elem67 = 0; elem67 < elem62.length; ++elem67) {
+              thrift.TList elem64 = iprot.readListBegin();
+              final elem63 = <int>[];
+              for(int elem66 = 0; elem66 < elem64.length; ++elem66) {
+                int elem65 = iprot.readI32();
+                elem63.add(elem65);
               }
               iprot.readListEnd();
-              elem45.add(elem40);
+              elem68.add(elem63);
             }
             iprot.readListEnd();
-            this.nums = elem45;
+            this.nums = elem68;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem46 = iprot.readListBegin();
-            final elem49 = <int>[];
-            for(int elem48 = 0; elem48 < elem46.length; ++elem48) {
-              int elem47 = iprot.readI32();
-              elem49.add(elem47);
+            thrift.TList elem69 = iprot.readListBegin();
+            final elem72 = <int>[];
+            for(int elem71 = 0; elem71 < elem69.length; ++elem71) {
+              int elem70 = iprot.readI32();
+              elem72.add(elem70);
             }
             iprot.readListEnd();
-            this.enums = elem49;
+            this.enums = elem72;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -412,8 +416,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            this.a_union = t_variety.TestingUnions();
-            a_union.read(iprot);
+            final tmp_a_union = t_variety.TestingUnions();
+            this.a_union = tmp_a_union;
+            tmp_a_union.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -443,62 +448,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem50 = iprot.readListBegin();
+            thrift.TList elem73 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem53 = <bool>[];
-            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
-              bool elem51 = iprot.readBool();
+            final elem76 = <bool>[];
+            for(int elem75 = 0; elem75 < elem73.length; ++elem75) {
+              bool elem74 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem53.add(elem51);
+              elem76.add(elem74);
             }
             iprot.readListEnd();
-            this.deprList = elem53;
+            this.deprList = elem76;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem54 = iprot.readListBegin();
-            final elem57 = <t_variety.Event>[];
-            for(int elem56 = 0; elem56 < elem54.length; ++elem56) {
-              t_variety.Event elem55 = t_variety.Event();
-              elem55.read(iprot);
-              elem57.add(elem55);
+            thrift.TList elem77 = iprot.readListBegin();
+            final elem80 = <t_variety.Event>[];
+            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
+              final tmp_elem78 = t_variety.Event();
+              t_variety.Event elem78 = tmp_elem78;
+              tmp_elem78.read(iprot);
+              elem80.add(elem78);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem57;
+            this.eventsDefault = elem80;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem58 = iprot.readMapBegin();
-            final elem61 = <int, t_variety.Event>{};
-            for(int elem60 = 0; elem60 < elem58.length; ++elem60) {
-              int elem62 = iprot.readI64();
-              t_variety.Event elem59 = t_variety.Event();
-              elem59.read(iprot);
-              elem61[elem62] = elem59;
+            thrift.TMap elem81 = iprot.readMapBegin();
+            final elem84 = <int, t_variety.Event>{};
+            for(int elem83 = 0; elem83 < elem81.length; ++elem83) {
+              int elem85 = iprot.readI64();
+              final tmp_elem82 = t_variety.Event();
+              t_variety.Event elem82 = tmp_elem82;
+              tmp_elem82.read(iprot);
+              elem84[elem85] = elem82;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem61;
+            this.eventMapDefault = elem84;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem63 = iprot.readSetBegin();
-            final elem66 = <t_variety.Event>{};
-            for(int elem65 = 0; elem65 < elem63.length; ++elem65) {
-              t_variety.Event elem64 = t_variety.Event();
-              elem64.read(iprot);
-              elem66.add(elem64);
+            thrift.TSet elem86 = iprot.readSetBegin();
+            final elem89 = <t_variety.Event>{};
+            for(int elem88 = 0; elem88 < elem86.length; ++elem88) {
+              final tmp_elem87 = t_variety.Event();
+              t_variety.Event elem87 = tmp_elem87;
+              tmp_elem87.read(iprot);
+              elem89.add(elem87);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem66;
+            this.eventSetDefault = elem89;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -519,133 +527,138 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem90 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(this.iD);
+      oprot.writeI64(elem90);
       oprot.writeFieldEnd();
     }
+    final elem91 = ev;
     oprot.writeFieldBegin(_EV_FIELD_DESC);
-    this.ev.write(oprot);
+    elem91.write(oprot);
     oprot.writeFieldEnd();
+    final elem92 = events;
     if (isSetEvents()) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      final temp = this.events;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
-      for(var elem67 in temp) {
-        elem67.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem92.length));
+      for(var elem93 in elem92) {
+        elem93.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem94 = events2;
     if (isSetEvents2()) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      final temp = this.events2;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, temp.length));
-      for(var elem68 in temp) {
-        elem68.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem94.length));
+      for(var elem95 in elem94) {
+        elem95.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
+    final elem96 = eventMap;
     if (isSetEventMap()) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      final temp = this.eventMap;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, temp.length));
-      for(var elem69 in temp.keys) {
-        oprot.writeI64(elem69);
-        temp[elem69].write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem96.length));
+      for(var elem97 in elem96.keys) {
+        final val = elem96[elem97];
+        oprot.writeI64(elem97);
+        val.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
+    final elem98 = nums;
     if (isSetNums()) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      final temp = this.nums;
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, temp.length));
-      for(var elem70 in temp) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem70.length));
-        for(var elem71 in elem70) {
-          oprot.writeI32(elem71);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem98.length));
+      for(var elem99 in elem98) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem99.length));
+        for(var elem100 in elem99) {
+          oprot.writeI32(elem100);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem101 = enums;
     if (isSetEnums()) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      final temp = this.enums;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem72 in temp) {
-        oprot.writeI32(elem72);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
+      for(var elem102 in elem101) {
+        oprot.writeI32(elem102);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem103 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(this.aBoolField);
+    oprot.writeBool(elem103);
     oprot.writeFieldEnd();
+    final elem104 = a_union;
     if (isSetA_union()) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      this.a_union.write(oprot);
+      elem104.write(oprot);
       oprot.writeFieldEnd();
     }
+    final elem105 = typedefOfTypedef;
     if (isSetTypedefOfTypedef()) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(this.typedefOfTypedef);
+      oprot.writeString(elem105);
       oprot.writeFieldEnd();
     }
+    final elem106 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    // ignore: deprecated_member_use
-    oprot.writeBool(this.depr);
+    oprot.writeBool(elem106);
     oprot.writeFieldEnd();
+    final elem107 = deprBinary;
     // ignore: deprecated_member_use
     if (isSetDeprBinary()) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      // ignore: deprecated_member_use
-      oprot.writeBinary(this.deprBinary);
+      oprot.writeBinary(elem107);
       oprot.writeFieldEnd();
     }
+    final elem108 = deprList;
     // ignore: deprecated_member_use
     if (isSetDeprList()) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      // ignore: deprecated_member_use
-      final temp = this.deprList;
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, temp.length));
-      // ignore: deprecated_member_use
-      for(var elem73 in temp) {
-        oprot.writeBool(elem73);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem108.length));
+      for(var elem109 in elem108) {
+        oprot.writeBool(elem109);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem110 = eventsDefault;
     if (isSetEventsDefault()) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      final temp = this.eventsDefault;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
-      for(var elem74 in temp) {
-        elem74.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem110.length));
+      for(var elem111 in elem110) {
+        elem111.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem112 = eventMapDefault;
     if (isSetEventMapDefault()) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      final temp = this.eventMapDefault;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, temp.length));
-      for(var elem75 in temp.keys) {
-        oprot.writeI64(elem75);
-        temp[elem75].write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem112.length));
+      for(var elem113 in elem112.keys) {
+        final val = elem112[elem113];
+        oprot.writeI64(elem113);
+        val.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
+    final elem114 = eventSetDefault;
     if (isSetEventSetDefault()) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      final temp = this.eventSetDefault;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, temp.length));
-      for(var elem76 in temp) {
-        elem76.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem114.length));
+      for(var elem115 in elem114) {
+        elem115.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullunset/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_events_scope.dart
@@ -123,12 +123,12 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem164 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem164.length));
-      for(var elem165 in elem164.keys) {
-        final elem166 = elem164[elem165];
-        oprot.writeI64(elem165);
-        elem166.write(oprot);
+    for(var elem180 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem180.length));
+      for(var elem181 in elem180.keys) {
+        final elem182 = elem180[elem181];
+        oprot.writeI64(elem181);
+        elem182.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -176,9 +176,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final tmp_req = t_variety.Event();
-      t_variety.Event req = tmp_req;
-      tmp_req.read(iprot);
+      final elem183 = t_variety.Event();
+      t_variety.Event req = elem183;
+      elem183.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -265,20 +265,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem167 = iprot.readListBegin();
+      thrift.TList elem184 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem173 = 0; elem173 < elem167.length; ++elem173) {
-        thrift.TMap elem169 = iprot.readMapBegin();
-        final elem168 = <int, t_variety.Event>{};
-        for(int elem171 = 0; elem171 < elem169.length; ++elem171) {
-          int elem172 = iprot.readI64();
-          final tmp_elem170 = t_variety.Event();
-          t_variety.Event elem170 = tmp_elem170;
-          tmp_elem170.read(iprot);
-          elem168[elem172] = elem170;
+      for(int elem191 = 0; elem191 < elem184.length; ++elem191) {
+        thrift.TMap elem186 = iprot.readMapBegin();
+        final elem185 = <int, t_variety.Event>{};
+        for(int elem189 = 0; elem189 < elem186.length; ++elem189) {
+          int elem190 = iprot.readI64();
+          final elem188 = t_variety.Event();
+          t_variety.Event elem187 = elem188;
+          elem188.read(iprot);
+          elem185[elem190] = elem187;
         }
         iprot.readMapEnd();
-        req.add(elem168);
+        req.add(elem185);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_events_scope.dart
@@ -123,12 +123,11 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem180 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem180.length));
-      for(var elem181 in elem180.keys) {
-        final elem182 = elem180[elem181];
-        oprot.writeI64(elem181);
-        elem182.write(oprot);
+    for(var elem170 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem170.length));
+      for(var entry in elem170.entries) {
+        oprot.writeI64(entry.key);
+        entry.value.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -176,9 +175,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final elem183 = t_variety.Event();
-      t_variety.Event req = elem183;
-      elem183.read(iprot);
+      final elem171 = t_variety.Event();
+      t_variety.Event req = elem171;
+      elem171.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -265,20 +264,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem184 = iprot.readListBegin();
+      thrift.TList elem172 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem191 = 0; elem191 < elem184.length; ++elem191) {
-        thrift.TMap elem186 = iprot.readMapBegin();
-        final elem185 = <int, t_variety.Event>{};
-        for(int elem189 = 0; elem189 < elem186.length; ++elem189) {
-          int elem190 = iprot.readI64();
-          final elem188 = t_variety.Event();
-          t_variety.Event elem187 = elem188;
-          elem188.read(iprot);
-          elem185[elem190] = elem187;
+      for(int elem179 = 0; elem179 < elem172.length; ++elem179) {
+        thrift.TMap elem174 = iprot.readMapBegin();
+        final elem173 = <int, t_variety.Event>{};
+        for(int elem177 = 0; elem177 < elem174.length; ++elem177) {
+          int elem178 = iprot.readI64();
+          final elem176 = t_variety.Event();
+          t_variety.Event elem175 = elem176;
+          elem176.read(iprot);
+          elem173[elem178] = elem175;
         }
         iprot.readMapEnd();
-        req.add(elem185);
+        req.add(elem173);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_events_scope.dart
@@ -123,12 +123,12 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem159 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem159.length));
-      for(var elem160 in elem159.keys) {
-        final val = elem159[elem160];
-        oprot.writeI64(elem160);
-        val.write(oprot);
+    for(var elem164 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem164.length));
+      for(var elem165 in elem164.keys) {
+        final elem166 = elem164[elem165];
+        oprot.writeI64(elem165);
+        elem166.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -265,20 +265,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem161 = iprot.readListBegin();
+      thrift.TList elem167 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem167 = 0; elem167 < elem161.length; ++elem167) {
-        thrift.TMap elem163 = iprot.readMapBegin();
-        final elem162 = <int, t_variety.Event>{};
-        for(int elem165 = 0; elem165 < elem163.length; ++elem165) {
-          int elem166 = iprot.readI64();
-          final tmp_elem164 = t_variety.Event();
-          t_variety.Event elem164 = tmp_elem164;
-          tmp_elem164.read(iprot);
-          elem162[elem166] = elem164;
+      for(int elem173 = 0; elem173 < elem167.length; ++elem173) {
+        thrift.TMap elem169 = iprot.readMapBegin();
+        final elem168 = <int, t_variety.Event>{};
+        for(int elem171 = 0; elem171 < elem169.length; ++elem171) {
+          int elem172 = iprot.readI64();
+          final tmp_elem170 = t_variety.Event();
+          t_variety.Event elem170 = tmp_elem170;
+          tmp_elem170.read(iprot);
+          elem168[elem172] = elem170;
         }
         iprot.readMapEnd();
-        req.add(elem162);
+        req.add(elem168);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_events_scope.dart
@@ -123,11 +123,12 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem90 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem90.length));
-      for(var elem91 in elem90.keys) {
-        oprot.writeI64(elem91);
-        elem90[elem91].write(oprot);
+    for(var elem159 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem159.length));
+      for(var elem160 in elem159.keys) {
+        final val = elem159[elem160];
+        oprot.writeI64(elem160);
+        val.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -175,8 +176,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      t_variety.Event req = t_variety.Event();
-      req.read(iprot);
+      final tmp_req = t_variety.Event();
+      t_variety.Event req = tmp_req;
+      tmp_req.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -263,19 +265,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem92 = iprot.readListBegin();
+      thrift.TList elem161 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem98 = 0; elem98 < elem92.length; ++elem98) {
-        thrift.TMap elem94 = iprot.readMapBegin();
-        final elem93 = <int, t_variety.Event>{};
-        for(int elem96 = 0; elem96 < elem94.length; ++elem96) {
-          int elem97 = iprot.readI64();
-          t_variety.Event elem95 = t_variety.Event();
-          elem95.read(iprot);
-          elem93[elem97] = elem95;
+      for(int elem167 = 0; elem167 < elem161.length; ++elem167) {
+        thrift.TMap elem163 = iprot.readMapBegin();
+        final elem162 = <int, t_variety.Event>{};
+        for(int elem165 = 0; elem165 < elem163.length; ++elem165) {
+          int elem166 = iprot.readI64();
+          final tmp_elem164 = t_variety.Event();
+          t_variety.Event elem164 = tmp_elem164;
+          tmp_elem164.read(iprot);
+          elem162[elem166] = elem164;
         }
         iprot.readMapEnd();
-        req.add(elem93);
+        req.add(elem162);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_events_scope.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
@@ -66,9 +64,7 @@ class EventsPublisher {
     oprot.writeMessageBegin(msg);
     req.write(oprot);
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 
 
@@ -88,9 +84,7 @@ class EventsPublisher {
     oprot.writeMessageBegin(msg);
     oprot.writeI64(req);
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 
 
@@ -110,9 +104,7 @@ class EventsPublisher {
     oprot.writeMessageBegin(msg);
     oprot.writeString(req);
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 
 
@@ -141,9 +133,7 @@ class EventsPublisher {
     }
     oprot.writeListEnd();
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 }
 

--- a/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
@@ -130,22 +130,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem116 = newMessage;
+    final elem119 = newMessage;
     if (isSetNewMessage()) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem116);
+      oprot.writeString(elem119);
       oprot.writeFieldEnd();
     }
-    final elem117 = messageArgs;
+    final elem120 = messageArgs;
     if (isSetMessageArgs()) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem117);
+      oprot.writeString(elem120);
       oprot.writeFieldEnd();
     }
-    final elem118 = messageResult;
+    final elem121 = messageResult;
     if (isSetMessageResult()) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem118);
+      oprot.writeString(elem121);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
@@ -130,19 +130,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem116 = newMessage;
     if (isSetNewMessage()) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(this.newMessage);
+      oprot.writeString(elem116);
       oprot.writeFieldEnd();
     }
+    final elem117 = messageArgs;
     if (isSetMessageArgs()) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(this.messageArgs);
+      oprot.writeString(elem117);
       oprot.writeFieldEnd();
     }
+    final elem118 = messageResult;
     if (isSetMessageResult()) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(this.messageResult);
+      oprot.writeString(elem118);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
@@ -130,22 +130,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem130 = newMessage;
+    final elem124 = newMessage;
     if (isSetNewMessage()) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem130);
+      oprot.writeString(elem124);
       oprot.writeFieldEnd();
     }
-    final elem131 = messageArgs;
+    final elem125 = messageArgs;
     if (isSetMessageArgs()) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem131);
+      oprot.writeString(elem125);
       oprot.writeFieldEnd();
     }
-    final elem132 = messageResult;
+    final elem126 = messageResult;
     if (isSetMessageResult()) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem132);
+      oprot.writeString(elem126);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
@@ -130,22 +130,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem119 = newMessage;
+    final elem130 = newMessage;
     if (isSetNewMessage()) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem119);
+      oprot.writeString(elem130);
       oprot.writeFieldEnd();
     }
-    final elem120 = messageArgs;
+    final elem131 = messageArgs;
     if (isSetMessageArgs()) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem120);
+      oprot.writeString(elem131);
       oprot.writeFieldEnd();
     }
-    final elem121 = messageResult;
+    final elem132 = messageResult;
     if (isSetMessageResult()) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem121);
+      oprot.writeString(elem132);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullunset/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_foo_service.dart
@@ -418,17 +418,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem136 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(this.num);
+    oprot.writeI32(elem136);
     oprot.writeFieldEnd();
-    if (this.str != null) {
+    final elem137 = str;
+    if (elem137 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(this.str);
+      oprot.writeString(elem137);
       oprot.writeFieldEnd();
     }
-    if (this.event != null) {
+    final elem138 = event;
+    if (elem138 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      this.event.write(oprot);
+      elem138.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -461,16 +464,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            this.awe = t_variety.AwesomeException();
-            awe.read(iprot);
+            final tmp_awe = t_variety.AwesomeException();
+            this.awe = tmp_awe;
+            tmp_awe.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            this.api = t_actual_base_dart.api_exception();
-            api.read(iprot);
+            final tmp_api = t_actual_base_dart.api_exception();
+            this.api = tmp_api;
+            tmp_api.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -504,16 +509,18 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem139 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(this.id);
+    oprot.writeI64(elem139);
     oprot.writeFieldEnd();
-    if (this.req != null) {
+    final elem140 = req;
+    if (elem140 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      final temp = this.req;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, temp.length));
-      for(var elem83 in temp.keys) {
-        oprot.writeI32(elem83);
-        oprot.writeString(temp[elem83]);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem140.length));
+      for(var elem141 in elem140.keys) {
+        final val = elem140[elem141];
+        oprot.writeI32(elem141);
+        oprot.writeString(val);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -540,14 +547,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.bin != null) {
+    final elem142 = bin;
+    if (elem142 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(this.bin);
+      oprot.writeBinary(elem142);
       oprot.writeFieldEnd();
     }
-    if (this.str != null) {
+    final elem143 = str;
+    if (elem143 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(this.str);
+      oprot.writeString(elem143);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -579,8 +588,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            this.api = t_actual_base_dart.api_exception();
-            api.read(iprot);
+            final tmp_api = t_actual_base_dart.api_exception();
+            this.api = tmp_api;
+            tmp_api.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -616,14 +626,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem144 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(this.opt_num);
+    oprot.writeI32(elem144);
     oprot.writeFieldEnd();
+    final elem145 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(this.default_num);
+    oprot.writeI32(elem145);
     oprot.writeFieldEnd();
+    final elem146 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(this.req_num);
+    oprot.writeI32(elem146);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -684,22 +697,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.list_type != null) {
+    final elem147 = list_type;
+    if (elem147 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      final temp = this.list_type;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, temp.length));
-      for(var elem84 in temp) {
-        oprot.writeI64(elem84);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem147.length));
+      for(var elem148 in elem147) {
+        oprot.writeI64(elem148);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (this.set_type != null) {
+    final elem149 = set_type;
+    if (elem149 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      final temp = this.set_type;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, temp.length));
-      for(var elem85 in temp) {
-        oprot.writeI64(elem85);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem149.length));
+      for(var elem150 in elem149) {
+        oprot.writeI64(elem150);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -725,14 +738,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem86 = iprot.readListBegin();
-            final elem89 = <int>[];
-            for(int elem88 = 0; elem88 < elem86.length; ++elem88) {
-              int elem87 = iprot.readI64();
-              elem89.add(elem87);
+            thrift.TList elem151 = iprot.readListBegin();
+            final elem154 = <int>[];
+            for(int elem153 = 0; elem153 < elem151.length; ++elem153) {
+              int elem152 = iprot.readI64();
+              elem154.add(elem152);
             }
             iprot.readListEnd();
-            this.success = elem89;
+            this.success = elem154;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -783,8 +796,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            this.success = t_validStructs.Thing();
-            success.read(iprot);
+            final tmp_success = t_validStructs.Thing();
+            this.success = tmp_success;
+            tmp_success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -867,9 +881,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.a != null) {
+    final elem155 = a;
+    if (elem155 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      this.a.write(oprot);
+      elem155.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -893,8 +908,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            this.success = t_subdir_include_ns.A();
-            success.read(iprot);
+            final tmp_success = t_subdir_include_ns.A();
+            this.success = tmp_success;
+            tmp_success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -926,9 +942,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.newMessage != null) {
+    final elem156 = newMessage;
+    if (elem156 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(this.newMessage);
+      oprot.writeString(elem156);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -984,9 +1001,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.messageArgs != null) {
+    final elem157 = messageArgs;
+    if (elem157 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(this.messageArgs);
+      oprot.writeString(elem157);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1042,9 +1060,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.messageResult != null) {
+    final elem158 = messageResult;
+    if (elem158 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(this.messageResult);
+      oprot.writeString(elem158);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_foo_service.dart
@@ -418,20 +418,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem136 = num;
+    final elem140 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem136);
+    oprot.writeI32(elem140);
     oprot.writeFieldEnd();
-    final elem137 = str;
-    if (elem137 != null) {
+    final elem141 = str;
+    if (elem141 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem137);
+      oprot.writeString(elem141);
       oprot.writeFieldEnd();
     }
-    final elem138 = event;
-    if (elem138 != null) {
+    final elem142 = event;
+    if (elem142 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem138.write(oprot);
+      elem142.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -509,18 +509,18 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem139 = id;
+    final elem143 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem139);
+    oprot.writeI64(elem143);
     oprot.writeFieldEnd();
-    final elem140 = req;
-    if (elem140 != null) {
+    final elem144 = req;
+    if (elem144 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem140.length));
-      for(var elem141 in elem140.keys) {
-        final val = elem140[elem141];
-        oprot.writeI32(elem141);
-        oprot.writeString(val);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem144.length));
+      for(var elem145 in elem144.keys) {
+        final elem146 = elem144[elem145];
+        oprot.writeI32(elem145);
+        oprot.writeString(elem146);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -547,16 +547,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem142 = bin;
-    if (elem142 != null) {
+    final elem147 = bin;
+    if (elem147 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem142);
+      oprot.writeBinary(elem147);
       oprot.writeFieldEnd();
     }
-    final elem143 = str;
-    if (elem143 != null) {
+    final elem148 = str;
+    if (elem148 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem143);
+      oprot.writeString(elem148);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -626,17 +626,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem144 = opt_num;
+    final elem149 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem144);
+    oprot.writeI32(elem149);
     oprot.writeFieldEnd();
-    final elem145 = default_num;
+    final elem150 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem145);
+    oprot.writeI32(elem150);
     oprot.writeFieldEnd();
-    final elem146 = req_num;
+    final elem151 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem146);
+    oprot.writeI32(elem151);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -697,22 +697,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem147 = list_type;
-    if (elem147 != null) {
+    final elem152 = list_type;
+    if (elem152 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem147.length));
-      for(var elem148 in elem147) {
-        oprot.writeI64(elem148);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem152.length));
+      for(var elem153 in elem152) {
+        oprot.writeI64(elem153);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem149 = set_type;
-    if (elem149 != null) {
+    final elem154 = set_type;
+    if (elem154 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem149.length));
-      for(var elem150 in elem149) {
-        oprot.writeI64(elem150);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem154.length));
+      for(var elem155 in elem154) {
+        oprot.writeI64(elem155);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -738,14 +738,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem151 = iprot.readListBegin();
-            final elem154 = <int>[];
-            for(int elem153 = 0; elem153 < elem151.length; ++elem153) {
-              int elem152 = iprot.readI64();
-              elem154.add(elem152);
+            thrift.TList elem156 = iprot.readListBegin();
+            final elem159 = <int>[];
+            for(int elem158 = 0; elem158 < elem156.length; ++elem158) {
+              int elem157 = iprot.readI64();
+              elem159.add(elem157);
             }
             iprot.readListEnd();
-            this.success = elem154;
+            this.success = elem159;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -881,10 +881,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem155 = a;
-    if (elem155 != null) {
+    final elem160 = a;
+    if (elem160 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem155.write(oprot);
+      elem160.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -942,10 +942,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem156 = newMessage;
-    if (elem156 != null) {
+    final elem161 = newMessage;
+    if (elem161 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem156);
+      oprot.writeString(elem161);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1001,10 +1001,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem157 = messageArgs;
-    if (elem157 != null) {
+    final elem162 = messageArgs;
+    if (elem162 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem157);
+      oprot.writeString(elem162);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1060,10 +1060,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem158 = messageResult;
-    if (elem158 != null) {
+    final elem163 = messageResult;
+    if (elem163 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem158);
+      oprot.writeString(elem163);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_foo_service.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart.nullunset/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_foo_service.dart
@@ -418,20 +418,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem151 = num;
+    final elem143 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem151);
+    oprot.writeI32(elem143);
     oprot.writeFieldEnd();
-    final elem152 = str;
-    if (elem152 != null) {
+    final elem144 = str;
+    if (elem144 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem152);
+      oprot.writeString(elem144);
       oprot.writeFieldEnd();
     }
-    final elem153 = event;
-    if (elem153 != null) {
+    final elem145 = event;
+    if (elem145 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem153.write(oprot);
+      elem145.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -464,18 +464,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem154 = t_variety.AwesomeException();
-            this.awe = elem154;
-            elem154.read(iprot);
+            final elem146 = t_variety.AwesomeException();
+            this.awe = elem146;
+            elem146.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            final elem155 = t_actual_base_dart.api_exception();
-            this.api = elem155;
-            elem155.read(iprot);
+            final elem147 = t_actual_base_dart.api_exception();
+            this.api = elem147;
+            elem147.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -509,18 +509,17 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem156 = id;
+    final elem148 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem156);
+    oprot.writeI64(elem148);
     oprot.writeFieldEnd();
-    final elem157 = req;
-    if (elem157 != null) {
+    final elem149 = req;
+    if (elem149 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem157.length));
-      for(var elem158 in elem157.keys) {
-        final elem159 = elem157[elem158];
-        oprot.writeI32(elem158);
-        oprot.writeString(elem159);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem149.length));
+      for(var entry in elem149.entries) {
+        oprot.writeI32(entry.key);
+        oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -547,16 +546,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem160 = bin;
-    if (elem160 != null) {
+    final elem150 = bin;
+    if (elem150 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem160);
+      oprot.writeBinary(elem150);
       oprot.writeFieldEnd();
     }
-    final elem161 = str;
-    if (elem161 != null) {
+    final elem151 = str;
+    if (elem151 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem161);
+      oprot.writeString(elem151);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -588,9 +587,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem162 = t_actual_base_dart.api_exception();
-            this.api = elem162;
-            elem162.read(iprot);
+            final elem152 = t_actual_base_dart.api_exception();
+            this.api = elem152;
+            elem152.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -626,17 +625,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem163 = opt_num;
+    final elem153 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem163);
+    oprot.writeI32(elem153);
     oprot.writeFieldEnd();
-    final elem164 = default_num;
+    final elem154 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem164);
+    oprot.writeI32(elem154);
     oprot.writeFieldEnd();
-    final elem165 = req_num;
+    final elem155 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem165);
+    oprot.writeI32(elem155);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -697,22 +696,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem166 = list_type;
-    if (elem166 != null) {
+    final elem156 = list_type;
+    if (elem156 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem166.length));
-      for(var elem167 in elem166) {
-        oprot.writeI64(elem167);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem156.length));
+      for(var elem157 in elem156) {
+        oprot.writeI64(elem157);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem168 = set_type;
-    if (elem168 != null) {
+    final elem158 = set_type;
+    if (elem158 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem168.length));
-      for(var elem169 in elem168) {
-        oprot.writeI64(elem169);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem158.length));
+      for(var elem159 in elem158) {
+        oprot.writeI64(elem159);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -738,14 +737,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem170 = iprot.readListBegin();
-            final elem173 = <int>[];
-            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
-              int elem171 = iprot.readI64();
-              elem173.add(elem171);
+            thrift.TList elem160 = iprot.readListBegin();
+            final elem163 = <int>[];
+            for(int elem162 = 0; elem162 < elem160.length; ++elem162) {
+              int elem161 = iprot.readI64();
+              elem163.add(elem161);
             }
             iprot.readListEnd();
-            this.success = elem173;
+            this.success = elem163;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -796,9 +795,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem174 = t_validStructs.Thing();
-            this.success = elem174;
-            elem174.read(iprot);
+            final elem164 = t_validStructs.Thing();
+            this.success = elem164;
+            elem164.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -881,10 +880,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem175 = a;
-    if (elem175 != null) {
+    final elem165 = a;
+    if (elem165 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem175.write(oprot);
+      elem165.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -908,9 +907,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem176 = t_subdir_include_ns.A();
-            this.success = elem176;
-            elem176.read(iprot);
+            final elem166 = t_subdir_include_ns.A();
+            this.success = elem166;
+            elem166.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -942,10 +941,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem177 = newMessage;
-    if (elem177 != null) {
+    final elem167 = newMessage;
+    if (elem167 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem177);
+      oprot.writeString(elem167);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1001,10 +1000,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem178 = messageArgs;
-    if (elem178 != null) {
+    final elem168 = messageArgs;
+    if (elem168 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem178);
+      oprot.writeString(elem168);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1060,10 +1059,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem179 = messageResult;
-    if (elem179 != null) {
+    final elem169 = messageResult;
+    if (elem169 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem179);
+      oprot.writeString(elem169);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_foo_service.dart
@@ -418,20 +418,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem140 = num;
+    final elem151 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem140);
+    oprot.writeI32(elem151);
     oprot.writeFieldEnd();
-    final elem141 = str;
-    if (elem141 != null) {
+    final elem152 = str;
+    if (elem152 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem141);
+      oprot.writeString(elem152);
       oprot.writeFieldEnd();
     }
-    final elem142 = event;
-    if (elem142 != null) {
+    final elem153 = event;
+    if (elem153 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem142.write(oprot);
+      elem153.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -464,18 +464,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_awe = t_variety.AwesomeException();
-            this.awe = tmp_awe;
-            tmp_awe.read(iprot);
+            final elem154 = t_variety.AwesomeException();
+            this.awe = elem154;
+            elem154.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_api = t_actual_base_dart.api_exception();
-            this.api = tmp_api;
-            tmp_api.read(iprot);
+            final elem155 = t_actual_base_dart.api_exception();
+            this.api = elem155;
+            elem155.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -509,18 +509,18 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem143 = id;
+    final elem156 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem143);
+    oprot.writeI64(elem156);
     oprot.writeFieldEnd();
-    final elem144 = req;
-    if (elem144 != null) {
+    final elem157 = req;
+    if (elem157 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem144.length));
-      for(var elem145 in elem144.keys) {
-        final elem146 = elem144[elem145];
-        oprot.writeI32(elem145);
-        oprot.writeString(elem146);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem157.length));
+      for(var elem158 in elem157.keys) {
+        final elem159 = elem157[elem158];
+        oprot.writeI32(elem158);
+        oprot.writeString(elem159);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -547,16 +547,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem147 = bin;
-    if (elem147 != null) {
+    final elem160 = bin;
+    if (elem160 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem147);
+      oprot.writeBinary(elem160);
       oprot.writeFieldEnd();
     }
-    final elem148 = str;
-    if (elem148 != null) {
+    final elem161 = str;
+    if (elem161 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem148);
+      oprot.writeString(elem161);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -588,9 +588,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_api = t_actual_base_dart.api_exception();
-            this.api = tmp_api;
-            tmp_api.read(iprot);
+            final elem162 = t_actual_base_dart.api_exception();
+            this.api = elem162;
+            elem162.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -626,17 +626,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem149 = opt_num;
+    final elem163 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem149);
+    oprot.writeI32(elem163);
     oprot.writeFieldEnd();
-    final elem150 = default_num;
+    final elem164 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem150);
+    oprot.writeI32(elem164);
     oprot.writeFieldEnd();
-    final elem151 = req_num;
+    final elem165 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem151);
+    oprot.writeI32(elem165);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -697,22 +697,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem152 = list_type;
-    if (elem152 != null) {
+    final elem166 = list_type;
+    if (elem166 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem152.length));
-      for(var elem153 in elem152) {
-        oprot.writeI64(elem153);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem166.length));
+      for(var elem167 in elem166) {
+        oprot.writeI64(elem167);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem154 = set_type;
-    if (elem154 != null) {
+    final elem168 = set_type;
+    if (elem168 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem154.length));
-      for(var elem155 in elem154) {
-        oprot.writeI64(elem155);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem168.length));
+      for(var elem169 in elem168) {
+        oprot.writeI64(elem169);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -738,14 +738,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem156 = iprot.readListBegin();
-            final elem159 = <int>[];
-            for(int elem158 = 0; elem158 < elem156.length; ++elem158) {
-              int elem157 = iprot.readI64();
-              elem159.add(elem157);
+            thrift.TList elem170 = iprot.readListBegin();
+            final elem173 = <int>[];
+            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
+              int elem171 = iprot.readI64();
+              elem173.add(elem171);
             }
             iprot.readListEnd();
-            this.success = elem159;
+            this.success = elem173;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -796,9 +796,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_success = t_validStructs.Thing();
-            this.success = tmp_success;
-            tmp_success.read(iprot);
+            final elem174 = t_validStructs.Thing();
+            this.success = elem174;
+            elem174.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -881,10 +881,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem160 = a;
-    if (elem160 != null) {
+    final elem175 = a;
+    if (elem175 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem160.write(oprot);
+      elem175.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -908,9 +908,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_success = t_subdir_include_ns.A();
-            this.success = tmp_success;
-            tmp_success.read(iprot);
+            final elem176 = t_subdir_include_ns.A();
+            this.success = elem176;
+            elem176.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -942,10 +942,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem161 = newMessage;
-    if (elem161 != null) {
+    final elem177 = newMessage;
+    if (elem177 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem161);
+      oprot.writeString(elem177);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1001,10 +1001,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem162 = messageArgs;
-    if (elem162 != null) {
+    final elem178 = messageArgs;
+    if (elem178 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem162);
+      oprot.writeString(elem178);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1060,10 +1060,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem163 = messageResult;
-    if (elem163 != null) {
+    final elem179 = messageResult;
+    if (elem179 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem163);
+      oprot.writeString(elem179);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_test_base.dart
@@ -65,9 +65,9 @@ class TestBase implements thrift.TBase {
       switch (field.id) {
         case BASE_STRUCT:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_base_struct = t_actual_base_dart.thing();
-            this.base_struct = tmp_base_struct;
-            tmp_base_struct.read(iprot);
+            final elem0 = t_actual_base_dart.thing();
+            this.base_struct = elem0;
+            elem0.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -88,10 +88,10 @@ class TestBase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem0 = base_struct;
+    final elem1 = base_struct;
     if (isSetBase_struct()) {
       oprot.writeFieldBegin(_BASE_STRUCT_FIELD_DESC);
-      elem0.write(oprot);
+      elem1.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_test_base.dart
@@ -65,8 +65,9 @@ class TestBase implements thrift.TBase {
       switch (field.id) {
         case BASE_STRUCT:
           if (field.type == thrift.TType.STRUCT) {
-            this.base_struct = t_actual_base_dart.thing();
-            base_struct.read(iprot);
+            final tmp_base_struct = t_actual_base_dart.thing();
+            this.base_struct = tmp_base_struct;
+            tmp_base_struct.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -87,9 +88,10 @@ class TestBase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem0 = base_struct;
     if (isSetBase_struct()) {
       oprot.writeFieldBegin(_BASE_STRUCT_FIELD_DESC);
-      this.base_struct.write(oprot);
+      elem0.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_test_base.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullunset/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_test_lowercase.dart
@@ -86,9 +86,9 @@ class TestLowercase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem1 = lowercaseInt;
+    final elem2 = lowercaseInt;
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
-    oprot.writeI32(elem1);
+    oprot.writeI32(elem2);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_test_lowercase.dart
@@ -86,8 +86,9 @@ class TestLowercase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem1 = lowercaseInt;
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
-    oprot.writeI32(this.lowercaseInt);
+    oprot.writeI32(elem1);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_test_lowercase.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
@@ -647,20 +647,20 @@ class TestingDefaults implements thrift.TBase {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
       oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem45.length));
       for(var elem46 in elem45.keys) {
-        final val = elem45[elem46];
+        final elem47 = elem45[elem46];
         oprot.writeString(elem46);
-        oprot.writeString(val);
+        oprot.writeString(elem47);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem47 = status;
+    final elem48 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem47);
-    oprot.writeFieldEnd();
-    final elem48 = base_status;
-    oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
     oprot.writeI32(elem48);
+    oprot.writeFieldEnd();
+    final elem49 = base_status;
+    oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
+    oprot.writeI32(elem49);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
@@ -367,18 +367,18 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_ev1 = t_variety.Event();
-            this.ev1 = tmp_ev1;
-            tmp_ev1.read(iprot);
+            final elem6 = t_variety.Event();
+            this.ev1 = elem6;
+            elem6.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_ev2 = t_variety.Event();
-            this.ev2 = tmp_ev2;
-            tmp_ev2.read(iprot);
+            final elem7 = t_variety.Event();
+            this.ev2 = elem7;
+            elem7.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -406,14 +406,14 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LISTFIELD:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem5 = iprot.readListBegin();
-            final elem8 = <int>[];
-            for(int elem7 = 0; elem7 < elem5.length; ++elem7) {
-              int elem6 = iprot.readI32();
-              elem8.add(elem6);
+            thrift.TList elem8 = iprot.readListBegin();
+            final elem11 = <int>[];
+            for(int elem10 = 0; elem10 < elem8.length; ++elem10) {
+              int elem9 = iprot.readI32();
+              elem11.add(elem9);
             }
             iprot.readListEnd();
-            this.listfield = elem8;
+            this.listfield = elem11;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -455,57 +455,57 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LIST2:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem9 = iprot.readListBegin();
-            final elem12 = <int>[];
-            for(int elem11 = 0; elem11 < elem9.length; ++elem11) {
-              int elem10 = iprot.readI32();
-              elem12.add(elem10);
+            thrift.TList elem12 = iprot.readListBegin();
+            final elem15 = <int>[];
+            for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
+              int elem13 = iprot.readI32();
+              elem15.add(elem13);
             }
             iprot.readListEnd();
-            this.list2 = elem12;
+            this.list2 = elem15;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST3:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem13 = iprot.readListBegin();
-            final elem16 = <int>[];
-            for(int elem15 = 0; elem15 < elem13.length; ++elem15) {
-              int elem14 = iprot.readI32();
-              elem16.add(elem14);
+            thrift.TList elem16 = iprot.readListBegin();
+            final elem19 = <int>[];
+            for(int elem18 = 0; elem18 < elem16.length; ++elem18) {
+              int elem17 = iprot.readI32();
+              elem19.add(elem17);
             }
             iprot.readListEnd();
-            this.list3 = elem16;
+            this.list3 = elem19;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST4:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem17 = iprot.readListBegin();
-            final elem20 = <int>[];
-            for(int elem19 = 0; elem19 < elem17.length; ++elem19) {
-              int elem18 = iprot.readI32();
-              elem20.add(elem18);
+            thrift.TList elem20 = iprot.readListBegin();
+            final elem23 = <int>[];
+            for(int elem22 = 0; elem22 < elem20.length; ++elem22) {
+              int elem21 = iprot.readI32();
+              elem23.add(elem21);
             }
             iprot.readListEnd();
-            this.list4 = elem20;
+            this.list4 = elem23;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case A_MAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem21 = iprot.readMapBegin();
-            final elem24 = <String, String>{};
-            for(int elem23 = 0; elem23 < elem21.length; ++elem23) {
+            thrift.TMap elem24 = iprot.readMapBegin();
+            final elem27 = <String, String>{};
+            for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
+              String elem28 = iprot.readString();
               String elem25 = iprot.readString();
-              String elem22 = iprot.readString();
-              elem24[elem25] = elem22;
+              elem27[elem28] = elem25;
             }
             iprot.readMapEnd();
-            this.a_map = elem24;
+            this.a_map = elem27;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -540,127 +540,127 @@ class TestingDefaults implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem26 = iD2;
+    final elem29 = iD2;
     if (isSetID2()) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
-      oprot.writeI64(elem26);
+      oprot.writeI64(elem29);
       oprot.writeFieldEnd();
     }
-    final elem27 = ev1;
+    final elem30 = ev1;
     if (isSetEv1()) {
       oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      elem27.write(oprot);
+      elem30.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem28 = ev2;
+    final elem31 = ev2;
     if (isSetEv2()) {
       oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      elem28.write(oprot);
+      elem31.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem29 = iD;
+    final elem32 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem29);
+    oprot.writeI64(elem32);
     oprot.writeFieldEnd();
-    final elem30 = thing;
+    final elem33 = thing;
     if (isSetThing()) {
       oprot.writeFieldBegin(_THING_FIELD_DESC);
-      oprot.writeString(elem30);
+      oprot.writeString(elem33);
       oprot.writeFieldEnd();
     }
-    final elem31 = thing2;
+    final elem34 = thing2;
     if (isSetThing2()) {
       oprot.writeFieldBegin(_THING2_FIELD_DESC);
-      oprot.writeString(elem31);
+      oprot.writeString(elem34);
       oprot.writeFieldEnd();
     }
-    final elem32 = listfield;
+    final elem35 = listfield;
     if (isSetListfield()) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem32.length));
-      for(var elem33 in elem32) {
-        oprot.writeI32(elem33);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem35.length));
+      for(var elem36 in elem35) {
+        oprot.writeI32(elem36);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem34 = iD3;
+    final elem37 = iD3;
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
-    oprot.writeI64(elem34);
+    oprot.writeI64(elem37);
     oprot.writeFieldEnd();
-    final elem35 = bin_field;
+    final elem38 = bin_field;
     if (isSetBin_field()) {
       oprot.writeFieldBegin(_BIN_FIELD_FIELD_DESC);
-      oprot.writeBinary(elem35);
-      oprot.writeFieldEnd();
-    }
-    final elem36 = bin_field2;
-    if (isSetBin_field2()) {
-      oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
-      oprot.writeBinary(elem36);
-      oprot.writeFieldEnd();
-    }
-    final elem37 = bin_field3;
-    if (isSetBin_field3()) {
-      oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
-      oprot.writeBinary(elem37);
-      oprot.writeFieldEnd();
-    }
-    final elem38 = bin_field4;
-    if (isSetBin_field4()) {
-      oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
       oprot.writeBinary(elem38);
       oprot.writeFieldEnd();
     }
-    final elem39 = list2;
+    final elem39 = bin_field2;
+    if (isSetBin_field2()) {
+      oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
+      oprot.writeBinary(elem39);
+      oprot.writeFieldEnd();
+    }
+    final elem40 = bin_field3;
+    if (isSetBin_field3()) {
+      oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
+      oprot.writeBinary(elem40);
+      oprot.writeFieldEnd();
+    }
+    final elem41 = bin_field4;
+    if (isSetBin_field4()) {
+      oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
+      oprot.writeBinary(elem41);
+      oprot.writeFieldEnd();
+    }
+    final elem42 = list2;
     if (isSetList2()) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem39.length));
-      for(var elem40 in elem39) {
-        oprot.writeI32(elem40);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem42.length));
+      for(var elem43 in elem42) {
+        oprot.writeI32(elem43);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem41 = list3;
+    final elem44 = list3;
     if (isSetList3()) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem41.length));
-      for(var elem42 in elem41) {
-        oprot.writeI32(elem42);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem44.length));
+      for(var elem45 in elem44) {
+        oprot.writeI32(elem45);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem43 = list4;
+    final elem46 = list4;
     if (isSetList4()) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem43.length));
-      for(var elem44 in elem43) {
-        oprot.writeI32(elem44);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem46.length));
+      for(var elem47 in elem46) {
+        oprot.writeI32(elem47);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem45 = a_map;
+    final elem48 = a_map;
     if (isSetA_map()) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem45.length));
-      for(var elem46 in elem45.keys) {
-        final elem47 = elem45[elem46];
-        oprot.writeString(elem46);
-        oprot.writeString(elem47);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem48.length));
+      for(var elem49 in elem48.keys) {
+        final elem50 = elem48[elem49];
+        oprot.writeString(elem49);
+        oprot.writeString(elem50);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem48 = status;
+    final elem51 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem48);
+    oprot.writeI32(elem51);
     oprot.writeFieldEnd();
-    final elem49 = base_status;
+    final elem52 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(elem49);
+    oprot.writeI32(elem52);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
@@ -367,16 +367,18 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
-            this.ev1 = t_variety.Event();
-            ev1.read(iprot);
+            final tmp_ev1 = t_variety.Event();
+            this.ev1 = tmp_ev1;
+            tmp_ev1.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
-            this.ev2 = t_variety.Event();
-            ev2.read(iprot);
+            final tmp_ev2 = t_variety.Event();
+            this.ev2 = tmp_ev2;
+            tmp_ev2.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -404,14 +406,14 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LISTFIELD:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem0 = iprot.readListBegin();
-            final elem3 = <int>[];
-            for(int elem2 = 0; elem2 < elem0.length; ++elem2) {
-              int elem1 = iprot.readI32();
-              elem3.add(elem1);
+            thrift.TList elem5 = iprot.readListBegin();
+            final elem8 = <int>[];
+            for(int elem7 = 0; elem7 < elem5.length; ++elem7) {
+              int elem6 = iprot.readI32();
+              elem8.add(elem6);
             }
             iprot.readListEnd();
-            this.listfield = elem3;
+            this.listfield = elem8;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -453,57 +455,57 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LIST2:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem4 = iprot.readListBegin();
-            final elem7 = <int>[];
-            for(int elem6 = 0; elem6 < elem4.length; ++elem6) {
-              int elem5 = iprot.readI32();
-              elem7.add(elem5);
+            thrift.TList elem9 = iprot.readListBegin();
+            final elem12 = <int>[];
+            for(int elem11 = 0; elem11 < elem9.length; ++elem11) {
+              int elem10 = iprot.readI32();
+              elem12.add(elem10);
             }
             iprot.readListEnd();
-            this.list2 = elem7;
+            this.list2 = elem12;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST3:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem8 = iprot.readListBegin();
-            final elem11 = <int>[];
-            for(int elem10 = 0; elem10 < elem8.length; ++elem10) {
-              int elem9 = iprot.readI32();
-              elem11.add(elem9);
+            thrift.TList elem13 = iprot.readListBegin();
+            final elem16 = <int>[];
+            for(int elem15 = 0; elem15 < elem13.length; ++elem15) {
+              int elem14 = iprot.readI32();
+              elem16.add(elem14);
             }
             iprot.readListEnd();
-            this.list3 = elem11;
+            this.list3 = elem16;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST4:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem12 = iprot.readListBegin();
-            final elem15 = <int>[];
-            for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
-              int elem13 = iprot.readI32();
-              elem15.add(elem13);
+            thrift.TList elem17 = iprot.readListBegin();
+            final elem20 = <int>[];
+            for(int elem19 = 0; elem19 < elem17.length; ++elem19) {
+              int elem18 = iprot.readI32();
+              elem20.add(elem18);
             }
             iprot.readListEnd();
-            this.list4 = elem15;
+            this.list4 = elem20;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case A_MAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem16 = iprot.readMapBegin();
-            final elem19 = <String, String>{};
-            for(int elem18 = 0; elem18 < elem16.length; ++elem18) {
-              String elem20 = iprot.readString();
-              String elem17 = iprot.readString();
-              elem19[elem20] = elem17;
+            thrift.TMap elem21 = iprot.readMapBegin();
+            final elem24 = <String, String>{};
+            for(int elem23 = 0; elem23 < elem21.length; ++elem23) {
+              String elem25 = iprot.readString();
+              String elem22 = iprot.readString();
+              elem24[elem25] = elem22;
             }
             iprot.readMapEnd();
-            this.a_map = elem19;
+            this.a_map = elem24;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -538,113 +540,127 @@ class TestingDefaults implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem26 = iD2;
     if (isSetID2()) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
-      oprot.writeI64(this.iD2);
+      oprot.writeI64(elem26);
       oprot.writeFieldEnd();
     }
+    final elem27 = ev1;
     if (isSetEv1()) {
       oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      this.ev1.write(oprot);
+      elem27.write(oprot);
       oprot.writeFieldEnd();
     }
+    final elem28 = ev2;
     if (isSetEv2()) {
       oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      this.ev2.write(oprot);
+      elem28.write(oprot);
       oprot.writeFieldEnd();
     }
+    final elem29 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(this.iD);
+    oprot.writeI64(elem29);
     oprot.writeFieldEnd();
+    final elem30 = thing;
     if (isSetThing()) {
       oprot.writeFieldBegin(_THING_FIELD_DESC);
-      oprot.writeString(this.thing);
+      oprot.writeString(elem30);
       oprot.writeFieldEnd();
     }
+    final elem31 = thing2;
     if (isSetThing2()) {
       oprot.writeFieldBegin(_THING2_FIELD_DESC);
-      oprot.writeString(this.thing2);
+      oprot.writeString(elem31);
       oprot.writeFieldEnd();
     }
+    final elem32 = listfield;
     if (isSetListfield()) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
-      final temp = this.listfield;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem21 in temp) {
-        oprot.writeI32(elem21);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem32.length));
+      for(var elem33 in elem32) {
+        oprot.writeI32(elem33);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem34 = iD3;
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
-    oprot.writeI64(this.iD3);
+    oprot.writeI64(elem34);
     oprot.writeFieldEnd();
+    final elem35 = bin_field;
     if (isSetBin_field()) {
       oprot.writeFieldBegin(_BIN_FIELD_FIELD_DESC);
-      oprot.writeBinary(this.bin_field);
+      oprot.writeBinary(elem35);
       oprot.writeFieldEnd();
     }
+    final elem36 = bin_field2;
     if (isSetBin_field2()) {
       oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
-      oprot.writeBinary(this.bin_field2);
+      oprot.writeBinary(elem36);
       oprot.writeFieldEnd();
     }
+    final elem37 = bin_field3;
     if (isSetBin_field3()) {
       oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
-      oprot.writeBinary(this.bin_field3);
+      oprot.writeBinary(elem37);
       oprot.writeFieldEnd();
     }
+    final elem38 = bin_field4;
     if (isSetBin_field4()) {
       oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
-      oprot.writeBinary(this.bin_field4);
+      oprot.writeBinary(elem38);
       oprot.writeFieldEnd();
     }
+    final elem39 = list2;
     if (isSetList2()) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
-      final temp = this.list2;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem22 in temp) {
-        oprot.writeI32(elem22);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem39.length));
+      for(var elem40 in elem39) {
+        oprot.writeI32(elem40);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem41 = list3;
     if (isSetList3()) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
-      final temp = this.list3;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem23 in temp) {
-        oprot.writeI32(elem23);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem41.length));
+      for(var elem42 in elem41) {
+        oprot.writeI32(elem42);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem43 = list4;
     if (isSetList4()) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
-      final temp = this.list4;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem24 in temp) {
-        oprot.writeI32(elem24);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem43.length));
+      for(var elem44 in elem43) {
+        oprot.writeI32(elem44);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem45 = a_map;
     if (isSetA_map()) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
-      final temp = this.a_map;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, temp.length));
-      for(var elem25 in temp.keys) {
-        oprot.writeString(elem25);
-        oprot.writeString(temp[elem25]);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem45.length));
+      for(var elem46 in elem45.keys) {
+        final val = elem45[elem46];
+        oprot.writeString(elem46);
+        oprot.writeString(val);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
+    final elem47 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(this.status);
+    oprot.writeI32(elem47);
     oprot.writeFieldEnd();
+    final elem48 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(this.base_status);
+    oprot.writeI32(elem48);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
@@ -646,21 +646,20 @@ class TestingDefaults implements thrift.TBase {
     if (isSetA_map()) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
       oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem48.length));
-      for(var elem49 in elem48.keys) {
-        final elem50 = elem48[elem49];
-        oprot.writeString(elem49);
-        oprot.writeString(elem50);
+      for(var entry in elem48.entries) {
+        oprot.writeString(entry.key);
+        oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem51 = status;
+    final elem49 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem51);
+    oprot.writeI32(elem49);
     oprot.writeFieldEnd();
-    final elem52 = base_status;
+    final elem50 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(elem52);
+    oprot.writeI32(elem50);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
@@ -203,15 +203,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem133 = iprot.readMapBegin();
-            final elem136 = <int, String>{};
-            for(int elem135 = 0; elem135 < elem133.length; ++elem135) {
-              int elem137 = iprot.readI32();
-              String elem134 = iprot.readString();
-              elem136[elem137] = elem134;
+            thrift.TMap elem127 = iprot.readMapBegin();
+            final elem130 = <int, String>{};
+            for(int elem129 = 0; elem129 < elem127.length; ++elem129) {
+              int elem131 = iprot.readI32();
+              String elem128 = iprot.readString();
+              elem130[elem131] = elem128;
             }
             iprot.readMapEnd();
-            this.requests = elem136;
+            this.requests = elem130;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -254,59 +254,58 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem138 = anID;
+    final elem132 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(elem138);
+      oprot.writeI64(elem132);
       oprot.writeFieldEnd();
     }
-    final elem139 = aString;
+    final elem133 = aString;
     if (isSetAString()) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem139);
+      oprot.writeString(elem133);
       oprot.writeFieldEnd();
     }
-    final elem140 = someotherthing;
+    final elem134 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem140);
+      oprot.writeI32(elem134);
       oprot.writeFieldEnd();
     }
-    final elem141 = anInt16;
+    final elem135 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem141);
+      oprot.writeI16(elem135);
       oprot.writeFieldEnd();
     }
-    final elem142 = requests;
+    final elem136 = requests;
     if (isSetRequests()) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem142.length));
-      for(var elem143 in elem142.keys) {
-        final elem144 = elem142[elem143];
-        oprot.writeI32(elem143);
-        oprot.writeString(elem144);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem136.length));
+      for(var entry in elem136.entries) {
+        oprot.writeI32(entry.key);
+        oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem145 = bin_field_in_union;
+    final elem137 = bin_field_in_union;
     if (isSetBin_field_in_union()) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem145);
+      oprot.writeBinary(elem137);
       oprot.writeFieldEnd();
     }
-    final elem146 = depr;
+    final elem138 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem146);
+      oprot.writeBool(elem138);
       oprot.writeFieldEnd();
     }
-    final elem147 = wHOA_BUDDY;
+    final elem139 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem147);
+      oprot.writeBool(elem139);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
@@ -203,15 +203,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem119 = iprot.readMapBegin();
-            final elem122 = <int, String>{};
-            for(int elem121 = 0; elem121 < elem119.length; ++elem121) {
-              int elem123 = iprot.readI32();
-              String elem120 = iprot.readString();
-              elem122[elem123] = elem120;
+            thrift.TMap elem122 = iprot.readMapBegin();
+            final elem125 = <int, String>{};
+            for(int elem124 = 0; elem124 < elem122.length; ++elem124) {
+              int elem126 = iprot.readI32();
+              String elem123 = iprot.readString();
+              elem125[elem126] = elem123;
             }
             iprot.readMapEnd();
-            this.requests = elem122;
+            this.requests = elem125;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -254,59 +254,59 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem124 = anID;
+    final elem127 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(elem124);
+      oprot.writeI64(elem127);
       oprot.writeFieldEnd();
     }
-    final elem125 = aString;
+    final elem128 = aString;
     if (isSetAString()) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem125);
+      oprot.writeString(elem128);
       oprot.writeFieldEnd();
     }
-    final elem126 = someotherthing;
+    final elem129 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem126);
+      oprot.writeI32(elem129);
       oprot.writeFieldEnd();
     }
-    final elem127 = anInt16;
+    final elem130 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem127);
+      oprot.writeI16(elem130);
       oprot.writeFieldEnd();
     }
-    final elem128 = requests;
+    final elem131 = requests;
     if (isSetRequests()) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem128.length));
-      for(var elem129 in elem128.keys) {
-        final val = elem128[elem129];
-        oprot.writeI32(elem129);
-        oprot.writeString(val);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem131.length));
+      for(var elem132 in elem131.keys) {
+        final elem133 = elem131[elem132];
+        oprot.writeI32(elem132);
+        oprot.writeString(elem133);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem130 = bin_field_in_union;
+    final elem134 = bin_field_in_union;
     if (isSetBin_field_in_union()) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem130);
+      oprot.writeBinary(elem134);
       oprot.writeFieldEnd();
     }
-    final elem131 = depr;
+    final elem135 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem131);
+      oprot.writeBool(elem135);
       oprot.writeFieldEnd();
     }
-    final elem132 = wHOA_BUDDY;
+    final elem136 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem132);
+      oprot.writeBool(elem136);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
@@ -203,15 +203,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem122 = iprot.readMapBegin();
-            final elem125 = <int, String>{};
-            for(int elem124 = 0; elem124 < elem122.length; ++elem124) {
-              int elem126 = iprot.readI32();
-              String elem123 = iprot.readString();
-              elem125[elem126] = elem123;
+            thrift.TMap elem133 = iprot.readMapBegin();
+            final elem136 = <int, String>{};
+            for(int elem135 = 0; elem135 < elem133.length; ++elem135) {
+              int elem137 = iprot.readI32();
+              String elem134 = iprot.readString();
+              elem136[elem137] = elem134;
             }
             iprot.readMapEnd();
-            this.requests = elem125;
+            this.requests = elem136;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -254,59 +254,59 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem127 = anID;
+    final elem138 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(elem127);
+      oprot.writeI64(elem138);
       oprot.writeFieldEnd();
     }
-    final elem128 = aString;
+    final elem139 = aString;
     if (isSetAString()) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem128);
+      oprot.writeString(elem139);
       oprot.writeFieldEnd();
     }
-    final elem129 = someotherthing;
+    final elem140 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem129);
+      oprot.writeI32(elem140);
       oprot.writeFieldEnd();
     }
-    final elem130 = anInt16;
+    final elem141 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem130);
+      oprot.writeI16(elem141);
       oprot.writeFieldEnd();
     }
-    final elem131 = requests;
+    final elem142 = requests;
     if (isSetRequests()) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem131.length));
-      for(var elem132 in elem131.keys) {
-        final elem133 = elem131[elem132];
-        oprot.writeI32(elem132);
-        oprot.writeString(elem133);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem142.length));
+      for(var elem143 in elem142.keys) {
+        final elem144 = elem142[elem143];
+        oprot.writeI32(elem143);
+        oprot.writeString(elem144);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem134 = bin_field_in_union;
+    final elem145 = bin_field_in_union;
     if (isSetBin_field_in_union()) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem134);
+      oprot.writeBinary(elem145);
       oprot.writeFieldEnd();
     }
-    final elem135 = depr;
+    final elem146 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem135);
+      oprot.writeBool(elem146);
       oprot.writeFieldEnd();
     }
-    final elem136 = wHOA_BUDDY;
+    final elem147 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem136);
+      oprot.writeBool(elem147);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
@@ -203,15 +203,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem77 = iprot.readMapBegin();
-            final elem80 = <int, String>{};
-            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
-              int elem81 = iprot.readI32();
-              String elem78 = iprot.readString();
-              elem80[elem81] = elem78;
+            thrift.TMap elem119 = iprot.readMapBegin();
+            final elem122 = <int, String>{};
+            for(int elem121 = 0; elem121 < elem119.length; ++elem121) {
+              int elem123 = iprot.readI32();
+              String elem120 = iprot.readString();
+              elem122[elem123] = elem120;
             }
             iprot.readMapEnd();
-            this.requests = elem80;
+            this.requests = elem122;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -254,52 +254,59 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem124 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(this.anID);
+      oprot.writeI64(elem124);
       oprot.writeFieldEnd();
     }
+    final elem125 = aString;
     if (isSetAString()) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(this.aString);
+      oprot.writeString(elem125);
       oprot.writeFieldEnd();
     }
+    final elem126 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(this.someotherthing);
+      oprot.writeI32(elem126);
       oprot.writeFieldEnd();
     }
+    final elem127 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(this.anInt16);
+      oprot.writeI16(elem127);
       oprot.writeFieldEnd();
     }
+    final elem128 = requests;
     if (isSetRequests()) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      final temp = this.requests;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, temp.length));
-      for(var elem82 in temp.keys) {
-        oprot.writeI32(elem82);
-        oprot.writeString(temp[elem82]);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem128.length));
+      for(var elem129 in elem128.keys) {
+        final val = elem128[elem129];
+        oprot.writeI32(elem129);
+        oprot.writeString(val);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
+    final elem130 = bin_field_in_union;
     if (isSetBin_field_in_union()) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(this.bin_field_in_union);
+      oprot.writeBinary(elem130);
       oprot.writeFieldEnd();
     }
+    final elem131 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      // ignore: deprecated_member_use
-      oprot.writeBool(this.depr);
+      oprot.writeBool(elem131);
       oprot.writeFieldEnd();
     }
+    final elem132 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(this.wHOA_BUDDY);
+      oprot.writeBool(elem132);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_variety_constants.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_variety_constants.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:convert' show utf8;
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart/actual_base/f_actual_base_dart_constants.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_actual_base_dart_constants.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:convert' show utf8;
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart/actual_base/f_api_exception.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_api_exception.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart/actual_base/f_base_foo_service.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_base_foo_service.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
@@ -67,15 +67,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem99 = iprot.readListBegin();
-            final elem102 = <t_actual_base_dart.thing>[];
-            for(int elem101 = 0; elem101 < elem99.length; ++elem101) {
-              t_actual_base_dart.thing elem100 = t_actual_base_dart.thing();
-              elem100.read(iprot);
-              elem102.add(elem100);
+            thrift.TList elem170 = iprot.readListBegin();
+            final elem173 = <t_actual_base_dart.thing>[];
+            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
+              final tmp_elem171 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem171 = tmp_elem171;
+              tmp_elem171.read(iprot);
+              elem173.add(elem171);
             }
             iprot.readListEnd();
-            this.things = elem102;
+            this.things = elem173;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -96,12 +97,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.things != null) {
+    final elem174 = things;
+    if (elem174 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      final temp = this.things;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
-      for(var elem103 in temp) {
-        elem103.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem174.length));
+      for(var elem175 in elem174) {
+        elem175.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
@@ -67,16 +67,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem176 = iprot.readListBegin();
-            final elem179 = <t_actual_base_dart.thing>[];
-            for(int elem178 = 0; elem178 < elem176.length; ++elem178) {
-              final tmp_elem177 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem177 = tmp_elem177;
-              tmp_elem177.read(iprot);
-              elem179.add(elem177);
+            thrift.TList elem194 = iprot.readListBegin();
+            final elem198 = <t_actual_base_dart.thing>[];
+            for(int elem197 = 0; elem197 < elem194.length; ++elem197) {
+              final elem196 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem195 = elem196;
+              elem196.read(iprot);
+              elem198.add(elem195);
             }
             iprot.readListEnd();
-            this.things = elem179;
+            this.things = elem198;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -97,12 +97,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem180 = things;
-    if (elem180 != null) {
+    final elem199 = things;
+    if (elem199 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem180.length));
-      for(var elem181 in elem180) {
-        elem181.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem199.length));
+      for(var elem200 in elem199) {
+        elem200.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
@@ -67,16 +67,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem194 = iprot.readListBegin();
-            final elem198 = <t_actual_base_dart.thing>[];
-            for(int elem197 = 0; elem197 < elem194.length; ++elem197) {
-              final elem196 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem195 = elem196;
-              elem196.read(iprot);
-              elem198.add(elem195);
+            thrift.TList elem182 = iprot.readListBegin();
+            final elem186 = <t_actual_base_dart.thing>[];
+            for(int elem185 = 0; elem185 < elem182.length; ++elem185) {
+              final elem184 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem183 = elem184;
+              elem184.read(iprot);
+              elem186.add(elem183);
             }
             iprot.readListEnd();
-            this.things = elem198;
+            this.things = elem186;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -97,12 +97,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem199 = things;
-    if (elem199 != null) {
+    final elem187 = things;
+    if (elem187 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem199.length));
-      for(var elem200 in elem199) {
-        elem200.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem187.length));
+      for(var elem188 in elem187) {
+        elem188.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
@@ -67,16 +67,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem170 = iprot.readListBegin();
-            final elem173 = <t_actual_base_dart.thing>[];
-            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
-              final tmp_elem171 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem171 = tmp_elem171;
-              tmp_elem171.read(iprot);
-              elem173.add(elem171);
+            thrift.TList elem176 = iprot.readListBegin();
+            final elem179 = <t_actual_base_dart.thing>[];
+            for(int elem178 = 0; elem178 < elem176.length; ++elem178) {
+              final tmp_elem177 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem177 = tmp_elem177;
+              tmp_elem177.read(iprot);
+              elem179.add(elem177);
             }
             iprot.readListEnd();
-            this.things = elem173;
+            this.things = elem179;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -97,12 +97,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem174 = things;
-    if (elem174 != null) {
+    final elem180 = things;
+    if (elem180 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem174.length));
-      for(var elem175 in elem174) {
-        elem175.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem180.length));
+      for(var elem181 in elem180) {
+        elem181.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_thing.dart
@@ -126,12 +126,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem168 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(this.an_id);
+    oprot.writeI32(elem168);
     oprot.writeFieldEnd();
-    if (this.a_string != null) {
+    final elem169 = a_string;
+    if (elem169 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(this.a_string);
+      oprot.writeString(elem169);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_thing.dart
@@ -126,14 +126,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem168 = an_id;
+    final elem174 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem168);
+    oprot.writeI32(elem174);
     oprot.writeFieldEnd();
-    final elem169 = a_string;
-    if (elem169 != null) {
+    final elem175 = a_string;
+    if (elem175 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem169);
+      oprot.writeString(elem175);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_thing.dart
@@ -126,14 +126,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem174 = an_id;
+    final elem192 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem174);
+    oprot.writeI32(elem192);
     oprot.writeFieldEnd();
-    final elem175 = a_string;
-    if (elem175 != null) {
+    final elem193 = a_string;
+    if (elem193 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem175);
+      oprot.writeString(elem193);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_thing.dart
@@ -126,14 +126,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem192 = an_id;
+    final elem180 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem192);
+    oprot.writeI32(elem180);
     oprot.writeFieldEnd();
-    final elem193 = a_string;
-    if (elem193 != null) {
+    final elem181 = a_string;
+    if (elem181 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem193);
+      oprot.writeString(elem181);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_thing.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart/include_vendor/f_my_scope_scope.dart
+++ b/compiler/testdata/expected/dart/include_vendor/f_my_scope_scope.dart
@@ -95,9 +95,9 @@ class MyScopeSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final tmp_req = t_vendor_namespace.Item();
-      t_vendor_namespace.Item req = tmp_req;
-      tmp_req.read(iprot);
+      final elem4 = t_vendor_namespace.Item();
+      t_vendor_namespace.Item req = elem4;
+      elem4.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }

--- a/compiler/testdata/expected/dart/include_vendor/f_my_scope_scope.dart
+++ b/compiler/testdata/expected/dart/include_vendor/f_my_scope_scope.dart
@@ -95,8 +95,9 @@ class MyScopeSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      t_vendor_namespace.Item req = t_vendor_namespace.Item();
-      req.read(iprot);
+      final tmp_req = t_vendor_namespace.Item();
+      t_vendor_namespace.Item req = tmp_req;
+      tmp_req.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }

--- a/compiler/testdata/expected/dart/include_vendor/f_my_scope_scope.dart
+++ b/compiler/testdata/expected/dart/include_vendor/f_my_scope_scope.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
@@ -59,9 +57,7 @@ class MyScopePublisher {
     oprot.writeMessageBegin(msg);
     req.write(oprot);
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 }
 

--- a/compiler/testdata/expected/dart/include_vendor/f_my_service_service.dart
+++ b/compiler/testdata/expected/dart/include_vendor/f_my_service_service.dart
@@ -115,18 +115,18 @@ class getItem_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_success = t_vendor_namespace.Item();
-            this.success = tmp_success;
-            tmp_success.read(iprot);
+            final elem2 = t_vendor_namespace.Item();
+            this.success = elem2;
+            elem2.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_d = t_excepts.InvalidData();
-            this.d = tmp_d;
-            tmp_d.read(iprot);
+            final elem3 = t_excepts.InvalidData();
+            this.d = elem3;
+            elem3.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }

--- a/compiler/testdata/expected/dart/include_vendor/f_my_service_service.dart
+++ b/compiler/testdata/expected/dart/include_vendor/f_my_service_service.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart/include_vendor/f_my_service_service.dart
+++ b/compiler/testdata/expected/dart/include_vendor/f_my_service_service.dart
@@ -115,16 +115,18 @@ class getItem_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            this.success = t_vendor_namespace.Item();
-            success.read(iprot);
+            final tmp_success = t_vendor_namespace.Item();
+            this.success = tmp_success;
+            tmp_success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            this.d = t_excepts.InvalidData();
-            d.read(iprot);
+            final tmp_d = t_excepts.InvalidData();
+            this.d = tmp_d;
+            tmp_d.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }

--- a/compiler/testdata/expected/dart/include_vendor/f_vendored_references.dart
+++ b/compiler/testdata/expected/dart/include_vendor/f_vendored_references.dart
@@ -145,14 +145,16 @@ class VendoredReferences implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem0 = reference_vendored_const;
     if (isSetReference_vendored_const()) {
       oprot.writeFieldBegin(_REFERENCE_VENDORED_CONST_FIELD_DESC);
-      oprot.writeI32(this.reference_vendored_const);
+      oprot.writeI32(elem0);
       oprot.writeFieldEnd();
     }
+    final elem1 = reference_vendored_enum;
     if (isSetReference_vendored_enum()) {
       oprot.writeFieldBegin(_REFERENCE_VENDORED_ENUM_FIELD_DESC);
-      oprot.writeI32(this.reference_vendored_enum);
+      oprot.writeI32(elem1);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/include_vendor/f_vendored_references.dart
+++ b/compiler/testdata/expected/dart/include_vendor/f_vendored_references.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
@@ -184,19 +184,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem148 = iD;
+    final elem140 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem148);
+    oprot.writeI64(elem140);
     oprot.writeFieldEnd();
-    final elem149 = reason;
-    if (elem149 != null) {
+    final elem141 = reason;
+    if (elem141 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem149);
+      oprot.writeString(elem141);
       oprot.writeFieldEnd();
     }
-    final elem150 = depr;
+    final elem142 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem150);
+    oprot.writeBool(elem142);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
@@ -184,19 +184,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem137 = iD;
+    final elem148 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem137);
+    oprot.writeI64(elem148);
     oprot.writeFieldEnd();
-    final elem138 = reason;
-    if (elem138 != null) {
+    final elem149 = reason;
+    if (elem149 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem138);
+      oprot.writeString(elem149);
       oprot.writeFieldEnd();
     }
-    final elem139 = depr;
+    final elem150 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem139);
+    oprot.writeBool(elem150);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
@@ -184,19 +184,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem133 = iD;
+    final elem137 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem133);
+    oprot.writeI64(elem137);
     oprot.writeFieldEnd();
-    final elem134 = reason;
-    if (elem134 != null) {
+    final elem138 = reason;
+    if (elem138 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem134);
+      oprot.writeString(elem138);
       oprot.writeFieldEnd();
     }
-    final elem135 = depr;
+    final elem139 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem135);
+    oprot.writeBool(elem139);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
@@ -184,17 +184,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem133 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(this.iD);
+    oprot.writeI64(elem133);
     oprot.writeFieldEnd();
-    if (this.reason != null) {
+    final elem134 = reason;
+    if (elem134 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(this.reason);
+      oprot.writeString(elem134);
       oprot.writeFieldEnd();
     }
+    final elem135 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    // ignore: deprecated_member_use
-    oprot.writeBool(this.depr);
+    oprot.writeBool(elem135);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart/variety/f_event.dart
+++ b/compiler/testdata/expected/dart/variety/f_event.dart
@@ -180,19 +180,19 @@ class Event implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem2 = iD;
+    final elem3 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem2);
+    oprot.writeI64(elem3);
     oprot.writeFieldEnd();
-    final elem3 = message;
-    if (elem3 != null) {
+    final elem4 = message;
+    if (elem4 != null) {
       oprot.writeFieldBegin(_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem3);
+      oprot.writeString(elem4);
       oprot.writeFieldEnd();
     }
-    final elem4 = yES_NO;
+    final elem5 = yES_NO;
     oprot.writeFieldBegin(_YE_S__NO_FIELD_DESC);
-    oprot.writeBool(elem4);
+    oprot.writeBool(elem5);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_event.dart
+++ b/compiler/testdata/expected/dart/variety/f_event.dart
@@ -180,16 +180,19 @@ class Event implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem2 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(this.iD);
+    oprot.writeI64(elem2);
     oprot.writeFieldEnd();
-    if (this.message != null) {
+    final elem3 = message;
+    if (elem3 != null) {
       oprot.writeFieldBegin(_MESSAGE_FIELD_DESC);
-      oprot.writeString(this.message);
+      oprot.writeString(elem3);
       oprot.writeFieldEnd();
     }
+    final elem4 = yES_NO;
     oprot.writeFieldBegin(_YE_S__NO_FIELD_DESC);
-    oprot.writeBool(this.yES_NO);
+    oprot.writeBool(elem4);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_event.dart
+++ b/compiler/testdata/expected/dart/variety/f_event.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
@@ -462,92 +462,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_ev = t_variety.Event();
-            this.ev = tmp_ev;
-            tmp_ev.read(iprot);
+            final elem53 = t_variety.Event();
+            this.ev = elem53;
+            elem53.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem50 = iprot.readListBegin();
-            final elem53 = <t_variety.Event>[];
-            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
-              final tmp_elem51 = t_variety.Event();
-              t_variety.Event elem51 = tmp_elem51;
-              tmp_elem51.read(iprot);
-              elem53.add(elem51);
+            thrift.TList elem54 = iprot.readListBegin();
+            final elem58 = <t_variety.Event>[];
+            for(int elem57 = 0; elem57 < elem54.length; ++elem57) {
+              final elem56 = t_variety.Event();
+              t_variety.Event elem55 = elem56;
+              elem56.read(iprot);
+              elem58.add(elem55);
             }
             iprot.readListEnd();
-            this.events = elem53;
+            this.events = elem58;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem54 = iprot.readSetBegin();
-            final elem57 = <t_variety.Event>{};
-            for(int elem56 = 0; elem56 < elem54.length; ++elem56) {
-              final tmp_elem55 = t_variety.Event();
-              t_variety.Event elem55 = tmp_elem55;
-              tmp_elem55.read(iprot);
-              elem57.add(elem55);
+            thrift.TSet elem59 = iprot.readSetBegin();
+            final elem63 = <t_variety.Event>{};
+            for(int elem62 = 0; elem62 < elem59.length; ++elem62) {
+              final elem61 = t_variety.Event();
+              t_variety.Event elem60 = elem61;
+              elem61.read(iprot);
+              elem63.add(elem60);
             }
             iprot.readSetEnd();
-            this.events2 = elem57;
+            this.events2 = elem63;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem58 = iprot.readMapBegin();
-            final elem61 = <int, t_variety.Event>{};
-            for(int elem60 = 0; elem60 < elem58.length; ++elem60) {
-              int elem62 = iprot.readI64();
-              final tmp_elem59 = t_variety.Event();
-              t_variety.Event elem59 = tmp_elem59;
-              tmp_elem59.read(iprot);
-              elem61[elem62] = elem59;
+            thrift.TMap elem64 = iprot.readMapBegin();
+            final elem68 = <int, t_variety.Event>{};
+            for(int elem67 = 0; elem67 < elem64.length; ++elem67) {
+              int elem69 = iprot.readI64();
+              final elem66 = t_variety.Event();
+              t_variety.Event elem65 = elem66;
+              elem66.read(iprot);
+              elem68[elem69] = elem65;
             }
             iprot.readMapEnd();
-            this.eventMap = elem61;
+            this.eventMap = elem68;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem63 = iprot.readListBegin();
-            final elem69 = <List<int>>[];
-            for(int elem68 = 0; elem68 < elem63.length; ++elem68) {
-              thrift.TList elem65 = iprot.readListBegin();
-              final elem64 = <int>[];
-              for(int elem67 = 0; elem67 < elem65.length; ++elem67) {
-                int elem66 = iprot.readI32();
-                elem64.add(elem66);
+            thrift.TList elem70 = iprot.readListBegin();
+            final elem76 = <List<int>>[];
+            for(int elem75 = 0; elem75 < elem70.length; ++elem75) {
+              thrift.TList elem72 = iprot.readListBegin();
+              final elem71 = <int>[];
+              for(int elem74 = 0; elem74 < elem72.length; ++elem74) {
+                int elem73 = iprot.readI32();
+                elem71.add(elem73);
               }
               iprot.readListEnd();
-              elem69.add(elem64);
+              elem76.add(elem71);
             }
             iprot.readListEnd();
-            this.nums = elem69;
+            this.nums = elem76;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem70 = iprot.readListBegin();
-            final elem73 = <int>[];
-            for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
-              int elem71 = iprot.readI32();
-              elem73.add(elem71);
+            thrift.TList elem77 = iprot.readListBegin();
+            final elem80 = <int>[];
+            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
+              int elem78 = iprot.readI32();
+              elem80.add(elem78);
             }
             iprot.readListEnd();
-            this.enums = elem73;
+            this.enums = elem80;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -562,9 +562,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_a_union = t_variety.TestingUnions();
-            this.a_union = tmp_a_union;
-            tmp_a_union.read(iprot);
+            final elem81 = t_variety.TestingUnions();
+            this.a_union = elem81;
+            elem81.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -595,65 +595,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem74 = iprot.readListBegin();
+            thrift.TList elem82 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem77 = <bool>[];
-            for(int elem76 = 0; elem76 < elem74.length; ++elem76) {
-              bool elem75 = iprot.readBool();
+            final elem85 = <bool>[];
+            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
+              bool elem83 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem77.add(elem75);
+              elem85.add(elem83);
             }
             iprot.readListEnd();
-            this.deprList = elem77;
+            this.deprList = elem85;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem78 = iprot.readListBegin();
-            final elem81 = <t_variety.Event>[];
-            for(int elem80 = 0; elem80 < elem78.length; ++elem80) {
-              final tmp_elem79 = t_variety.Event();
-              t_variety.Event elem79 = tmp_elem79;
-              tmp_elem79.read(iprot);
-              elem81.add(elem79);
+            thrift.TList elem86 = iprot.readListBegin();
+            final elem90 = <t_variety.Event>[];
+            for(int elem89 = 0; elem89 < elem86.length; ++elem89) {
+              final elem88 = t_variety.Event();
+              t_variety.Event elem87 = elem88;
+              elem88.read(iprot);
+              elem90.add(elem87);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem81;
+            this.eventsDefault = elem90;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem82 = iprot.readMapBegin();
-            final elem85 = <int, t_variety.Event>{};
-            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
-              int elem86 = iprot.readI64();
-              final tmp_elem83 = t_variety.Event();
-              t_variety.Event elem83 = tmp_elem83;
-              tmp_elem83.read(iprot);
-              elem85[elem86] = elem83;
+            thrift.TMap elem91 = iprot.readMapBegin();
+            final elem95 = <int, t_variety.Event>{};
+            for(int elem94 = 0; elem94 < elem91.length; ++elem94) {
+              int elem96 = iprot.readI64();
+              final elem93 = t_variety.Event();
+              t_variety.Event elem92 = elem93;
+              elem93.read(iprot);
+              elem95[elem96] = elem92;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem85;
+            this.eventMapDefault = elem95;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem87 = iprot.readSetBegin();
-            final elem90 = <t_variety.Event>{};
-            for(int elem89 = 0; elem89 < elem87.length; ++elem89) {
-              final tmp_elem88 = t_variety.Event();
-              t_variety.Event elem88 = tmp_elem88;
-              tmp_elem88.read(iprot);
-              elem90.add(elem88);
+            thrift.TSet elem97 = iprot.readSetBegin();
+            final elem101 = <t_variety.Event>{};
+            for(int elem100 = 0; elem100 < elem97.length; ++elem100) {
+              final elem99 = t_variety.Event();
+              t_variety.Event elem98 = elem99;
+              elem99.read(iprot);
+              elem101.add(elem98);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem90;
+            this.eventSetDefault = elem101;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -674,140 +674,140 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem91 = iD;
+    final elem102 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(elem91);
+      oprot.writeI64(elem102);
       oprot.writeFieldEnd();
     }
-    final elem92 = ev;
-    if (elem92 != null) {
+    final elem103 = ev;
+    if (elem103 != null) {
       oprot.writeFieldBegin(_EV_FIELD_DESC);
-      elem92.write(oprot);
+      elem103.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem93 = events;
-    if (elem93 != null) {
+    final elem104 = events;
+    if (elem104 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem93.length));
-      for(var elem94 in elem93) {
-        elem94.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem104.length));
+      for(var elem105 in elem104) {
+        elem105.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem95 = events2;
-    if (elem95 != null) {
+    final elem106 = events2;
+    if (elem106 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem95.length));
-      for(var elem96 in elem95) {
-        elem96.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem106.length));
+      for(var elem107 in elem106) {
+        elem107.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem97 = eventMap;
-    if (elem97 != null) {
+    final elem108 = eventMap;
+    if (elem108 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem97.length));
-      for(var elem98 in elem97.keys) {
-        final elem99 = elem97[elem98];
-        oprot.writeI64(elem98);
-        elem99.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem108.length));
+      for(var elem109 in elem108.keys) {
+        final elem110 = elem108[elem109];
+        oprot.writeI64(elem109);
+        elem110.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem100 = nums;
-    if (elem100 != null) {
+    final elem111 = nums;
+    if (elem111 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem100.length));
-      for(var elem101 in elem100) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
-        for(var elem102 in elem101) {
-          oprot.writeI32(elem102);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem111.length));
+      for(var elem112 in elem111) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem112.length));
+        for(var elem113 in elem112) {
+          oprot.writeI32(elem113);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem103 = enums;
-    if (elem103 != null) {
+    final elem114 = enums;
+    if (elem114 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem103.length));
-      for(var elem104 in elem103) {
-        oprot.writeI32(elem104);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem114.length));
+      for(var elem115 in elem114) {
+        oprot.writeI32(elem115);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem105 = aBoolField;
+    final elem116 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem105);
+    oprot.writeBool(elem116);
     oprot.writeFieldEnd();
-    final elem106 = a_union;
-    if (elem106 != null) {
+    final elem117 = a_union;
+    if (elem117 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem106.write(oprot);
+      elem117.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem107 = typedefOfTypedef;
-    if (elem107 != null) {
+    final elem118 = typedefOfTypedef;
+    if (elem118 != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem107);
+      oprot.writeString(elem118);
       oprot.writeFieldEnd();
     }
-    final elem108 = depr;
+    final elem119 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem108);
+    oprot.writeBool(elem119);
     oprot.writeFieldEnd();
-    final elem109 = deprBinary;
+    final elem120 = deprBinary;
     // ignore: deprecated_member_use
-    if (elem109 != null) {
+    if (elem120 != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem109);
+      oprot.writeBinary(elem120);
       oprot.writeFieldEnd();
     }
-    final elem110 = deprList;
+    final elem121 = deprList;
     // ignore: deprecated_member_use
-    if (elem110 != null) {
+    if (elem121 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem110.length));
-      for(var elem111 in elem110) {
-        oprot.writeBool(elem111);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem121.length));
+      for(var elem122 in elem121) {
+        oprot.writeBool(elem122);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem112 = eventsDefault;
-    if (isSetEventsDefault() && elem112 != null) {
+    final elem123 = eventsDefault;
+    if (isSetEventsDefault() && elem123 != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem112.length));
-      for(var elem113 in elem112) {
-        elem113.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem123.length));
+      for(var elem124 in elem123) {
+        elem124.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem114 = eventMapDefault;
-    if (isSetEventMapDefault() && elem114 != null) {
+    final elem125 = eventMapDefault;
+    if (isSetEventMapDefault() && elem125 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem114.length));
-      for(var elem115 in elem114.keys) {
-        final elem116 = elem114[elem115];
-        oprot.writeI64(elem115);
-        elem116.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem125.length));
+      for(var elem126 in elem125.keys) {
+        final elem127 = elem125[elem126];
+        oprot.writeI64(elem126);
+        elem127.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem117 = eventSetDefault;
-    if (isSetEventSetDefault() && elem117 != null) {
+    final elem128 = eventSetDefault;
+    if (isSetEventSetDefault() && elem128 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem117.length));
-      for(var elem118 in elem117) {
-        elem118.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem128.length));
+      for(var elem129 in elem128) {
+        elem129.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
@@ -471,83 +471,83 @@ class EventWrapper implements thrift.TBase {
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem49 = iprot.readListBegin();
-            final elem52 = <t_variety.Event>[];
-            for(int elem51 = 0; elem51 < elem49.length; ++elem51) {
-              final tmp_elem50 = t_variety.Event();
-              t_variety.Event elem50 = tmp_elem50;
-              tmp_elem50.read(iprot);
-              elem52.add(elem50);
+            thrift.TList elem50 = iprot.readListBegin();
+            final elem53 = <t_variety.Event>[];
+            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
+              final tmp_elem51 = t_variety.Event();
+              t_variety.Event elem51 = tmp_elem51;
+              tmp_elem51.read(iprot);
+              elem53.add(elem51);
             }
             iprot.readListEnd();
-            this.events = elem52;
+            this.events = elem53;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem53 = iprot.readSetBegin();
-            final elem56 = <t_variety.Event>{};
-            for(int elem55 = 0; elem55 < elem53.length; ++elem55) {
-              final tmp_elem54 = t_variety.Event();
-              t_variety.Event elem54 = tmp_elem54;
-              tmp_elem54.read(iprot);
-              elem56.add(elem54);
+            thrift.TSet elem54 = iprot.readSetBegin();
+            final elem57 = <t_variety.Event>{};
+            for(int elem56 = 0; elem56 < elem54.length; ++elem56) {
+              final tmp_elem55 = t_variety.Event();
+              t_variety.Event elem55 = tmp_elem55;
+              tmp_elem55.read(iprot);
+              elem57.add(elem55);
             }
             iprot.readSetEnd();
-            this.events2 = elem56;
+            this.events2 = elem57;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem57 = iprot.readMapBegin();
-            final elem60 = <int, t_variety.Event>{};
-            for(int elem59 = 0; elem59 < elem57.length; ++elem59) {
-              int elem61 = iprot.readI64();
-              final tmp_elem58 = t_variety.Event();
-              t_variety.Event elem58 = tmp_elem58;
-              tmp_elem58.read(iprot);
-              elem60[elem61] = elem58;
+            thrift.TMap elem58 = iprot.readMapBegin();
+            final elem61 = <int, t_variety.Event>{};
+            for(int elem60 = 0; elem60 < elem58.length; ++elem60) {
+              int elem62 = iprot.readI64();
+              final tmp_elem59 = t_variety.Event();
+              t_variety.Event elem59 = tmp_elem59;
+              tmp_elem59.read(iprot);
+              elem61[elem62] = elem59;
             }
             iprot.readMapEnd();
-            this.eventMap = elem60;
+            this.eventMap = elem61;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem62 = iprot.readListBegin();
-            final elem68 = <List<int>>[];
-            for(int elem67 = 0; elem67 < elem62.length; ++elem67) {
-              thrift.TList elem64 = iprot.readListBegin();
-              final elem63 = <int>[];
-              for(int elem66 = 0; elem66 < elem64.length; ++elem66) {
-                int elem65 = iprot.readI32();
-                elem63.add(elem65);
+            thrift.TList elem63 = iprot.readListBegin();
+            final elem69 = <List<int>>[];
+            for(int elem68 = 0; elem68 < elem63.length; ++elem68) {
+              thrift.TList elem65 = iprot.readListBegin();
+              final elem64 = <int>[];
+              for(int elem67 = 0; elem67 < elem65.length; ++elem67) {
+                int elem66 = iprot.readI32();
+                elem64.add(elem66);
               }
               iprot.readListEnd();
-              elem68.add(elem63);
+              elem69.add(elem64);
             }
             iprot.readListEnd();
-            this.nums = elem68;
+            this.nums = elem69;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem69 = iprot.readListBegin();
-            final elem72 = <int>[];
-            for(int elem71 = 0; elem71 < elem69.length; ++elem71) {
-              int elem70 = iprot.readI32();
-              elem72.add(elem70);
+            thrift.TList elem70 = iprot.readListBegin();
+            final elem73 = <int>[];
+            for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
+              int elem71 = iprot.readI32();
+              elem73.add(elem71);
             }
             iprot.readListEnd();
-            this.enums = elem72;
+            this.enums = elem73;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -595,65 +595,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem73 = iprot.readListBegin();
+            thrift.TList elem74 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem76 = <bool>[];
-            for(int elem75 = 0; elem75 < elem73.length; ++elem75) {
-              bool elem74 = iprot.readBool();
+            final elem77 = <bool>[];
+            for(int elem76 = 0; elem76 < elem74.length; ++elem76) {
+              bool elem75 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem76.add(elem74);
+              elem77.add(elem75);
             }
             iprot.readListEnd();
-            this.deprList = elem76;
+            this.deprList = elem77;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem77 = iprot.readListBegin();
-            final elem80 = <t_variety.Event>[];
-            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
-              final tmp_elem78 = t_variety.Event();
-              t_variety.Event elem78 = tmp_elem78;
-              tmp_elem78.read(iprot);
-              elem80.add(elem78);
+            thrift.TList elem78 = iprot.readListBegin();
+            final elem81 = <t_variety.Event>[];
+            for(int elem80 = 0; elem80 < elem78.length; ++elem80) {
+              final tmp_elem79 = t_variety.Event();
+              t_variety.Event elem79 = tmp_elem79;
+              tmp_elem79.read(iprot);
+              elem81.add(elem79);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem80;
+            this.eventsDefault = elem81;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem81 = iprot.readMapBegin();
-            final elem84 = <int, t_variety.Event>{};
-            for(int elem83 = 0; elem83 < elem81.length; ++elem83) {
-              int elem85 = iprot.readI64();
-              final tmp_elem82 = t_variety.Event();
-              t_variety.Event elem82 = tmp_elem82;
-              tmp_elem82.read(iprot);
-              elem84[elem85] = elem82;
+            thrift.TMap elem82 = iprot.readMapBegin();
+            final elem85 = <int, t_variety.Event>{};
+            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
+              int elem86 = iprot.readI64();
+              final tmp_elem83 = t_variety.Event();
+              t_variety.Event elem83 = tmp_elem83;
+              tmp_elem83.read(iprot);
+              elem85[elem86] = elem83;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem84;
+            this.eventMapDefault = elem85;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem86 = iprot.readSetBegin();
-            final elem89 = <t_variety.Event>{};
-            for(int elem88 = 0; elem88 < elem86.length; ++elem88) {
-              final tmp_elem87 = t_variety.Event();
-              t_variety.Event elem87 = tmp_elem87;
-              tmp_elem87.read(iprot);
-              elem89.add(elem87);
+            thrift.TSet elem87 = iprot.readSetBegin();
+            final elem90 = <t_variety.Event>{};
+            for(int elem89 = 0; elem89 < elem87.length; ++elem89) {
+              final tmp_elem88 = t_variety.Event();
+              t_variety.Event elem88 = tmp_elem88;
+              tmp_elem88.read(iprot);
+              elem90.add(elem88);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem89;
+            this.eventSetDefault = elem90;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -674,140 +674,140 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem90 = iD;
+    final elem91 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(elem90);
+      oprot.writeI64(elem91);
       oprot.writeFieldEnd();
     }
-    final elem91 = ev;
-    if (elem91 != null) {
-      oprot.writeFieldBegin(_EV_FIELD_DESC);
-      elem91.write(oprot);
-      oprot.writeFieldEnd();
-    }
-    final elem92 = events;
+    final elem92 = ev;
     if (elem92 != null) {
+      oprot.writeFieldBegin(_EV_FIELD_DESC);
+      elem92.write(oprot);
+      oprot.writeFieldEnd();
+    }
+    final elem93 = events;
+    if (elem93 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem92.length));
-      for(var elem93 in elem92) {
-        elem93.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem93.length));
+      for(var elem94 in elem93) {
+        elem94.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem94 = events2;
-    if (elem94 != null) {
+    final elem95 = events2;
+    if (elem95 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem94.length));
-      for(var elem95 in elem94) {
-        elem95.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem95.length));
+      for(var elem96 in elem95) {
+        elem96.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem96 = eventMap;
-    if (elem96 != null) {
+    final elem97 = eventMap;
+    if (elem97 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem96.length));
-      for(var elem97 in elem96.keys) {
-        final val = elem96[elem97];
-        oprot.writeI64(elem97);
-        val.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem97.length));
+      for(var elem98 in elem97.keys) {
+        final elem99 = elem97[elem98];
+        oprot.writeI64(elem98);
+        elem99.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem98 = nums;
-    if (elem98 != null) {
+    final elem100 = nums;
+    if (elem100 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem98.length));
-      for(var elem99 in elem98) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem99.length));
-        for(var elem100 in elem99) {
-          oprot.writeI32(elem100);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem100.length));
+      for(var elem101 in elem100) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
+        for(var elem102 in elem101) {
+          oprot.writeI32(elem102);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem101 = enums;
-    if (elem101 != null) {
+    final elem103 = enums;
+    if (elem103 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
-      for(var elem102 in elem101) {
-        oprot.writeI32(elem102);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem103.length));
+      for(var elem104 in elem103) {
+        oprot.writeI32(elem104);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem103 = aBoolField;
+    final elem105 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem103);
+    oprot.writeBool(elem105);
     oprot.writeFieldEnd();
-    final elem104 = a_union;
-    if (elem104 != null) {
+    final elem106 = a_union;
+    if (elem106 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem104.write(oprot);
+      elem106.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem105 = typedefOfTypedef;
-    if (elem105 != null) {
-      oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem105);
-      oprot.writeFieldEnd();
-    }
-    final elem106 = depr;
-    oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem106);
-    oprot.writeFieldEnd();
-    final elem107 = deprBinary;
-    // ignore: deprecated_member_use
+    final elem107 = typedefOfTypedef;
     if (elem107 != null) {
-      oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem107);
+      oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
+      oprot.writeString(elem107);
       oprot.writeFieldEnd();
     }
-    final elem108 = deprList;
+    final elem108 = depr;
+    oprot.writeFieldBegin(_DEPR_FIELD_DESC);
+    oprot.writeBool(elem108);
+    oprot.writeFieldEnd();
+    final elem109 = deprBinary;
     // ignore: deprecated_member_use
-    if (elem108 != null) {
+    if (elem109 != null) {
+      oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
+      oprot.writeBinary(elem109);
+      oprot.writeFieldEnd();
+    }
+    final elem110 = deprList;
+    // ignore: deprecated_member_use
+    if (elem110 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem108.length));
-      for(var elem109 in elem108) {
-        oprot.writeBool(elem109);
-      }
-      oprot.writeListEnd();
-      oprot.writeFieldEnd();
-    }
-    final elem110 = eventsDefault;
-    if (isSetEventsDefault() && elem110 != null) {
-      oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem110.length));
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem110.length));
       for(var elem111 in elem110) {
-        elem111.write(oprot);
+        oprot.writeBool(elem111);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem112 = eventMapDefault;
-    if (isSetEventMapDefault() && elem112 != null) {
+    final elem112 = eventsDefault;
+    if (isSetEventsDefault() && elem112 != null) {
+      oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem112.length));
+      for(var elem113 in elem112) {
+        elem113.write(oprot);
+      }
+      oprot.writeListEnd();
+      oprot.writeFieldEnd();
+    }
+    final elem114 = eventMapDefault;
+    if (isSetEventMapDefault() && elem114 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem112.length));
-      for(var elem113 in elem112.keys) {
-        final val = elem112[elem113];
-        oprot.writeI64(elem113);
-        val.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem114.length));
+      for(var elem115 in elem114.keys) {
+        final elem116 = elem114[elem115];
+        oprot.writeI64(elem115);
+        elem116.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem114 = eventSetDefault;
-    if (isSetEventSetDefault() && elem114 != null) {
+    final elem117 = eventSetDefault;
+    if (isSetEventSetDefault() && elem117 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem114.length));
-      for(var elem115 in elem114) {
-        elem115.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem117.length));
+      for(var elem118 in elem117) {
+        elem118.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
@@ -462,92 +462,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            final elem53 = t_variety.Event();
-            this.ev = elem53;
-            elem53.read(iprot);
+            final elem51 = t_variety.Event();
+            this.ev = elem51;
+            elem51.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem54 = iprot.readListBegin();
-            final elem58 = <t_variety.Event>[];
-            for(int elem57 = 0; elem57 < elem54.length; ++elem57) {
-              final elem56 = t_variety.Event();
-              t_variety.Event elem55 = elem56;
-              elem56.read(iprot);
-              elem58.add(elem55);
+            thrift.TList elem52 = iprot.readListBegin();
+            final elem56 = <t_variety.Event>[];
+            for(int elem55 = 0; elem55 < elem52.length; ++elem55) {
+              final elem54 = t_variety.Event();
+              t_variety.Event elem53 = elem54;
+              elem54.read(iprot);
+              elem56.add(elem53);
             }
             iprot.readListEnd();
-            this.events = elem58;
+            this.events = elem56;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem59 = iprot.readSetBegin();
-            final elem63 = <t_variety.Event>{};
-            for(int elem62 = 0; elem62 < elem59.length; ++elem62) {
-              final elem61 = t_variety.Event();
-              t_variety.Event elem60 = elem61;
-              elem61.read(iprot);
-              elem63.add(elem60);
+            thrift.TSet elem57 = iprot.readSetBegin();
+            final elem61 = <t_variety.Event>{};
+            for(int elem60 = 0; elem60 < elem57.length; ++elem60) {
+              final elem59 = t_variety.Event();
+              t_variety.Event elem58 = elem59;
+              elem59.read(iprot);
+              elem61.add(elem58);
             }
             iprot.readSetEnd();
-            this.events2 = elem63;
+            this.events2 = elem61;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem64 = iprot.readMapBegin();
-            final elem68 = <int, t_variety.Event>{};
-            for(int elem67 = 0; elem67 < elem64.length; ++elem67) {
-              int elem69 = iprot.readI64();
-              final elem66 = t_variety.Event();
-              t_variety.Event elem65 = elem66;
-              elem66.read(iprot);
-              elem68[elem69] = elem65;
+            thrift.TMap elem62 = iprot.readMapBegin();
+            final elem66 = <int, t_variety.Event>{};
+            for(int elem65 = 0; elem65 < elem62.length; ++elem65) {
+              int elem67 = iprot.readI64();
+              final elem64 = t_variety.Event();
+              t_variety.Event elem63 = elem64;
+              elem64.read(iprot);
+              elem66[elem67] = elem63;
             }
             iprot.readMapEnd();
-            this.eventMap = elem68;
+            this.eventMap = elem66;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem70 = iprot.readListBegin();
-            final elem76 = <List<int>>[];
-            for(int elem75 = 0; elem75 < elem70.length; ++elem75) {
-              thrift.TList elem72 = iprot.readListBegin();
-              final elem71 = <int>[];
-              for(int elem74 = 0; elem74 < elem72.length; ++elem74) {
-                int elem73 = iprot.readI32();
-                elem71.add(elem73);
+            thrift.TList elem68 = iprot.readListBegin();
+            final elem74 = <List<int>>[];
+            for(int elem73 = 0; elem73 < elem68.length; ++elem73) {
+              thrift.TList elem70 = iprot.readListBegin();
+              final elem69 = <int>[];
+              for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
+                int elem71 = iprot.readI32();
+                elem69.add(elem71);
               }
               iprot.readListEnd();
-              elem76.add(elem71);
+              elem74.add(elem69);
             }
             iprot.readListEnd();
-            this.nums = elem76;
+            this.nums = elem74;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem77 = iprot.readListBegin();
-            final elem80 = <int>[];
-            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
-              int elem78 = iprot.readI32();
-              elem80.add(elem78);
+            thrift.TList elem75 = iprot.readListBegin();
+            final elem78 = <int>[];
+            for(int elem77 = 0; elem77 < elem75.length; ++elem77) {
+              int elem76 = iprot.readI32();
+              elem78.add(elem76);
             }
             iprot.readListEnd();
-            this.enums = elem80;
+            this.enums = elem78;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -562,9 +562,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            final elem81 = t_variety.TestingUnions();
-            this.a_union = elem81;
-            elem81.read(iprot);
+            final elem79 = t_variety.TestingUnions();
+            this.a_union = elem79;
+            elem79.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -595,65 +595,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem82 = iprot.readListBegin();
+            thrift.TList elem80 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem85 = <bool>[];
-            for(int elem84 = 0; elem84 < elem82.length; ++elem84) {
-              bool elem83 = iprot.readBool();
+            final elem83 = <bool>[];
+            for(int elem82 = 0; elem82 < elem80.length; ++elem82) {
+              bool elem81 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem85.add(elem83);
+              elem83.add(elem81);
             }
             iprot.readListEnd();
-            this.deprList = elem85;
+            this.deprList = elem83;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem86 = iprot.readListBegin();
-            final elem90 = <t_variety.Event>[];
-            for(int elem89 = 0; elem89 < elem86.length; ++elem89) {
-              final elem88 = t_variety.Event();
-              t_variety.Event elem87 = elem88;
-              elem88.read(iprot);
-              elem90.add(elem87);
+            thrift.TList elem84 = iprot.readListBegin();
+            final elem88 = <t_variety.Event>[];
+            for(int elem87 = 0; elem87 < elem84.length; ++elem87) {
+              final elem86 = t_variety.Event();
+              t_variety.Event elem85 = elem86;
+              elem86.read(iprot);
+              elem88.add(elem85);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem90;
+            this.eventsDefault = elem88;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem91 = iprot.readMapBegin();
-            final elem95 = <int, t_variety.Event>{};
-            for(int elem94 = 0; elem94 < elem91.length; ++elem94) {
-              int elem96 = iprot.readI64();
-              final elem93 = t_variety.Event();
-              t_variety.Event elem92 = elem93;
-              elem93.read(iprot);
-              elem95[elem96] = elem92;
+            thrift.TMap elem89 = iprot.readMapBegin();
+            final elem93 = <int, t_variety.Event>{};
+            for(int elem92 = 0; elem92 < elem89.length; ++elem92) {
+              int elem94 = iprot.readI64();
+              final elem91 = t_variety.Event();
+              t_variety.Event elem90 = elem91;
+              elem91.read(iprot);
+              elem93[elem94] = elem90;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem95;
+            this.eventMapDefault = elem93;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem97 = iprot.readSetBegin();
-            final elem101 = <t_variety.Event>{};
-            for(int elem100 = 0; elem100 < elem97.length; ++elem100) {
-              final elem99 = t_variety.Event();
-              t_variety.Event elem98 = elem99;
-              elem99.read(iprot);
-              elem101.add(elem98);
+            thrift.TSet elem95 = iprot.readSetBegin();
+            final elem99 = <t_variety.Event>{};
+            for(int elem98 = 0; elem98 < elem95.length; ++elem98) {
+              final elem97 = t_variety.Event();
+              t_variety.Event elem96 = elem97;
+              elem97.read(iprot);
+              elem99.add(elem96);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem101;
+            this.eventSetDefault = elem99;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -674,140 +674,138 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem102 = iD;
+    final elem100 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(elem102);
+      oprot.writeI64(elem100);
       oprot.writeFieldEnd();
     }
-    final elem103 = ev;
-    if (elem103 != null) {
+    final elem101 = ev;
+    if (elem101 != null) {
       oprot.writeFieldBegin(_EV_FIELD_DESC);
-      elem103.write(oprot);
+      elem101.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem104 = events;
-    if (elem104 != null) {
+    final elem102 = events;
+    if (elem102 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem104.length));
-      for(var elem105 in elem104) {
-        elem105.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem102.length));
+      for(var elem103 in elem102) {
+        elem103.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem106 = events2;
-    if (elem106 != null) {
+    final elem104 = events2;
+    if (elem104 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem106.length));
-      for(var elem107 in elem106) {
-        elem107.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem104.length));
+      for(var elem105 in elem104) {
+        elem105.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem108 = eventMap;
-    if (elem108 != null) {
+    final elem106 = eventMap;
+    if (elem106 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem108.length));
-      for(var elem109 in elem108.keys) {
-        final elem110 = elem108[elem109];
-        oprot.writeI64(elem109);
-        elem110.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem106.length));
+      for(var entry in elem106.entries) {
+        oprot.writeI64(entry.key);
+        entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem111 = nums;
-    if (elem111 != null) {
+    final elem107 = nums;
+    if (elem107 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem111.length));
-      for(var elem112 in elem111) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem112.length));
-        for(var elem113 in elem112) {
-          oprot.writeI32(elem113);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem107.length));
+      for(var elem108 in elem107) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem108.length));
+        for(var elem109 in elem108) {
+          oprot.writeI32(elem109);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem114 = enums;
-    if (elem114 != null) {
+    final elem110 = enums;
+    if (elem110 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem114.length));
-      for(var elem115 in elem114) {
-        oprot.writeI32(elem115);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem110.length));
+      for(var elem111 in elem110) {
+        oprot.writeI32(elem111);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem116 = aBoolField;
+    final elem112 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem116);
+    oprot.writeBool(elem112);
     oprot.writeFieldEnd();
-    final elem117 = a_union;
-    if (elem117 != null) {
+    final elem113 = a_union;
+    if (elem113 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem117.write(oprot);
+      elem113.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem118 = typedefOfTypedef;
-    if (elem118 != null) {
+    final elem114 = typedefOfTypedef;
+    if (elem114 != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem118);
+      oprot.writeString(elem114);
       oprot.writeFieldEnd();
     }
-    final elem119 = depr;
+    final elem115 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem119);
+    oprot.writeBool(elem115);
     oprot.writeFieldEnd();
-    final elem120 = deprBinary;
+    final elem116 = deprBinary;
     // ignore: deprecated_member_use
-    if (elem120 != null) {
+    if (elem116 != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem120);
+      oprot.writeBinary(elem116);
       oprot.writeFieldEnd();
     }
-    final elem121 = deprList;
+    final elem117 = deprList;
     // ignore: deprecated_member_use
-    if (elem121 != null) {
+    if (elem117 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem121.length));
-      for(var elem122 in elem121) {
-        oprot.writeBool(elem122);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem117.length));
+      for(var elem118 in elem117) {
+        oprot.writeBool(elem118);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem123 = eventsDefault;
-    if (isSetEventsDefault() && elem123 != null) {
+    final elem119 = eventsDefault;
+    if (isSetEventsDefault() && elem119 != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem123.length));
-      for(var elem124 in elem123) {
-        elem124.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem119.length));
+      for(var elem120 in elem119) {
+        elem120.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem125 = eventMapDefault;
-    if (isSetEventMapDefault() && elem125 != null) {
+    final elem121 = eventMapDefault;
+    if (isSetEventMapDefault() && elem121 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem125.length));
-      for(var elem126 in elem125.keys) {
-        final elem127 = elem125[elem126];
-        oprot.writeI64(elem126);
-        elem127.write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem121.length));
+      for(var entry in elem121.entries) {
+        oprot.writeI64(entry.key);
+        entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem128 = eventSetDefault;
-    if (isSetEventSetDefault() && elem128 != null) {
+    final elem122 = eventSetDefault;
+    if (isSetEventSetDefault() && elem122 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem128.length));
-      for(var elem129 in elem128) {
-        elem129.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem122.length));
+      for(var elem123 in elem122) {
+        elem123.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
@@ -462,88 +462,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            this.ev = t_variety.Event();
-            ev.read(iprot);
+            final tmp_ev = t_variety.Event();
+            this.ev = tmp_ev;
+            tmp_ev.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem26 = iprot.readListBegin();
-            final elem29 = <t_variety.Event>[];
-            for(int elem28 = 0; elem28 < elem26.length; ++elem28) {
-              t_variety.Event elem27 = t_variety.Event();
-              elem27.read(iprot);
-              elem29.add(elem27);
+            thrift.TList elem49 = iprot.readListBegin();
+            final elem52 = <t_variety.Event>[];
+            for(int elem51 = 0; elem51 < elem49.length; ++elem51) {
+              final tmp_elem50 = t_variety.Event();
+              t_variety.Event elem50 = tmp_elem50;
+              tmp_elem50.read(iprot);
+              elem52.add(elem50);
             }
             iprot.readListEnd();
-            this.events = elem29;
+            this.events = elem52;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem30 = iprot.readSetBegin();
-            final elem33 = <t_variety.Event>{};
-            for(int elem32 = 0; elem32 < elem30.length; ++elem32) {
-              t_variety.Event elem31 = t_variety.Event();
-              elem31.read(iprot);
-              elem33.add(elem31);
+            thrift.TSet elem53 = iprot.readSetBegin();
+            final elem56 = <t_variety.Event>{};
+            for(int elem55 = 0; elem55 < elem53.length; ++elem55) {
+              final tmp_elem54 = t_variety.Event();
+              t_variety.Event elem54 = tmp_elem54;
+              tmp_elem54.read(iprot);
+              elem56.add(elem54);
             }
             iprot.readSetEnd();
-            this.events2 = elem33;
+            this.events2 = elem56;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem34 = iprot.readMapBegin();
-            final elem37 = <int, t_variety.Event>{};
-            for(int elem36 = 0; elem36 < elem34.length; ++elem36) {
-              int elem38 = iprot.readI64();
-              t_variety.Event elem35 = t_variety.Event();
-              elem35.read(iprot);
-              elem37[elem38] = elem35;
+            thrift.TMap elem57 = iprot.readMapBegin();
+            final elem60 = <int, t_variety.Event>{};
+            for(int elem59 = 0; elem59 < elem57.length; ++elem59) {
+              int elem61 = iprot.readI64();
+              final tmp_elem58 = t_variety.Event();
+              t_variety.Event elem58 = tmp_elem58;
+              tmp_elem58.read(iprot);
+              elem60[elem61] = elem58;
             }
             iprot.readMapEnd();
-            this.eventMap = elem37;
+            this.eventMap = elem60;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem39 = iprot.readListBegin();
-            final elem45 = <List<int>>[];
-            for(int elem44 = 0; elem44 < elem39.length; ++elem44) {
-              thrift.TList elem41 = iprot.readListBegin();
-              final elem40 = <int>[];
-              for(int elem43 = 0; elem43 < elem41.length; ++elem43) {
-                int elem42 = iprot.readI32();
-                elem40.add(elem42);
+            thrift.TList elem62 = iprot.readListBegin();
+            final elem68 = <List<int>>[];
+            for(int elem67 = 0; elem67 < elem62.length; ++elem67) {
+              thrift.TList elem64 = iprot.readListBegin();
+              final elem63 = <int>[];
+              for(int elem66 = 0; elem66 < elem64.length; ++elem66) {
+                int elem65 = iprot.readI32();
+                elem63.add(elem65);
               }
               iprot.readListEnd();
-              elem45.add(elem40);
+              elem68.add(elem63);
             }
             iprot.readListEnd();
-            this.nums = elem45;
+            this.nums = elem68;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem46 = iprot.readListBegin();
-            final elem49 = <int>[];
-            for(int elem48 = 0; elem48 < elem46.length; ++elem48) {
-              int elem47 = iprot.readI32();
-              elem49.add(elem47);
+            thrift.TList elem69 = iprot.readListBegin();
+            final elem72 = <int>[];
+            for(int elem71 = 0; elem71 < elem69.length; ++elem71) {
+              int elem70 = iprot.readI32();
+              elem72.add(elem70);
             }
             iprot.readListEnd();
-            this.enums = elem49;
+            this.enums = elem72;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -558,8 +562,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            this.a_union = t_variety.TestingUnions();
-            a_union.read(iprot);
+            final tmp_a_union = t_variety.TestingUnions();
+            this.a_union = tmp_a_union;
+            tmp_a_union.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -590,62 +595,65 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem50 = iprot.readListBegin();
+            thrift.TList elem73 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem53 = <bool>[];
-            for(int elem52 = 0; elem52 < elem50.length; ++elem52) {
-              bool elem51 = iprot.readBool();
+            final elem76 = <bool>[];
+            for(int elem75 = 0; elem75 < elem73.length; ++elem75) {
+              bool elem74 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem53.add(elem51);
+              elem76.add(elem74);
             }
             iprot.readListEnd();
-            this.deprList = elem53;
+            this.deprList = elem76;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem54 = iprot.readListBegin();
-            final elem57 = <t_variety.Event>[];
-            for(int elem56 = 0; elem56 < elem54.length; ++elem56) {
-              t_variety.Event elem55 = t_variety.Event();
-              elem55.read(iprot);
-              elem57.add(elem55);
+            thrift.TList elem77 = iprot.readListBegin();
+            final elem80 = <t_variety.Event>[];
+            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
+              final tmp_elem78 = t_variety.Event();
+              t_variety.Event elem78 = tmp_elem78;
+              tmp_elem78.read(iprot);
+              elem80.add(elem78);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem57;
+            this.eventsDefault = elem80;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem58 = iprot.readMapBegin();
-            final elem61 = <int, t_variety.Event>{};
-            for(int elem60 = 0; elem60 < elem58.length; ++elem60) {
-              int elem62 = iprot.readI64();
-              t_variety.Event elem59 = t_variety.Event();
-              elem59.read(iprot);
-              elem61[elem62] = elem59;
+            thrift.TMap elem81 = iprot.readMapBegin();
+            final elem84 = <int, t_variety.Event>{};
+            for(int elem83 = 0; elem83 < elem81.length; ++elem83) {
+              int elem85 = iprot.readI64();
+              final tmp_elem82 = t_variety.Event();
+              t_variety.Event elem82 = tmp_elem82;
+              tmp_elem82.read(iprot);
+              elem84[elem85] = elem82;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem61;
+            this.eventMapDefault = elem84;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem63 = iprot.readSetBegin();
-            final elem66 = <t_variety.Event>{};
-            for(int elem65 = 0; elem65 < elem63.length; ++elem65) {
-              t_variety.Event elem64 = t_variety.Event();
-              elem64.read(iprot);
-              elem66.add(elem64);
+            thrift.TSet elem86 = iprot.readSetBegin();
+            final elem89 = <t_variety.Event>{};
+            for(int elem88 = 0; elem88 < elem86.length; ++elem88) {
+              final tmp_elem87 = t_variety.Event();
+              t_variety.Event elem87 = tmp_elem87;
+              tmp_elem87.read(iprot);
+              elem89.add(elem87);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem66;
+            this.eventSetDefault = elem89;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -666,135 +674,140 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem90 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(this.iD);
+      oprot.writeI64(elem90);
       oprot.writeFieldEnd();
     }
-    if (this.ev != null) {
+    final elem91 = ev;
+    if (elem91 != null) {
       oprot.writeFieldBegin(_EV_FIELD_DESC);
-      this.ev.write(oprot);
+      elem91.write(oprot);
       oprot.writeFieldEnd();
     }
-    if (this.events != null) {
+    final elem92 = events;
+    if (elem92 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      final temp = this.events;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
-      for(var elem67 in temp) {
-        elem67.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem92.length));
+      for(var elem93 in elem92) {
+        elem93.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (this.events2 != null) {
+    final elem94 = events2;
+    if (elem94 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      final temp = this.events2;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, temp.length));
-      for(var elem68 in temp) {
-        elem68.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem94.length));
+      for(var elem95 in elem94) {
+        elem95.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    if (this.eventMap != null) {
+    final elem96 = eventMap;
+    if (elem96 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      final temp = this.eventMap;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, temp.length));
-      for(var elem69 in temp.keys) {
-        oprot.writeI64(elem69);
-        temp[elem69].write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem96.length));
+      for(var elem97 in elem96.keys) {
+        final val = elem96[elem97];
+        oprot.writeI64(elem97);
+        val.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    if (this.nums != null) {
+    final elem98 = nums;
+    if (elem98 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      final temp = this.nums;
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, temp.length));
-      for(var elem70 in temp) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem70.length));
-        for(var elem71 in elem70) {
-          oprot.writeI32(elem71);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem98.length));
+      for(var elem99 in elem98) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem99.length));
+        for(var elem100 in elem99) {
+          oprot.writeI32(elem100);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (this.enums != null) {
+    final elem101 = enums;
+    if (elem101 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      final temp = this.enums;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem72 in temp) {
-        oprot.writeI32(elem72);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem101.length));
+      for(var elem102 in elem101) {
+        oprot.writeI32(elem102);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem103 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(this.aBoolField);
+    oprot.writeBool(elem103);
     oprot.writeFieldEnd();
-    if (this.a_union != null) {
+    final elem104 = a_union;
+    if (elem104 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      this.a_union.write(oprot);
+      elem104.write(oprot);
       oprot.writeFieldEnd();
     }
-    if (this.typedefOfTypedef != null) {
+    final elem105 = typedefOfTypedef;
+    if (elem105 != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(this.typedefOfTypedef);
+      oprot.writeString(elem105);
       oprot.writeFieldEnd();
     }
+    final elem106 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    // ignore: deprecated_member_use
-    oprot.writeBool(this.depr);
+    oprot.writeBool(elem106);
     oprot.writeFieldEnd();
+    final elem107 = deprBinary;
     // ignore: deprecated_member_use
-    if (this.deprBinary != null) {
+    if (elem107 != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      // ignore: deprecated_member_use
-      oprot.writeBinary(this.deprBinary);
+      oprot.writeBinary(elem107);
       oprot.writeFieldEnd();
     }
+    final elem108 = deprList;
     // ignore: deprecated_member_use
-    if (this.deprList != null) {
+    if (elem108 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      // ignore: deprecated_member_use
-      final temp = this.deprList;
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, temp.length));
-      // ignore: deprecated_member_use
-      for(var elem73 in temp) {
-        oprot.writeBool(elem73);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem108.length));
+      for(var elem109 in elem108) {
+        oprot.writeBool(elem109);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetEventsDefault() && this.eventsDefault != null) {
+    final elem110 = eventsDefault;
+    if (isSetEventsDefault() && elem110 != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      final temp = this.eventsDefault;
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, temp.length));
-      for(var elem74 in temp) {
-        elem74.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem110.length));
+      for(var elem111 in elem110) {
+        elem111.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetEventMapDefault() && this.eventMapDefault != null) {
+    final elem112 = eventMapDefault;
+    if (isSetEventMapDefault() && elem112 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      final temp = this.eventMapDefault;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, temp.length));
-      for(var elem75 in temp.keys) {
-        oprot.writeI64(elem75);
-        temp[elem75].write(oprot);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem112.length));
+      for(var elem113 in elem112.keys) {
+        final val = elem112[elem113];
+        oprot.writeI64(elem113);
+        val.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetEventSetDefault() && this.eventSetDefault != null) {
+    final elem114 = eventSetDefault;
+    if (isSetEventSetDefault() && elem114 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      final temp = this.eventSetDefault;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, temp.length));
-      for(var elem76 in temp) {
-        elem76.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem114.length));
+      for(var elem115 in elem114) {
+        elem115.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart/variety/f_events_scope.dart
@@ -123,12 +123,12 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem164 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem164.length));
-      for(var elem165 in elem164.keys) {
-        final elem166 = elem164[elem165];
-        oprot.writeI64(elem165);
-        elem166.write(oprot);
+    for(var elem180 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem180.length));
+      for(var elem181 in elem180.keys) {
+        final elem182 = elem180[elem181];
+        oprot.writeI64(elem181);
+        elem182.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -176,9 +176,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final tmp_req = t_variety.Event();
-      t_variety.Event req = tmp_req;
-      tmp_req.read(iprot);
+      final elem183 = t_variety.Event();
+      t_variety.Event req = elem183;
+      elem183.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -265,20 +265,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem167 = iprot.readListBegin();
+      thrift.TList elem184 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem173 = 0; elem173 < elem167.length; ++elem173) {
-        thrift.TMap elem169 = iprot.readMapBegin();
-        final elem168 = <int, t_variety.Event>{};
-        for(int elem171 = 0; elem171 < elem169.length; ++elem171) {
-          int elem172 = iprot.readI64();
-          final tmp_elem170 = t_variety.Event();
-          t_variety.Event elem170 = tmp_elem170;
-          tmp_elem170.read(iprot);
-          elem168[elem172] = elem170;
+      for(int elem191 = 0; elem191 < elem184.length; ++elem191) {
+        thrift.TMap elem186 = iprot.readMapBegin();
+        final elem185 = <int, t_variety.Event>{};
+        for(int elem189 = 0; elem189 < elem186.length; ++elem189) {
+          int elem190 = iprot.readI64();
+          final elem188 = t_variety.Event();
+          t_variety.Event elem187 = elem188;
+          elem188.read(iprot);
+          elem185[elem190] = elem187;
         }
         iprot.readMapEnd();
-        req.add(elem168);
+        req.add(elem185);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart/variety/f_events_scope.dart
@@ -123,12 +123,11 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem180 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem180.length));
-      for(var elem181 in elem180.keys) {
-        final elem182 = elem180[elem181];
-        oprot.writeI64(elem181);
-        elem182.write(oprot);
+    for(var elem170 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem170.length));
+      for(var entry in elem170.entries) {
+        oprot.writeI64(entry.key);
+        entry.value.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -176,9 +175,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final elem183 = t_variety.Event();
-      t_variety.Event req = elem183;
-      elem183.read(iprot);
+      final elem171 = t_variety.Event();
+      t_variety.Event req = elem171;
+      elem171.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -265,20 +264,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem184 = iprot.readListBegin();
+      thrift.TList elem172 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem191 = 0; elem191 < elem184.length; ++elem191) {
-        thrift.TMap elem186 = iprot.readMapBegin();
-        final elem185 = <int, t_variety.Event>{};
-        for(int elem189 = 0; elem189 < elem186.length; ++elem189) {
-          int elem190 = iprot.readI64();
-          final elem188 = t_variety.Event();
-          t_variety.Event elem187 = elem188;
-          elem188.read(iprot);
-          elem185[elem190] = elem187;
+      for(int elem179 = 0; elem179 < elem172.length; ++elem179) {
+        thrift.TMap elem174 = iprot.readMapBegin();
+        final elem173 = <int, t_variety.Event>{};
+        for(int elem177 = 0; elem177 < elem174.length; ++elem177) {
+          int elem178 = iprot.readI64();
+          final elem176 = t_variety.Event();
+          t_variety.Event elem175 = elem176;
+          elem176.read(iprot);
+          elem173[elem178] = elem175;
         }
         iprot.readMapEnd();
-        req.add(elem185);
+        req.add(elem173);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart/variety/f_events_scope.dart
@@ -123,12 +123,12 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem159 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem159.length));
-      for(var elem160 in elem159.keys) {
-        final val = elem159[elem160];
-        oprot.writeI64(elem160);
-        val.write(oprot);
+    for(var elem164 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem164.length));
+      for(var elem165 in elem164.keys) {
+        final elem166 = elem164[elem165];
+        oprot.writeI64(elem165);
+        elem166.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -265,20 +265,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem161 = iprot.readListBegin();
+      thrift.TList elem167 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem167 = 0; elem167 < elem161.length; ++elem167) {
-        thrift.TMap elem163 = iprot.readMapBegin();
-        final elem162 = <int, t_variety.Event>{};
-        for(int elem165 = 0; elem165 < elem163.length; ++elem165) {
-          int elem166 = iprot.readI64();
-          final tmp_elem164 = t_variety.Event();
-          t_variety.Event elem164 = tmp_elem164;
-          tmp_elem164.read(iprot);
-          elem162[elem166] = elem164;
+      for(int elem173 = 0; elem173 < elem167.length; ++elem173) {
+        thrift.TMap elem169 = iprot.readMapBegin();
+        final elem168 = <int, t_variety.Event>{};
+        for(int elem171 = 0; elem171 < elem169.length; ++elem171) {
+          int elem172 = iprot.readI64();
+          final tmp_elem170 = t_variety.Event();
+          t_variety.Event elem170 = tmp_elem170;
+          tmp_elem170.read(iprot);
+          elem168[elem172] = elem170;
         }
         iprot.readMapEnd();
-        req.add(elem162);
+        req.add(elem168);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart/variety/f_events_scope.dart
@@ -123,11 +123,12 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem90 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem90.length));
-      for(var elem91 in elem90.keys) {
-        oprot.writeI64(elem91);
-        elem90[elem91].write(oprot);
+    for(var elem159 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem159.length));
+      for(var elem160 in elem159.keys) {
+        final val = elem159[elem160];
+        oprot.writeI64(elem160);
+        val.write(oprot);
       }
       oprot.writeMapEnd();
     }
@@ -175,8 +176,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      t_variety.Event req = t_variety.Event();
-      req.read(iprot);
+      final tmp_req = t_variety.Event();
+      t_variety.Event req = tmp_req;
+      tmp_req.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -263,19 +265,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem92 = iprot.readListBegin();
+      thrift.TList elem161 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem98 = 0; elem98 < elem92.length; ++elem98) {
-        thrift.TMap elem94 = iprot.readMapBegin();
-        final elem93 = <int, t_variety.Event>{};
-        for(int elem96 = 0; elem96 < elem94.length; ++elem96) {
-          int elem97 = iprot.readI64();
-          t_variety.Event elem95 = t_variety.Event();
-          elem95.read(iprot);
-          elem93[elem97] = elem95;
+      for(int elem167 = 0; elem167 < elem161.length; ++elem167) {
+        thrift.TMap elem163 = iprot.readMapBegin();
+        final elem162 = <int, t_variety.Event>{};
+        for(int elem165 = 0; elem165 < elem163.length; ++elem165) {
+          int elem166 = iprot.readI64();
+          final tmp_elem164 = t_variety.Event();
+          t_variety.Event elem164 = tmp_elem164;
+          tmp_elem164.read(iprot);
+          elem162[elem166] = elem164;
         }
         iprot.readMapEnd();
-        req.add(elem93);
+        req.add(elem162);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart/variety/f_events_scope.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 
@@ -66,9 +64,7 @@ class EventsPublisher {
     oprot.writeMessageBegin(msg);
     req.write(oprot);
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 
 
@@ -88,9 +84,7 @@ class EventsPublisher {
     oprot.writeMessageBegin(msg);
     oprot.writeI64(req);
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 
 
@@ -110,9 +104,7 @@ class EventsPublisher {
     oprot.writeMessageBegin(msg);
     oprot.writeString(req);
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 
 
@@ -141,9 +133,7 @@ class EventsPublisher {
     }
     oprot.writeListEnd();
     oprot.writeMessageEnd();
-    // sync in this version but async in v2. Mitigate breaking changes by always awaiting.
-    // ignore: await_only_futures
-    await transport.publish(topic, memoryBuffer.writeBytes);
+    transport.publish(topic, memoryBuffer.writeBytes);
   }
 }
 

--- a/compiler/testdata/expected/dart/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart/variety/f_foo_args.dart
@@ -148,19 +148,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.newMessage != null) {
+    final elem116 = newMessage;
+    if (elem116 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(this.newMessage);
+      oprot.writeString(elem116);
       oprot.writeFieldEnd();
     }
-    if (this.messageArgs != null) {
+    final elem117 = messageArgs;
+    if (elem117 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(this.messageArgs);
+      oprot.writeString(elem117);
       oprot.writeFieldEnd();
     }
-    if (this.messageResult != null) {
+    final elem118 = messageResult;
+    if (elem118 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(this.messageResult);
+      oprot.writeString(elem118);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart/variety/f_foo_args.dart
@@ -148,22 +148,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem130 = newMessage;
-    if (elem130 != null) {
+    final elem124 = newMessage;
+    if (elem124 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem130);
+      oprot.writeString(elem124);
       oprot.writeFieldEnd();
     }
-    final elem131 = messageArgs;
-    if (elem131 != null) {
+    final elem125 = messageArgs;
+    if (elem125 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem131);
+      oprot.writeString(elem125);
       oprot.writeFieldEnd();
     }
-    final elem132 = messageResult;
-    if (elem132 != null) {
+    final elem126 = messageResult;
+    if (elem126 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem132);
+      oprot.writeString(elem126);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart/variety/f_foo_args.dart
@@ -148,22 +148,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem116 = newMessage;
-    if (elem116 != null) {
+    final elem119 = newMessage;
+    if (elem119 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem116);
+      oprot.writeString(elem119);
       oprot.writeFieldEnd();
     }
-    final elem117 = messageArgs;
-    if (elem117 != null) {
+    final elem120 = messageArgs;
+    if (elem120 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem117);
+      oprot.writeString(elem120);
       oprot.writeFieldEnd();
     }
-    final elem118 = messageResult;
-    if (elem118 != null) {
+    final elem121 = messageResult;
+    if (elem121 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem118);
+      oprot.writeString(elem121);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart/variety/f_foo_args.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart/variety/f_foo_args.dart
@@ -148,22 +148,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem119 = newMessage;
-    if (elem119 != null) {
+    final elem130 = newMessage;
+    if (elem130 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem119);
+      oprot.writeString(elem130);
       oprot.writeFieldEnd();
     }
-    final elem120 = messageArgs;
-    if (elem120 != null) {
+    final elem131 = messageArgs;
+    if (elem131 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem120);
+      oprot.writeString(elem131);
       oprot.writeFieldEnd();
     }
-    final elem121 = messageResult;
-    if (elem121 != null) {
+    final elem132 = messageResult;
+    if (elem132 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem121);
+      oprot.writeString(elem132);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart/variety/f_foo_service.dart
@@ -418,17 +418,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem136 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(this.num);
+    oprot.writeI32(elem136);
     oprot.writeFieldEnd();
-    if (this.str != null) {
+    final elem137 = str;
+    if (elem137 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(this.str);
+      oprot.writeString(elem137);
       oprot.writeFieldEnd();
     }
-    if (this.event != null) {
+    final elem138 = event;
+    if (elem138 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      this.event.write(oprot);
+      elem138.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -461,16 +464,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            this.awe = t_variety.AwesomeException();
-            awe.read(iprot);
+            final tmp_awe = t_variety.AwesomeException();
+            this.awe = tmp_awe;
+            tmp_awe.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            this.api = t_actual_base_dart.api_exception();
-            api.read(iprot);
+            final tmp_api = t_actual_base_dart.api_exception();
+            this.api = tmp_api;
+            tmp_api.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -504,16 +509,18 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem139 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(this.id);
+    oprot.writeI64(elem139);
     oprot.writeFieldEnd();
-    if (this.req != null) {
+    final elem140 = req;
+    if (elem140 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      final temp = this.req;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, temp.length));
-      for(var elem83 in temp.keys) {
-        oprot.writeI32(elem83);
-        oprot.writeString(temp[elem83]);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem140.length));
+      for(var elem141 in elem140.keys) {
+        final val = elem140[elem141];
+        oprot.writeI32(elem141);
+        oprot.writeString(val);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -540,14 +547,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.bin != null) {
+    final elem142 = bin;
+    if (elem142 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(this.bin);
+      oprot.writeBinary(elem142);
       oprot.writeFieldEnd();
     }
-    if (this.str != null) {
+    final elem143 = str;
+    if (elem143 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(this.str);
+      oprot.writeString(elem143);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -579,8 +588,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            this.api = t_actual_base_dart.api_exception();
-            api.read(iprot);
+            final tmp_api = t_actual_base_dart.api_exception();
+            this.api = tmp_api;
+            tmp_api.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -616,14 +626,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem144 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(this.opt_num);
+    oprot.writeI32(elem144);
     oprot.writeFieldEnd();
+    final elem145 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(this.default_num);
+    oprot.writeI32(elem145);
     oprot.writeFieldEnd();
+    final elem146 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(this.req_num);
+    oprot.writeI32(elem146);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -684,22 +697,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.list_type != null) {
+    final elem147 = list_type;
+    if (elem147 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      final temp = this.list_type;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, temp.length));
-      for(var elem84 in temp) {
-        oprot.writeI64(elem84);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem147.length));
+      for(var elem148 in elem147) {
+        oprot.writeI64(elem148);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (this.set_type != null) {
+    final elem149 = set_type;
+    if (elem149 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      final temp = this.set_type;
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, temp.length));
-      for(var elem85 in temp) {
-        oprot.writeI64(elem85);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem149.length));
+      for(var elem150 in elem149) {
+        oprot.writeI64(elem150);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -725,14 +738,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem86 = iprot.readListBegin();
-            final elem89 = <int>[];
-            for(int elem88 = 0; elem88 < elem86.length; ++elem88) {
-              int elem87 = iprot.readI64();
-              elem89.add(elem87);
+            thrift.TList elem151 = iprot.readListBegin();
+            final elem154 = <int>[];
+            for(int elem153 = 0; elem153 < elem151.length; ++elem153) {
+              int elem152 = iprot.readI64();
+              elem154.add(elem152);
             }
             iprot.readListEnd();
-            this.success = elem89;
+            this.success = elem154;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -783,8 +796,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            this.success = t_validStructs.Thing();
-            success.read(iprot);
+            final tmp_success = t_validStructs.Thing();
+            this.success = tmp_success;
+            tmp_success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -867,9 +881,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.a != null) {
+    final elem155 = a;
+    if (elem155 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      this.a.write(oprot);
+      elem155.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -893,8 +908,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            this.success = t_subdir_include_ns.A();
-            success.read(iprot);
+            final tmp_success = t_subdir_include_ns.A();
+            this.success = tmp_success;
+            tmp_success.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -926,9 +942,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.newMessage != null) {
+    final elem156 = newMessage;
+    if (elem156 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(this.newMessage);
+      oprot.writeString(elem156);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -984,9 +1001,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.messageArgs != null) {
+    final elem157 = messageArgs;
+    if (elem157 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(this.messageArgs);
+      oprot.writeString(elem157);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1042,9 +1060,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.messageResult != null) {
+    final elem158 = messageResult;
+    if (elem158 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(this.messageResult);
+      oprot.writeString(elem158);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart/variety/f_foo_service.dart
@@ -418,20 +418,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem136 = num;
+    final elem140 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem136);
+    oprot.writeI32(elem140);
     oprot.writeFieldEnd();
-    final elem137 = str;
-    if (elem137 != null) {
+    final elem141 = str;
+    if (elem141 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem137);
+      oprot.writeString(elem141);
       oprot.writeFieldEnd();
     }
-    final elem138 = event;
-    if (elem138 != null) {
+    final elem142 = event;
+    if (elem142 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem138.write(oprot);
+      elem142.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -509,18 +509,18 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem139 = id;
+    final elem143 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem139);
+    oprot.writeI64(elem143);
     oprot.writeFieldEnd();
-    final elem140 = req;
-    if (elem140 != null) {
+    final elem144 = req;
+    if (elem144 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem140.length));
-      for(var elem141 in elem140.keys) {
-        final val = elem140[elem141];
-        oprot.writeI32(elem141);
-        oprot.writeString(val);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem144.length));
+      for(var elem145 in elem144.keys) {
+        final elem146 = elem144[elem145];
+        oprot.writeI32(elem145);
+        oprot.writeString(elem146);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -547,16 +547,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem142 = bin;
-    if (elem142 != null) {
+    final elem147 = bin;
+    if (elem147 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem142);
+      oprot.writeBinary(elem147);
       oprot.writeFieldEnd();
     }
-    final elem143 = str;
-    if (elem143 != null) {
+    final elem148 = str;
+    if (elem148 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem143);
+      oprot.writeString(elem148);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -626,17 +626,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem144 = opt_num;
+    final elem149 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem144);
+    oprot.writeI32(elem149);
     oprot.writeFieldEnd();
-    final elem145 = default_num;
+    final elem150 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem145);
+    oprot.writeI32(elem150);
     oprot.writeFieldEnd();
-    final elem146 = req_num;
+    final elem151 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem146);
+    oprot.writeI32(elem151);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -697,22 +697,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem147 = list_type;
-    if (elem147 != null) {
+    final elem152 = list_type;
+    if (elem152 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem147.length));
-      for(var elem148 in elem147) {
-        oprot.writeI64(elem148);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem152.length));
+      for(var elem153 in elem152) {
+        oprot.writeI64(elem153);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem149 = set_type;
-    if (elem149 != null) {
+    final elem154 = set_type;
+    if (elem154 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem149.length));
-      for(var elem150 in elem149) {
-        oprot.writeI64(elem150);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem154.length));
+      for(var elem155 in elem154) {
+        oprot.writeI64(elem155);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -738,14 +738,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem151 = iprot.readListBegin();
-            final elem154 = <int>[];
-            for(int elem153 = 0; elem153 < elem151.length; ++elem153) {
-              int elem152 = iprot.readI64();
-              elem154.add(elem152);
+            thrift.TList elem156 = iprot.readListBegin();
+            final elem159 = <int>[];
+            for(int elem158 = 0; elem158 < elem156.length; ++elem158) {
+              int elem157 = iprot.readI64();
+              elem159.add(elem157);
             }
             iprot.readListEnd();
-            this.success = elem154;
+            this.success = elem159;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -881,10 +881,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem155 = a;
-    if (elem155 != null) {
+    final elem160 = a;
+    if (elem160 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem155.write(oprot);
+      elem160.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -942,10 +942,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem156 = newMessage;
-    if (elem156 != null) {
+    final elem161 = newMessage;
+    if (elem161 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem156);
+      oprot.writeString(elem161);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1001,10 +1001,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem157 = messageArgs;
-    if (elem157 != null) {
+    final elem162 = messageArgs;
+    if (elem162 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem157);
+      oprot.writeString(elem162);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1060,10 +1060,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem158 = messageResult;
-    if (elem158 != null) {
+    final elem163 = messageResult;
+    if (elem163 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem158);
+      oprot.writeString(elem163);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart/variety/f_foo_service.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart/variety/f_foo_service.dart
@@ -418,20 +418,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem151 = num;
+    final elem143 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem151);
+    oprot.writeI32(elem143);
     oprot.writeFieldEnd();
-    final elem152 = str;
-    if (elem152 != null) {
+    final elem144 = str;
+    if (elem144 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem152);
+      oprot.writeString(elem144);
       oprot.writeFieldEnd();
     }
-    final elem153 = event;
-    if (elem153 != null) {
+    final elem145 = event;
+    if (elem145 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem153.write(oprot);
+      elem145.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -464,18 +464,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem154 = t_variety.AwesomeException();
-            this.awe = elem154;
-            elem154.read(iprot);
+            final elem146 = t_variety.AwesomeException();
+            this.awe = elem146;
+            elem146.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            final elem155 = t_actual_base_dart.api_exception();
-            this.api = elem155;
-            elem155.read(iprot);
+            final elem147 = t_actual_base_dart.api_exception();
+            this.api = elem147;
+            elem147.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -509,18 +509,17 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem156 = id;
+    final elem148 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem156);
+    oprot.writeI64(elem148);
     oprot.writeFieldEnd();
-    final elem157 = req;
-    if (elem157 != null) {
+    final elem149 = req;
+    if (elem149 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem157.length));
-      for(var elem158 in elem157.keys) {
-        final elem159 = elem157[elem158];
-        oprot.writeI32(elem158);
-        oprot.writeString(elem159);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem149.length));
+      for(var entry in elem149.entries) {
+        oprot.writeI32(entry.key);
+        oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -547,16 +546,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem160 = bin;
-    if (elem160 != null) {
+    final elem150 = bin;
+    if (elem150 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem160);
+      oprot.writeBinary(elem150);
       oprot.writeFieldEnd();
     }
-    final elem161 = str;
-    if (elem161 != null) {
+    final elem151 = str;
+    if (elem151 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem161);
+      oprot.writeString(elem151);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -588,9 +587,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem162 = t_actual_base_dart.api_exception();
-            this.api = elem162;
-            elem162.read(iprot);
+            final elem152 = t_actual_base_dart.api_exception();
+            this.api = elem152;
+            elem152.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -626,17 +625,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem163 = opt_num;
+    final elem153 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem163);
+    oprot.writeI32(elem153);
     oprot.writeFieldEnd();
-    final elem164 = default_num;
+    final elem154 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem164);
+    oprot.writeI32(elem154);
     oprot.writeFieldEnd();
-    final elem165 = req_num;
+    final elem155 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem165);
+    oprot.writeI32(elem155);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -697,22 +696,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem166 = list_type;
-    if (elem166 != null) {
+    final elem156 = list_type;
+    if (elem156 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem166.length));
-      for(var elem167 in elem166) {
-        oprot.writeI64(elem167);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem156.length));
+      for(var elem157 in elem156) {
+        oprot.writeI64(elem157);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem168 = set_type;
-    if (elem168 != null) {
+    final elem158 = set_type;
+    if (elem158 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem168.length));
-      for(var elem169 in elem168) {
-        oprot.writeI64(elem169);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem158.length));
+      for(var elem159 in elem158) {
+        oprot.writeI64(elem159);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -738,14 +737,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem170 = iprot.readListBegin();
-            final elem173 = <int>[];
-            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
-              int elem171 = iprot.readI64();
-              elem173.add(elem171);
+            thrift.TList elem160 = iprot.readListBegin();
+            final elem163 = <int>[];
+            for(int elem162 = 0; elem162 < elem160.length; ++elem162) {
+              int elem161 = iprot.readI64();
+              elem163.add(elem161);
             }
             iprot.readListEnd();
-            this.success = elem173;
+            this.success = elem163;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -796,9 +795,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem174 = t_validStructs.Thing();
-            this.success = elem174;
-            elem174.read(iprot);
+            final elem164 = t_validStructs.Thing();
+            this.success = elem164;
+            elem164.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -881,10 +880,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem175 = a;
-    if (elem175 != null) {
+    final elem165 = a;
+    if (elem165 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem175.write(oprot);
+      elem165.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -908,9 +907,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem176 = t_subdir_include_ns.A();
-            this.success = elem176;
-            elem176.read(iprot);
+            final elem166 = t_subdir_include_ns.A();
+            this.success = elem166;
+            elem166.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -942,10 +941,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem177 = newMessage;
-    if (elem177 != null) {
+    final elem167 = newMessage;
+    if (elem167 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem177);
+      oprot.writeString(elem167);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1001,10 +1000,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem178 = messageArgs;
-    if (elem178 != null) {
+    final elem168 = messageArgs;
+    if (elem168 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem178);
+      oprot.writeString(elem168);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1060,10 +1059,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem179 = messageResult;
-    if (elem179 != null) {
+    final elem169 = messageResult;
+    if (elem169 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem179);
+      oprot.writeString(elem169);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart/variety/f_foo_service.dart
@@ -418,20 +418,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem140 = num;
+    final elem151 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem140);
+    oprot.writeI32(elem151);
     oprot.writeFieldEnd();
-    final elem141 = str;
-    if (elem141 != null) {
+    final elem152 = str;
+    if (elem152 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem141);
+      oprot.writeString(elem152);
       oprot.writeFieldEnd();
     }
-    final elem142 = event;
-    if (elem142 != null) {
+    final elem153 = event;
+    if (elem153 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem142.write(oprot);
+      elem153.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -464,18 +464,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_awe = t_variety.AwesomeException();
-            this.awe = tmp_awe;
-            tmp_awe.read(iprot);
+            final elem154 = t_variety.AwesomeException();
+            this.awe = elem154;
+            elem154.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_api = t_actual_base_dart.api_exception();
-            this.api = tmp_api;
-            tmp_api.read(iprot);
+            final elem155 = t_actual_base_dart.api_exception();
+            this.api = elem155;
+            elem155.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -509,18 +509,18 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem143 = id;
+    final elem156 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem143);
+    oprot.writeI64(elem156);
     oprot.writeFieldEnd();
-    final elem144 = req;
-    if (elem144 != null) {
+    final elem157 = req;
+    if (elem157 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem144.length));
-      for(var elem145 in elem144.keys) {
-        final elem146 = elem144[elem145];
-        oprot.writeI32(elem145);
-        oprot.writeString(elem146);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem157.length));
+      for(var elem158 in elem157.keys) {
+        final elem159 = elem157[elem158];
+        oprot.writeI32(elem158);
+        oprot.writeString(elem159);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
@@ -547,16 +547,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem147 = bin;
-    if (elem147 != null) {
+    final elem160 = bin;
+    if (elem160 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem147);
+      oprot.writeBinary(elem160);
       oprot.writeFieldEnd();
     }
-    final elem148 = str;
-    if (elem148 != null) {
+    final elem161 = str;
+    if (elem161 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem148);
+      oprot.writeString(elem161);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -588,9 +588,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_api = t_actual_base_dart.api_exception();
-            this.api = tmp_api;
-            tmp_api.read(iprot);
+            final elem162 = t_actual_base_dart.api_exception();
+            this.api = elem162;
+            elem162.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -626,17 +626,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem149 = opt_num;
+    final elem163 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem149);
+    oprot.writeI32(elem163);
     oprot.writeFieldEnd();
-    final elem150 = default_num;
+    final elem164 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem150);
+    oprot.writeI32(elem164);
     oprot.writeFieldEnd();
-    final elem151 = req_num;
+    final elem165 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem151);
+    oprot.writeI32(elem165);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -697,22 +697,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem152 = list_type;
-    if (elem152 != null) {
+    final elem166 = list_type;
+    if (elem166 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem152.length));
-      for(var elem153 in elem152) {
-        oprot.writeI64(elem153);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem166.length));
+      for(var elem167 in elem166) {
+        oprot.writeI64(elem167);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem154 = set_type;
-    if (elem154 != null) {
+    final elem168 = set_type;
+    if (elem168 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem154.length));
-      for(var elem155 in elem154) {
-        oprot.writeI64(elem155);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem168.length));
+      for(var elem169 in elem168) {
+        oprot.writeI64(elem169);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -738,14 +738,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem156 = iprot.readListBegin();
-            final elem159 = <int>[];
-            for(int elem158 = 0; elem158 < elem156.length; ++elem158) {
-              int elem157 = iprot.readI64();
-              elem159.add(elem157);
+            thrift.TList elem170 = iprot.readListBegin();
+            final elem173 = <int>[];
+            for(int elem172 = 0; elem172 < elem170.length; ++elem172) {
+              int elem171 = iprot.readI64();
+              elem173.add(elem171);
             }
             iprot.readListEnd();
-            this.success = elem159;
+            this.success = elem173;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -796,9 +796,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_success = t_validStructs.Thing();
-            this.success = tmp_success;
-            tmp_success.read(iprot);
+            final elem174 = t_validStructs.Thing();
+            this.success = elem174;
+            elem174.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -881,10 +881,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem160 = a;
-    if (elem160 != null) {
+    final elem175 = a;
+    if (elem175 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem160.write(oprot);
+      elem175.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -908,9 +908,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_success = t_subdir_include_ns.A();
-            this.success = tmp_success;
-            tmp_success.read(iprot);
+            final elem176 = t_subdir_include_ns.A();
+            this.success = elem176;
+            elem176.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -942,10 +942,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem161 = newMessage;
-    if (elem161 != null) {
+    final elem177 = newMessage;
+    if (elem177 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem161);
+      oprot.writeString(elem177);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1001,10 +1001,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem162 = messageArgs;
-    if (elem162 != null) {
+    final elem178 = messageArgs;
+    if (elem178 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem162);
+      oprot.writeString(elem178);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1060,10 +1060,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem163 = messageResult;
-    if (elem163 != null) {
+    final elem179 = messageResult;
+    if (elem179 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem163);
+      oprot.writeString(elem179);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart/variety/f_test_base.dart
@@ -71,8 +71,9 @@ class TestBase implements thrift.TBase {
       switch (field.id) {
         case BASE_STRUCT:
           if (field.type == thrift.TType.STRUCT) {
-            this.base_struct = t_actual_base_dart.thing();
-            base_struct.read(iprot);
+            final tmp_base_struct = t_actual_base_dart.thing();
+            this.base_struct = tmp_base_struct;
+            tmp_base_struct.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -93,9 +94,10 @@ class TestBase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    if (this.base_struct != null) {
+    final elem0 = base_struct;
+    if (elem0 != null) {
       oprot.writeFieldBegin(_BASE_STRUCT_FIELD_DESC);
-      this.base_struct.write(oprot);
+      elem0.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart/variety/f_test_base.dart
@@ -71,9 +71,9 @@ class TestBase implements thrift.TBase {
       switch (field.id) {
         case BASE_STRUCT:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_base_struct = t_actual_base_dart.thing();
-            this.base_struct = tmp_base_struct;
-            tmp_base_struct.read(iprot);
+            final elem0 = t_actual_base_dart.thing();
+            this.base_struct = elem0;
+            elem0.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -94,10 +94,10 @@ class TestBase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem0 = base_struct;
-    if (elem0 != null) {
+    final elem1 = base_struct;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_BASE_STRUCT_FIELD_DESC);
-      elem0.write(oprot);
+      elem1.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_test_base.dart
+++ b/compiler/testdata/expected/dart/variety/f_test_base.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart/variety/f_test_lowercase.dart
@@ -103,8 +103,9 @@ class TestLowercase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem1 = lowercaseInt;
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
-    oprot.writeI32(this.lowercaseInt);
+    oprot.writeI32(elem1);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart/variety/f_test_lowercase.dart
@@ -103,9 +103,9 @@ class TestLowercase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem1 = lowercaseInt;
+    final elem2 = lowercaseInt;
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
-    oprot.writeI32(elem1);
+    oprot.writeI32(elem2);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart/variety/f_test_lowercase.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
@@ -808,21 +808,20 @@ class TestingDefaults implements thrift.TBase {
     if (isSetA_map() && elem48 != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
       oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem48.length));
-      for(var elem49 in elem48.keys) {
-        final elem50 = elem48[elem49];
-        oprot.writeString(elem49);
-        oprot.writeString(elem50);
+      for(var entry in elem48.entries) {
+        oprot.writeString(entry.key);
+        oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem51 = status;
+    final elem49 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem51);
+    oprot.writeI32(elem49);
     oprot.writeFieldEnd();
-    final elem52 = base_status;
+    final elem50 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(elem52);
+    oprot.writeI32(elem50);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
@@ -525,16 +525,18 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
-            this.ev1 = t_variety.Event();
-            ev1.read(iprot);
+            final tmp_ev1 = t_variety.Event();
+            this.ev1 = tmp_ev1;
+            tmp_ev1.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
-            this.ev2 = t_variety.Event();
-            ev2.read(iprot);
+            final tmp_ev2 = t_variety.Event();
+            this.ev2 = tmp_ev2;
+            tmp_ev2.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -563,14 +565,14 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LISTFIELD:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem0 = iprot.readListBegin();
-            final elem3 = <int>[];
-            for(int elem2 = 0; elem2 < elem0.length; ++elem2) {
-              int elem1 = iprot.readI32();
-              elem3.add(elem1);
+            thrift.TList elem5 = iprot.readListBegin();
+            final elem8 = <int>[];
+            for(int elem7 = 0; elem7 < elem5.length; ++elem7) {
+              int elem6 = iprot.readI32();
+              elem8.add(elem6);
             }
             iprot.readListEnd();
-            this.listfield = elem3;
+            this.listfield = elem8;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -613,57 +615,57 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LIST2:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem4 = iprot.readListBegin();
-            final elem7 = <int>[];
-            for(int elem6 = 0; elem6 < elem4.length; ++elem6) {
-              int elem5 = iprot.readI32();
-              elem7.add(elem5);
+            thrift.TList elem9 = iprot.readListBegin();
+            final elem12 = <int>[];
+            for(int elem11 = 0; elem11 < elem9.length; ++elem11) {
+              int elem10 = iprot.readI32();
+              elem12.add(elem10);
             }
             iprot.readListEnd();
-            this.list2 = elem7;
+            this.list2 = elem12;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST3:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem8 = iprot.readListBegin();
-            final elem11 = <int>[];
-            for(int elem10 = 0; elem10 < elem8.length; ++elem10) {
-              int elem9 = iprot.readI32();
-              elem11.add(elem9);
+            thrift.TList elem13 = iprot.readListBegin();
+            final elem16 = <int>[];
+            for(int elem15 = 0; elem15 < elem13.length; ++elem15) {
+              int elem14 = iprot.readI32();
+              elem16.add(elem14);
             }
             iprot.readListEnd();
-            this.list3 = elem11;
+            this.list3 = elem16;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST4:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem12 = iprot.readListBegin();
-            final elem15 = <int>[];
-            for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
-              int elem13 = iprot.readI32();
-              elem15.add(elem13);
+            thrift.TList elem17 = iprot.readListBegin();
+            final elem20 = <int>[];
+            for(int elem19 = 0; elem19 < elem17.length; ++elem19) {
+              int elem18 = iprot.readI32();
+              elem20.add(elem18);
             }
             iprot.readListEnd();
-            this.list4 = elem15;
+            this.list4 = elem20;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case A_MAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem16 = iprot.readMapBegin();
-            final elem19 = <String, String>{};
-            for(int elem18 = 0; elem18 < elem16.length; ++elem18) {
-              String elem20 = iprot.readString();
-              String elem17 = iprot.readString();
-              elem19[elem20] = elem17;
+            thrift.TMap elem21 = iprot.readMapBegin();
+            final elem24 = <String, String>{};
+            for(int elem23 = 0; elem23 < elem21.length; ++elem23) {
+              String elem25 = iprot.readString();
+              String elem22 = iprot.readString();
+              elem24[elem25] = elem22;
             }
             iprot.readMapEnd();
-            this.a_map = elem19;
+            this.a_map = elem24;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -700,113 +702,127 @@ class TestingDefaults implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem26 = iD2;
     if (isSetID2()) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
-      oprot.writeI64(this.iD2);
+      oprot.writeI64(elem26);
       oprot.writeFieldEnd();
     }
-    if (this.ev1 != null) {
+    final elem27 = ev1;
+    if (elem27 != null) {
       oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      this.ev1.write(oprot);
+      elem27.write(oprot);
       oprot.writeFieldEnd();
     }
-    if (this.ev2 != null) {
+    final elem28 = ev2;
+    if (elem28 != null) {
       oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      this.ev2.write(oprot);
+      elem28.write(oprot);
       oprot.writeFieldEnd();
     }
+    final elem29 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(this.iD);
+    oprot.writeI64(elem29);
     oprot.writeFieldEnd();
-    if (this.thing != null) {
+    final elem30 = thing;
+    if (elem30 != null) {
       oprot.writeFieldBegin(_THING_FIELD_DESC);
-      oprot.writeString(this.thing);
+      oprot.writeString(elem30);
       oprot.writeFieldEnd();
     }
-    if (isSetThing2() && this.thing2 != null) {
+    final elem31 = thing2;
+    if (isSetThing2() && elem31 != null) {
       oprot.writeFieldBegin(_THING2_FIELD_DESC);
-      oprot.writeString(this.thing2);
+      oprot.writeString(elem31);
       oprot.writeFieldEnd();
     }
-    if (this.listfield != null) {
+    final elem32 = listfield;
+    if (elem32 != null) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
-      final temp = this.listfield;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem21 in temp) {
-        oprot.writeI32(elem21);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem32.length));
+      for(var elem33 in elem32) {
+        oprot.writeI32(elem33);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
+    final elem34 = iD3;
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
-    oprot.writeI64(this.iD3);
+    oprot.writeI64(elem34);
     oprot.writeFieldEnd();
-    if (this.bin_field != null) {
+    final elem35 = bin_field;
+    if (elem35 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_FIELD_DESC);
-      oprot.writeBinary(this.bin_field);
+      oprot.writeBinary(elem35);
       oprot.writeFieldEnd();
     }
-    if (isSetBin_field2() && this.bin_field2 != null) {
+    final elem36 = bin_field2;
+    if (isSetBin_field2() && elem36 != null) {
       oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
-      oprot.writeBinary(this.bin_field2);
+      oprot.writeBinary(elem36);
       oprot.writeFieldEnd();
     }
-    if (this.bin_field3 != null) {
+    final elem37 = bin_field3;
+    if (elem37 != null) {
       oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
-      oprot.writeBinary(this.bin_field3);
+      oprot.writeBinary(elem37);
       oprot.writeFieldEnd();
     }
-    if (isSetBin_field4() && this.bin_field4 != null) {
+    final elem38 = bin_field4;
+    if (isSetBin_field4() && elem38 != null) {
       oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
-      oprot.writeBinary(this.bin_field4);
+      oprot.writeBinary(elem38);
       oprot.writeFieldEnd();
     }
-    if (isSetList2() && this.list2 != null) {
+    final elem39 = list2;
+    if (isSetList2() && elem39 != null) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
-      final temp = this.list2;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem22 in temp) {
-        oprot.writeI32(elem22);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem39.length));
+      for(var elem40 in elem39) {
+        oprot.writeI32(elem40);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetList3() && this.list3 != null) {
+    final elem41 = list3;
+    if (isSetList3() && elem41 != null) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
-      final temp = this.list3;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem23 in temp) {
-        oprot.writeI32(elem23);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem41.length));
+      for(var elem42 in elem41) {
+        oprot.writeI32(elem42);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (this.list4 != null) {
+    final elem43 = list4;
+    if (elem43 != null) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
-      final temp = this.list4;
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, temp.length));
-      for(var elem24 in temp) {
-        oprot.writeI32(elem24);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem43.length));
+      for(var elem44 in elem43) {
+        oprot.writeI32(elem44);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetA_map() && this.a_map != null) {
+    final elem45 = a_map;
+    if (isSetA_map() && elem45 != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
-      final temp = this.a_map;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, temp.length));
-      for(var elem25 in temp.keys) {
-        oprot.writeString(elem25);
-        oprot.writeString(temp[elem25]);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem45.length));
+      for(var elem46 in elem45.keys) {
+        final val = elem45[elem46];
+        oprot.writeString(elem46);
+        oprot.writeString(val);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
+    final elem47 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(this.status);
+    oprot.writeI32(elem47);
     oprot.writeFieldEnd();
+    final elem48 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(this.base_status);
+    oprot.writeI32(elem48);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
@@ -809,20 +809,20 @@ class TestingDefaults implements thrift.TBase {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
       oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem45.length));
       for(var elem46 in elem45.keys) {
-        final val = elem45[elem46];
+        final elem47 = elem45[elem46];
         oprot.writeString(elem46);
-        oprot.writeString(val);
+        oprot.writeString(elem47);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem47 = status;
+    final elem48 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem47);
-    oprot.writeFieldEnd();
-    final elem48 = base_status;
-    oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
     oprot.writeI32(elem48);
+    oprot.writeFieldEnd();
+    final elem49 = base_status;
+    oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
+    oprot.writeI32(elem49);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
@@ -525,18 +525,18 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_ev1 = t_variety.Event();
-            this.ev1 = tmp_ev1;
-            tmp_ev1.read(iprot);
+            final elem6 = t_variety.Event();
+            this.ev1 = elem6;
+            elem6.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
-            final tmp_ev2 = t_variety.Event();
-            this.ev2 = tmp_ev2;
-            tmp_ev2.read(iprot);
+            final elem7 = t_variety.Event();
+            this.ev2 = elem7;
+            elem7.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -565,14 +565,14 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LISTFIELD:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem5 = iprot.readListBegin();
-            final elem8 = <int>[];
-            for(int elem7 = 0; elem7 < elem5.length; ++elem7) {
-              int elem6 = iprot.readI32();
-              elem8.add(elem6);
+            thrift.TList elem8 = iprot.readListBegin();
+            final elem11 = <int>[];
+            for(int elem10 = 0; elem10 < elem8.length; ++elem10) {
+              int elem9 = iprot.readI32();
+              elem11.add(elem9);
             }
             iprot.readListEnd();
-            this.listfield = elem8;
+            this.listfield = elem11;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -615,57 +615,57 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LIST2:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem9 = iprot.readListBegin();
-            final elem12 = <int>[];
-            for(int elem11 = 0; elem11 < elem9.length; ++elem11) {
-              int elem10 = iprot.readI32();
-              elem12.add(elem10);
+            thrift.TList elem12 = iprot.readListBegin();
+            final elem15 = <int>[];
+            for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
+              int elem13 = iprot.readI32();
+              elem15.add(elem13);
             }
             iprot.readListEnd();
-            this.list2 = elem12;
+            this.list2 = elem15;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST3:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem13 = iprot.readListBegin();
-            final elem16 = <int>[];
-            for(int elem15 = 0; elem15 < elem13.length; ++elem15) {
-              int elem14 = iprot.readI32();
-              elem16.add(elem14);
+            thrift.TList elem16 = iprot.readListBegin();
+            final elem19 = <int>[];
+            for(int elem18 = 0; elem18 < elem16.length; ++elem18) {
+              int elem17 = iprot.readI32();
+              elem19.add(elem17);
             }
             iprot.readListEnd();
-            this.list3 = elem16;
+            this.list3 = elem19;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST4:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem17 = iprot.readListBegin();
-            final elem20 = <int>[];
-            for(int elem19 = 0; elem19 < elem17.length; ++elem19) {
-              int elem18 = iprot.readI32();
-              elem20.add(elem18);
+            thrift.TList elem20 = iprot.readListBegin();
+            final elem23 = <int>[];
+            for(int elem22 = 0; elem22 < elem20.length; ++elem22) {
+              int elem21 = iprot.readI32();
+              elem23.add(elem21);
             }
             iprot.readListEnd();
-            this.list4 = elem20;
+            this.list4 = elem23;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case A_MAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem21 = iprot.readMapBegin();
-            final elem24 = <String, String>{};
-            for(int elem23 = 0; elem23 < elem21.length; ++elem23) {
+            thrift.TMap elem24 = iprot.readMapBegin();
+            final elem27 = <String, String>{};
+            for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
+              String elem28 = iprot.readString();
               String elem25 = iprot.readString();
-              String elem22 = iprot.readString();
-              elem24[elem25] = elem22;
+              elem27[elem28] = elem25;
             }
             iprot.readMapEnd();
-            this.a_map = elem24;
+            this.a_map = elem27;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -702,127 +702,127 @@ class TestingDefaults implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem26 = iD2;
+    final elem29 = iD2;
     if (isSetID2()) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
-      oprot.writeI64(elem26);
+      oprot.writeI64(elem29);
       oprot.writeFieldEnd();
     }
-    final elem27 = ev1;
-    if (elem27 != null) {
-      oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      elem27.write(oprot);
-      oprot.writeFieldEnd();
-    }
-    final elem28 = ev2;
-    if (elem28 != null) {
-      oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      elem28.write(oprot);
-      oprot.writeFieldEnd();
-    }
-    final elem29 = iD;
-    oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem29);
-    oprot.writeFieldEnd();
-    final elem30 = thing;
+    final elem30 = ev1;
     if (elem30 != null) {
+      oprot.writeFieldBegin(_EV1_FIELD_DESC);
+      elem30.write(oprot);
+      oprot.writeFieldEnd();
+    }
+    final elem31 = ev2;
+    if (elem31 != null) {
+      oprot.writeFieldBegin(_EV2_FIELD_DESC);
+      elem31.write(oprot);
+      oprot.writeFieldEnd();
+    }
+    final elem32 = iD;
+    oprot.writeFieldBegin(_ID_FIELD_DESC);
+    oprot.writeI64(elem32);
+    oprot.writeFieldEnd();
+    final elem33 = thing;
+    if (elem33 != null) {
       oprot.writeFieldBegin(_THING_FIELD_DESC);
-      oprot.writeString(elem30);
+      oprot.writeString(elem33);
       oprot.writeFieldEnd();
     }
-    final elem31 = thing2;
-    if (isSetThing2() && elem31 != null) {
+    final elem34 = thing2;
+    if (isSetThing2() && elem34 != null) {
       oprot.writeFieldBegin(_THING2_FIELD_DESC);
-      oprot.writeString(elem31);
+      oprot.writeString(elem34);
       oprot.writeFieldEnd();
     }
-    final elem32 = listfield;
-    if (elem32 != null) {
+    final elem35 = listfield;
+    if (elem35 != null) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem32.length));
-      for(var elem33 in elem32) {
-        oprot.writeI32(elem33);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem35.length));
+      for(var elem36 in elem35) {
+        oprot.writeI32(elem36);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem34 = iD3;
+    final elem37 = iD3;
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
-    oprot.writeI64(elem34);
+    oprot.writeI64(elem37);
     oprot.writeFieldEnd();
-    final elem35 = bin_field;
-    if (elem35 != null) {
+    final elem38 = bin_field;
+    if (elem38 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_FIELD_DESC);
-      oprot.writeBinary(elem35);
-      oprot.writeFieldEnd();
-    }
-    final elem36 = bin_field2;
-    if (isSetBin_field2() && elem36 != null) {
-      oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
-      oprot.writeBinary(elem36);
-      oprot.writeFieldEnd();
-    }
-    final elem37 = bin_field3;
-    if (elem37 != null) {
-      oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
-      oprot.writeBinary(elem37);
-      oprot.writeFieldEnd();
-    }
-    final elem38 = bin_field4;
-    if (isSetBin_field4() && elem38 != null) {
-      oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
       oprot.writeBinary(elem38);
       oprot.writeFieldEnd();
     }
-    final elem39 = list2;
-    if (isSetList2() && elem39 != null) {
+    final elem39 = bin_field2;
+    if (isSetBin_field2() && elem39 != null) {
+      oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
+      oprot.writeBinary(elem39);
+      oprot.writeFieldEnd();
+    }
+    final elem40 = bin_field3;
+    if (elem40 != null) {
+      oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
+      oprot.writeBinary(elem40);
+      oprot.writeFieldEnd();
+    }
+    final elem41 = bin_field4;
+    if (isSetBin_field4() && elem41 != null) {
+      oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
+      oprot.writeBinary(elem41);
+      oprot.writeFieldEnd();
+    }
+    final elem42 = list2;
+    if (isSetList2() && elem42 != null) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem39.length));
-      for(var elem40 in elem39) {
-        oprot.writeI32(elem40);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem42.length));
+      for(var elem43 in elem42) {
+        oprot.writeI32(elem43);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem41 = list3;
-    if (isSetList3() && elem41 != null) {
+    final elem44 = list3;
+    if (isSetList3() && elem44 != null) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem41.length));
-      for(var elem42 in elem41) {
-        oprot.writeI32(elem42);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem44.length));
+      for(var elem45 in elem44) {
+        oprot.writeI32(elem45);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem43 = list4;
-    if (elem43 != null) {
+    final elem46 = list4;
+    if (elem46 != null) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem43.length));
-      for(var elem44 in elem43) {
-        oprot.writeI32(elem44);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem46.length));
+      for(var elem47 in elem46) {
+        oprot.writeI32(elem47);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem45 = a_map;
-    if (isSetA_map() && elem45 != null) {
+    final elem48 = a_map;
+    if (isSetA_map() && elem48 != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem45.length));
-      for(var elem46 in elem45.keys) {
-        final elem47 = elem45[elem46];
-        oprot.writeString(elem46);
-        oprot.writeString(elem47);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem48.length));
+      for(var elem49 in elem48.keys) {
+        final elem50 = elem48[elem49];
+        oprot.writeString(elem49);
+        oprot.writeString(elem50);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem48 = status;
+    final elem51 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem48);
+    oprot.writeI32(elem51);
     oprot.writeFieldEnd();
-    final elem49 = base_status;
+    final elem52 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(elem49);
+    oprot.writeI32(elem52);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_unions.dart
@@ -300,15 +300,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem133 = iprot.readMapBegin();
-            final elem136 = <int, String>{};
-            for(int elem135 = 0; elem135 < elem133.length; ++elem135) {
-              int elem137 = iprot.readI32();
-              String elem134 = iprot.readString();
-              elem136[elem137] = elem134;
+            thrift.TMap elem127 = iprot.readMapBegin();
+            final elem130 = <int, String>{};
+            for(int elem129 = 0; elem129 < elem127.length; ++elem129) {
+              int elem131 = iprot.readI32();
+              String elem128 = iprot.readString();
+              elem130[elem131] = elem128;
             }
             iprot.readMapEnd();
-            this.requests = elem136;
+            this.requests = elem130;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -353,59 +353,58 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem138 = anID;
+    final elem132 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(elem138);
+      oprot.writeI64(elem132);
       oprot.writeFieldEnd();
     }
-    final elem139 = aString;
-    if (isSetAString() && elem139 != null) {
+    final elem133 = aString;
+    if (isSetAString() && elem133 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem139);
+      oprot.writeString(elem133);
       oprot.writeFieldEnd();
     }
-    final elem140 = someotherthing;
+    final elem134 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem140);
+      oprot.writeI32(elem134);
       oprot.writeFieldEnd();
     }
-    final elem141 = anInt16;
+    final elem135 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem141);
+      oprot.writeI16(elem135);
       oprot.writeFieldEnd();
     }
-    final elem142 = requests;
-    if (isSetRequests() && elem142 != null) {
+    final elem136 = requests;
+    if (isSetRequests() && elem136 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem142.length));
-      for(var elem143 in elem142.keys) {
-        final elem144 = elem142[elem143];
-        oprot.writeI32(elem143);
-        oprot.writeString(elem144);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem136.length));
+      for(var entry in elem136.entries) {
+        oprot.writeI32(entry.key);
+        oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem145 = bin_field_in_union;
-    if (isSetBin_field_in_union() && elem145 != null) {
+    final elem137 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem137 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem145);
+      oprot.writeBinary(elem137);
       oprot.writeFieldEnd();
     }
-    final elem146 = depr;
+    final elem138 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem146);
+      oprot.writeBool(elem138);
       oprot.writeFieldEnd();
     }
-    final elem147 = wHOA_BUDDY;
+    final elem139 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem147);
+      oprot.writeBool(elem139);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_unions.dart
@@ -300,15 +300,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem122 = iprot.readMapBegin();
-            final elem125 = <int, String>{};
-            for(int elem124 = 0; elem124 < elem122.length; ++elem124) {
-              int elem126 = iprot.readI32();
-              String elem123 = iprot.readString();
-              elem125[elem126] = elem123;
+            thrift.TMap elem133 = iprot.readMapBegin();
+            final elem136 = <int, String>{};
+            for(int elem135 = 0; elem135 < elem133.length; ++elem135) {
+              int elem137 = iprot.readI32();
+              String elem134 = iprot.readString();
+              elem136[elem137] = elem134;
             }
             iprot.readMapEnd();
-            this.requests = elem125;
+            this.requests = elem136;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -353,59 +353,59 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem127 = anID;
+    final elem138 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(elem127);
+      oprot.writeI64(elem138);
       oprot.writeFieldEnd();
     }
-    final elem128 = aString;
-    if (isSetAString() && elem128 != null) {
+    final elem139 = aString;
+    if (isSetAString() && elem139 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem128);
+      oprot.writeString(elem139);
       oprot.writeFieldEnd();
     }
-    final elem129 = someotherthing;
+    final elem140 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem129);
+      oprot.writeI32(elem140);
       oprot.writeFieldEnd();
     }
-    final elem130 = anInt16;
+    final elem141 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem130);
+      oprot.writeI16(elem141);
       oprot.writeFieldEnd();
     }
-    final elem131 = requests;
-    if (isSetRequests() && elem131 != null) {
+    final elem142 = requests;
+    if (isSetRequests() && elem142 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem131.length));
-      for(var elem132 in elem131.keys) {
-        final elem133 = elem131[elem132];
-        oprot.writeI32(elem132);
-        oprot.writeString(elem133);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem142.length));
+      for(var elem143 in elem142.keys) {
+        final elem144 = elem142[elem143];
+        oprot.writeI32(elem143);
+        oprot.writeString(elem144);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem134 = bin_field_in_union;
-    if (isSetBin_field_in_union() && elem134 != null) {
+    final elem145 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem145 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem134);
+      oprot.writeBinary(elem145);
       oprot.writeFieldEnd();
     }
-    final elem135 = depr;
+    final elem146 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem135);
+      oprot.writeBool(elem146);
       oprot.writeFieldEnd();
     }
-    final elem136 = wHOA_BUDDY;
+    final elem147 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem136);
+      oprot.writeBool(elem147);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_unions.dart
@@ -300,15 +300,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem119 = iprot.readMapBegin();
-            final elem122 = <int, String>{};
-            for(int elem121 = 0; elem121 < elem119.length; ++elem121) {
-              int elem123 = iprot.readI32();
-              String elem120 = iprot.readString();
-              elem122[elem123] = elem120;
+            thrift.TMap elem122 = iprot.readMapBegin();
+            final elem125 = <int, String>{};
+            for(int elem124 = 0; elem124 < elem122.length; ++elem124) {
+              int elem126 = iprot.readI32();
+              String elem123 = iprot.readString();
+              elem125[elem126] = elem123;
             }
             iprot.readMapEnd();
-            this.requests = elem122;
+            this.requests = elem125;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -353,59 +353,59 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem124 = anID;
+    final elem127 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(elem124);
+      oprot.writeI64(elem127);
       oprot.writeFieldEnd();
     }
-    final elem125 = aString;
-    if (isSetAString() && elem125 != null) {
+    final elem128 = aString;
+    if (isSetAString() && elem128 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem125);
+      oprot.writeString(elem128);
       oprot.writeFieldEnd();
     }
-    final elem126 = someotherthing;
+    final elem129 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem126);
+      oprot.writeI32(elem129);
       oprot.writeFieldEnd();
     }
-    final elem127 = anInt16;
+    final elem130 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem127);
+      oprot.writeI16(elem130);
       oprot.writeFieldEnd();
     }
-    final elem128 = requests;
-    if (isSetRequests() && elem128 != null) {
+    final elem131 = requests;
+    if (isSetRequests() && elem131 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem128.length));
-      for(var elem129 in elem128.keys) {
-        final val = elem128[elem129];
-        oprot.writeI32(elem129);
-        oprot.writeString(val);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem131.length));
+      for(var elem132 in elem131.keys) {
+        final elem133 = elem131[elem132];
+        oprot.writeI32(elem132);
+        oprot.writeString(elem133);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem130 = bin_field_in_union;
-    if (isSetBin_field_in_union() && elem130 != null) {
+    final elem134 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem134 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem130);
+      oprot.writeBinary(elem134);
       oprot.writeFieldEnd();
     }
-    final elem131 = depr;
+    final elem135 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem131);
+      oprot.writeBool(elem135);
       oprot.writeFieldEnd();
     }
-    final elem132 = wHOA_BUDDY;
+    final elem136 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem132);
+      oprot.writeBool(elem136);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_unions.dart
@@ -300,15 +300,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem77 = iprot.readMapBegin();
-            final elem80 = <int, String>{};
-            for(int elem79 = 0; elem79 < elem77.length; ++elem79) {
-              int elem81 = iprot.readI32();
-              String elem78 = iprot.readString();
-              elem80[elem81] = elem78;
+            thrift.TMap elem119 = iprot.readMapBegin();
+            final elem122 = <int, String>{};
+            for(int elem121 = 0; elem121 < elem119.length; ++elem121) {
+              int elem123 = iprot.readI32();
+              String elem120 = iprot.readString();
+              elem122[elem123] = elem120;
             }
             iprot.readMapEnd();
-            this.requests = elem80;
+            this.requests = elem122;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -353,52 +353,59 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
+    final elem124 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(this.anID);
+      oprot.writeI64(elem124);
       oprot.writeFieldEnd();
     }
-    if (isSetAString() && this.aString != null) {
+    final elem125 = aString;
+    if (isSetAString() && elem125 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(this.aString);
+      oprot.writeString(elem125);
       oprot.writeFieldEnd();
     }
+    final elem126 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(this.someotherthing);
+      oprot.writeI32(elem126);
       oprot.writeFieldEnd();
     }
+    final elem127 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(this.anInt16);
+      oprot.writeI16(elem127);
       oprot.writeFieldEnd();
     }
-    if (isSetRequests() && this.requests != null) {
+    final elem128 = requests;
+    if (isSetRequests() && elem128 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      final temp = this.requests;
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, temp.length));
-      for(var elem82 in temp.keys) {
-        oprot.writeI32(elem82);
-        oprot.writeString(temp[elem82]);
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem128.length));
+      for(var elem129 in elem128.keys) {
+        final val = elem128[elem129];
+        oprot.writeI32(elem129);
+        oprot.writeString(val);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    if (isSetBin_field_in_union() && this.bin_field_in_union != null) {
+    final elem130 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem130 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(this.bin_field_in_union);
+      oprot.writeBinary(elem130);
       oprot.writeFieldEnd();
     }
+    final elem131 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      // ignore: deprecated_member_use
-      oprot.writeBool(this.depr);
+      oprot.writeBool(elem131);
       oprot.writeFieldEnd();
     }
+    final elem132 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(this.wHOA_BUDDY);
+      oprot.writeBool(elem132);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_unions.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart/variety/f_variety_constants.dart
+++ b/compiler/testdata/expected/dart/variety/f_variety_constants.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:convert' show utf8;
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart/vendor_namespace/f_item.dart
+++ b/compiler/testdata/expected/dart/vendor_namespace/f_item.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:typed_data' show Uint8List;
 
 import 'package:collection/collection.dart';

--- a/compiler/testdata/expected/dart/vendor_namespace/f_vendor_namespace_constants.dart
+++ b/compiler/testdata/expected/dart/vendor_namespace/f_vendor_namespace_constants.dart
@@ -3,9 +3,6 @@
 
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
-// ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:convert' show utf8;
 import 'dart:typed_data' show Uint8List;
 

--- a/compiler/testdata/expected/dart/vendor_namespace/f_vendored_base_service.dart
+++ b/compiler/testdata/expected/dart/vendor_namespace/f_vendored_base_service.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: unused_import
 // ignore_for_file: unused_field
 // ignore_for_file: invalid_null_aware_operator
-// ignore_for_file: unnecessary_non_null_assertion
-// ignore_for_file: unnecessary_null_comparison
 import 'dart:async';
 import 'dart:typed_data' show Uint8List;
 


### PR DESCRIPTION
### Story:

The generated nullsafe code had some ? added in places that should be treated as lints, but were somehow causing compile problems. There's also an await on a call that does not and will not be returning a Future, despite the comment that v2 will.

### Acceptance Criteria:
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master
