### PR TITLE
Add an option that will allow callers to decide if dart sdk annotations are included. 👨‍💼

### DIFF
--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -47,12 +47,14 @@ const (
 	useInt64              = "use_int64"
 	useVendorOption       = "use_vendor"
 	nullsafe              = "nullsafe"
-	addDartComment        = false // Enable this when debugging Dart generated code
+	addDartCommentOption  = "adddartcomment" // Useful when generating unsound null-safe code (pubspec.yaml sdk >= 2.12, some files annotated at 2.11)
 	thriftVer             = "^0.0.14"
 	collectionVer         = "^1.14.12"
 	nullsafeThriftVer     = "^0.0.15"
 	nullsafeCollectionVer = "^1.15.0"
 )
+
+var addDartComment = false // Enable this when debugging Dart generated code
 
 // Generator implements the LanguageGenerator interface for Dart.
 type Generator struct {
@@ -76,6 +78,10 @@ func NewGenerator(options map[string]string) generator.LanguageGenerator {
 	generator.thriftVer = thriftVer
 	generator.collectionVer = collectionVer
 	generator.dartComment = "// @dart=2.11"
+
+	if _, ok := options[addDartCommentOption]; ok {
+		addDartComment = true
+	}
 	if _, ok := options[nullsafe]; ok {
 		generator.genNullsafe = true
 		generator.nullableOperator = "?"


### PR DESCRIPTION
### Story:
doc_plat_client is running in unsound null-safety to allow incremental conversion.  This means that it needs to specify which code is not null-safe by putting a `// @dart=2.11` annotation at the top of each unsafe file.  The generator already has the capability to generate this comment, but no control for callers to toggle the ability.

This PR adds an option which, when present, turns on the annotation of output files.

### Acceptance Criteria:
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
TODO

### My Test Results:
TODO

#### Reviewers:
@Workiva/service-platform
