### PR TITLE
Dart 2.19

### DIFF
--- a/scripts/skynet/cross/setup_dart.sh
+++ b/scripts/skynet/cross/setup_dart.sh
@@ -7,21 +7,21 @@ export FRUGAL_HOME=$GOPATH/src/github.com/Workiva/frugal
 # Dart Dependencies
 cd $FRUGAL_HOME/test/integration/dart/test_client
 rm -rf .packages packages
-pub upgrade
+dart pub upgrade
 
-# Try pub get and ignore failures - it will fail on any release
+# Try dart pub get and ignore failures - it will fail on any release
 cd $FRUGAL_HOME/test/integration/dart/gen-dart/frugal_test
-if pub upgrade ; then
-    echo 'pub upgrade returned no error'
+if dart pub upgrade ; then
+    echo 'dart pub upgrade returned no error'
 else
-    echo 'Pub upgrade returned an error we ignored'
+    echo 'dart pub upgrade returned an error we ignored'
 fi
 
 # get frugal version to use with manually placing package in pub-cache
 frugal_version=$(frugal --version | awk '{print $3}')
 
 # we need to manually install frugal to match with the version of we are testing
-# so delete existing package (if above pub get succeeded) and override with the
+# so delete existing package (if above dart pub get succeeded) and override with the
 # current version if not. Otherwise, it will use the latest matching release
 
 rm -rf  ~/.pub-cache/hosted/pub.workiva.org/frugal-${frugal_version}/
@@ -35,4 +35,4 @@ else
     cp -r $FRUGAL_HOME/lib/dart/* $pub_extract_target
 fi
 
-pub get --offline
+dart pub get --offline


### PR DESCRIPTION
Summary
---
This batch updates CI to use Dart 2.19. In most cases, updating Just Works™, 
but here's some things that have changed or may cause problems while updating.
- The pub and dart2js aliases have been removed. You may need to replace bare pub commands. See the replacements here https://wiki.atl.workiva.net/display/CP/Dart+2.18+FAQ
- There may be some new lints, or lints that actually function better and now find new issues that need fixing or ignoring.
- Some lints may have been raised to warnings that now need fixing or ignoring until fixed.
- Dockerfiles or skynet may try to install things that don't work quite right on newer debian 11 (bullseye)
  - Potential examples are installing python or nodejs into the dart images
- If you have build.yaml files that "split" the builders into separate targets, you may have to exclude a new builder
```
  build_resolvers|transitive_digests:
    enabled: false
```

These PRs are ok to get reviewed and approved. 
If it is out of draft and there isn't a `Hold`` label, then it is ok to merge.

For support go to `#support-frontend-dx` in Slack.

[_Created by Sourcegraph batch change `Workiva/dart_2_19`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_2_19)