### PR TITLE
FEDX-423 : Resolve analyzer error in some repos

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -1257,7 +1257,6 @@ func (g *Generator) generateWrite(s *parser.Struct, kind structKind) string {
 
 		tmpElem := g.GetElem()
 		tmpField := parser.FieldFromType(field.Type, tmpElem)
-		contents += tabtab + fmt.Sprintf("final %s = %s;\n", tmpElem, fName)
 
 		var isSet bool
 		var isNull bool
@@ -1282,6 +1281,11 @@ func (g *Generator) generateWrite(s *parser.Struct, kind structKind) string {
 			isNull = !g.isDartPrimitive(g.Frugal.UnderlyingType(field.Type))
 		}
 
+		if isNull {
+			contents += tabtab + fmt.Sprintf("final %s = %s;\n", tmpElem, fName)
+		} else {
+			contents += tabtab + fmt.Sprintf("final %s = %s%s;\n", tmpElem, fName, g.notNullOperator)
+		}
 		ind := ""
 		if isSet || isNull {
 			ind = tab

--- a/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullsafe/actual_base/f_thing.dart
@@ -126,7 +126,7 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem180 = an_id;
+    final elem180 = an_id!;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
     oprot.writeI32(elem180);
     oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_awesome_exception.dart
@@ -184,7 +184,7 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem140 = iD;
+    final elem140 = iD!;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
     oprot.writeI64(elem140);
     oprot.writeFieldEnd();
@@ -194,7 +194,7 @@ class AwesomeException extends Error implements thrift.TBase {
       oprot.writeString(elem141);
       oprot.writeFieldEnd();
     }
-    final elem142 = depr;
+    final elem142 = depr!;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
     oprot.writeBool(elem142);
     oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_event.dart
@@ -180,7 +180,7 @@ class Event implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem3 = iD;
+    final elem3 = iD!;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
     oprot.writeI64(elem3);
     oprot.writeFieldEnd();
@@ -190,7 +190,7 @@ class Event implements thrift.TBase {
       oprot.writeString(elem4);
       oprot.writeFieldEnd();
     }
-    final elem5 = yES_NO;
+    final elem5 = yES_NO!;
     oprot.writeFieldBegin(_YE_S__NO_FIELD_DESC);
     oprot.writeBool(elem5);
     oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_event_wrapper.dart
@@ -674,7 +674,7 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem100 = iD;
+    final elem100 = iD!;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
       oprot.writeI64(elem100);
@@ -741,7 +741,7 @@ class EventWrapper implements thrift.TBase {
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem112 = aBoolField;
+    final elem112 = aBoolField!;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
     oprot.writeBool(elem112);
     oprot.writeFieldEnd();
@@ -757,7 +757,7 @@ class EventWrapper implements thrift.TBase {
       oprot.writeString(elem114);
       oprot.writeFieldEnd();
     }
-    final elem115 = depr;
+    final elem115 = depr!;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
     oprot.writeBool(elem115);
     oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_foo_service.dart
@@ -415,7 +415,7 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem143 = num;
+    final elem143 = num!;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
     oprot.writeI32(elem143);
     oprot.writeFieldEnd();
@@ -506,7 +506,7 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem148 = id;
+    final elem148 = id!;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
     oprot.writeI64(elem148);
     oprot.writeFieldEnd();
@@ -622,15 +622,15 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem153 = opt_num;
+    final elem153 = opt_num!;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
     oprot.writeI32(elem153);
     oprot.writeFieldEnd();
-    final elem154 = default_num;
+    final elem154 = default_num!;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
     oprot.writeI32(elem154);
     oprot.writeFieldEnd();
-    final elem155 = req_num;
+    final elem155 = req_num!;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
     oprot.writeI32(elem155);
     oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_test_lowercase.dart
@@ -103,7 +103,7 @@ class TestLowercase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem2 = lowercaseInt;
+    final elem2 = lowercaseInt!;
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
     oprot.writeI32(elem2);
     oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_defaults.dart
@@ -702,7 +702,7 @@ class TestingDefaults implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem29 = iD2;
+    final elem29 = iD2!;
     if (isSetID2()) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
       oprot.writeI64(elem29);
@@ -720,7 +720,7 @@ class TestingDefaults implements thrift.TBase {
       elem31.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem32 = iD;
+    final elem32 = iD!;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
     oprot.writeI64(elem32);
     oprot.writeFieldEnd();
@@ -746,7 +746,7 @@ class TestingDefaults implements thrift.TBase {
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem37 = iD3;
+    final elem37 = iD3!;
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
     oprot.writeI64(elem37);
     oprot.writeFieldEnd();
@@ -815,11 +815,11 @@ class TestingDefaults implements thrift.TBase {
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem49 = status;
+    final elem49 = status!;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
     oprot.writeI32(elem49);
     oprot.writeFieldEnd();
-    final elem50 = base_status;
+    final elem50 = base_status!;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
     oprot.writeI32(elem50);
     oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullsafe/variety/f_testing_unions.dart
@@ -353,7 +353,7 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem132 = anID;
+    final elem132 = anID!;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
       oprot.writeI64(elem132);
@@ -365,13 +365,13 @@ class TestingUnions implements thrift.TBase {
       oprot.writeString(elem133);
       oprot.writeFieldEnd();
     }
-    final elem134 = someotherthing;
+    final elem134 = someotherthing!;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
       oprot.writeI32(elem134);
       oprot.writeFieldEnd();
     }
-    final elem135 = anInt16;
+    final elem135 = anInt16!;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
       oprot.writeI16(elem135);
@@ -394,14 +394,14 @@ class TestingUnions implements thrift.TBase {
       oprot.writeBinary(elem137);
       oprot.writeFieldEnd();
     }
-    final elem138 = depr;
+    final elem138 = depr!;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
       oprot.writeBool(elem138);
       oprot.writeFieldEnd();
     }
-    final elem139 = wHOA_BUDDY;
+    final elem139 = wHOA_BUDDY!;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
       oprot.writeBool(elem139);


### PR DESCRIPTION
Resolve the following analyzer error in some files of the nullsafe generated code

`The property 'length' can't be unconditionally accessed because the receiver can be 'null'. Try making the access conditional (using '?.') or adding a null check to the target ('!').`

This is present in some of the repos like **content-aggregation-frugal** and **attachments-package-frugal**