### PR TITLE
Update messaging docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.16 as build
+FROM drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.20 as build
 
 ARG GIT_BRANCH
 ARG GIT_MERGE_BRANCH

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -7,7 +7,7 @@ run:  # local tests only, never run in Skynet
   on-pull-request: false
 
 contact: messaging@workiva.com
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.16
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.20
 
 env:
   - IN_SKYNET_CLI=true
@@ -40,7 +40,7 @@ requires:
 
 contact: messaging@workiva.com
 
-image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.16
+image: drydock-prod.workiva.net/workiva/messaging-docker-images:0.1.20
 env:
   - PYTHONIOENCODING=utf-8
 


### PR DESCRIPTION
# Summary
This batch updates the version of messaging-docker-images
to one that has Dart 2.19.
If CI passes, you can merge this.
For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/dart_219_messaging_image`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/dart_219_messaging_image)