### PR TITLE
dart: make element number per file

### DIFF
--- a/compiler/generator/base.go
+++ b/compiler/generator/base.go
@@ -80,6 +80,10 @@ func (b *BaseGenerator) GetElem() string {
 	return s
 }
 
+func (b *BaseGenerator) ResetElem() {
+	b.elemNum = 0
+}
+
 // ServiceMethodStruct is a service method _args or _result struct.
 type ServiceMethodStruct struct {
 	*parser.Struct

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -341,6 +341,9 @@ func (g *Generator) exportClasses(dir string) error {
 
 // GenerateFile generates the given FileType.
 func (g *Generator) GenerateFile(name, outputDir string, fileType generator.FileType) (*os.File, error) {
+	// This relies on GenerateFile not calling itself recursively, so we finish writing
+	// each file before moving on to the next file. Otherwise, we could end up with conflicting
+	// variable names.
 	g.ResetElem()
 
 	if _, ok := g.Options[libraryPrefixOption]; !ok {

--- a/compiler/generator/dartlang/generator.go
+++ b/compiler/generator/dartlang/generator.go
@@ -341,6 +341,8 @@ func (g *Generator) exportClasses(dir string) error {
 
 // GenerateFile generates the given FileType.
 func (g *Generator) GenerateFile(name, outputDir string, fileType generator.FileType) (*os.File, error) {
+	g.ResetElem()
+
 	if _, ok := g.Options[libraryPrefixOption]; !ok {
 		outputDir = filepath.Join(outputDir, "lib")
 		outputDir = filepath.Join(outputDir, "src")

--- a/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_nested_thing.dart
@@ -68,16 +68,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem203 = iprot.readListBegin();
-            final elem207 = <t_actual_base_dart.thing>[];
-            for(int elem206 = 0; elem206 < elem203.length; ++elem206) {
-              final elem205 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem204 = elem205;
-              elem205.read(iprot);
-              elem207.add(elem204);
+            thrift.TList elem0 = iprot.readListBegin();
+            final elem4 = <t_actual_base_dart.thing>[];
+            for(int elem3 = 0; elem3 < elem0.length; ++elem3) {
+              final elem2 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem1 = elem2;
+              elem2.read(iprot);
+              elem4.add(elem1);
             }
             iprot.readListEnd();
-            this.things = elem207;
+            this.things = elem4;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -98,12 +98,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem208 = things;
-    if (elem208 != null) {
+    final elem5 = things;
+    if (elem5 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem208.length));
-      for(var elem209 in elem208) {
-        elem209.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem5.length));
+      for(var elem6 in elem5) {
+        elem6.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.int64/actual_base/f_thing.dart
@@ -127,14 +127,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem201 = an_id;
+    final elem0 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem201);
+    oprot.writeI32(elem0);
     oprot.writeFieldEnd();
-    final elem202 = a_string;
-    if (elem202 != null) {
+    final elem1 = a_string;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem202);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_awesome_exception.dart
@@ -185,19 +185,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem161 = iD;
+    final elem0 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(elem161);
+    oprot.writeInt64(elem0);
     oprot.writeFieldEnd();
-    final elem162 = reason;
-    if (elem162 != null) {
+    final elem1 = reason;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem162);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem163 = depr;
+    final elem2 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem163);
+    oprot.writeBool(elem2);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_event.dart
@@ -181,19 +181,19 @@ class Event implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem3 = iD;
+    final elem0 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(elem3);
+    oprot.writeInt64(elem0);
     oprot.writeFieldEnd();
-    final elem4 = message;
-    if (elem4 != null) {
+    final elem1 = message;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem4);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem5 = yES_NO;
+    final elem2 = yES_NO;
     oprot.writeFieldBegin(_YE_S__NO_FIELD_DESC);
-    oprot.writeBool(elem5);
+    oprot.writeBool(elem2);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_event_wrapper.dart
@@ -532,92 +532,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            final elem51 = t_variety.Event();
-            this.ev = elem51;
-            elem51.read(iprot);
+            final elem0 = t_variety.Event();
+            this.ev = elem0;
+            elem0.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem52 = iprot.readListBegin();
-            final elem56 = <t_variety.Event>[];
-            for(int elem55 = 0; elem55 < elem52.length; ++elem55) {
-              final elem54 = t_variety.Event();
-              t_variety.Event elem53 = elem54;
-              elem54.read(iprot);
-              elem56.add(elem53);
+            thrift.TList elem1 = iprot.readListBegin();
+            final elem5 = <t_variety.Event>[];
+            for(int elem4 = 0; elem4 < elem1.length; ++elem4) {
+              final elem3 = t_variety.Event();
+              t_variety.Event elem2 = elem3;
+              elem3.read(iprot);
+              elem5.add(elem2);
             }
             iprot.readListEnd();
-            this.events = elem56;
+            this.events = elem5;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem57 = iprot.readSetBegin();
-            final elem61 = <t_variety.Event>{};
-            for(int elem60 = 0; elem60 < elem57.length; ++elem60) {
-              final elem59 = t_variety.Event();
-              t_variety.Event elem58 = elem59;
-              elem59.read(iprot);
-              elem61.add(elem58);
+            thrift.TSet elem6 = iprot.readSetBegin();
+            final elem10 = <t_variety.Event>{};
+            for(int elem9 = 0; elem9 < elem6.length; ++elem9) {
+              final elem8 = t_variety.Event();
+              t_variety.Event elem7 = elem8;
+              elem8.read(iprot);
+              elem10.add(elem7);
             }
             iprot.readSetEnd();
-            this.events2 = elem61;
+            this.events2 = elem10;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem62 = iprot.readMapBegin();
-            final elem66 = <fixnum.Int64, t_variety.Event>{};
-            for(int elem65 = 0; elem65 < elem62.length; ++elem65) {
-              fixnum.Int64 elem67 = iprot.readInt64();
-              final elem64 = t_variety.Event();
-              t_variety.Event elem63 = elem64;
-              elem64.read(iprot);
-              elem66[elem67] = elem63;
+            thrift.TMap elem11 = iprot.readMapBegin();
+            final elem15 = <fixnum.Int64, t_variety.Event>{};
+            for(int elem14 = 0; elem14 < elem11.length; ++elem14) {
+              fixnum.Int64 elem16 = iprot.readInt64();
+              final elem13 = t_variety.Event();
+              t_variety.Event elem12 = elem13;
+              elem13.read(iprot);
+              elem15[elem16] = elem12;
             }
             iprot.readMapEnd();
-            this.eventMap = elem66;
+            this.eventMap = elem15;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem68 = iprot.readListBegin();
-            final elem74 = <List<int>>[];
-            for(int elem73 = 0; elem73 < elem68.length; ++elem73) {
-              thrift.TList elem70 = iprot.readListBegin();
-              final elem69 = <int>[];
-              for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
-                int elem71 = iprot.readI32();
-                elem69.add(elem71);
+            thrift.TList elem17 = iprot.readListBegin();
+            final elem23 = <List<int>>[];
+            for(int elem22 = 0; elem22 < elem17.length; ++elem22) {
+              thrift.TList elem19 = iprot.readListBegin();
+              final elem18 = <int>[];
+              for(int elem21 = 0; elem21 < elem19.length; ++elem21) {
+                int elem20 = iprot.readI32();
+                elem18.add(elem20);
               }
               iprot.readListEnd();
-              elem74.add(elem69);
+              elem23.add(elem18);
             }
             iprot.readListEnd();
-            this.nums = elem74;
+            this.nums = elem23;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem75 = iprot.readListBegin();
-            final elem78 = <int>[];
-            for(int elem77 = 0; elem77 < elem75.length; ++elem77) {
-              int elem76 = iprot.readI32();
-              elem78.add(elem76);
+            thrift.TList elem24 = iprot.readListBegin();
+            final elem27 = <int>[];
+            for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
+              int elem25 = iprot.readI32();
+              elem27.add(elem25);
             }
             iprot.readListEnd();
-            this.enums = elem78;
+            this.enums = elem27;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -632,9 +632,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            final elem79 = t_variety.TestingUnions();
-            this.a_union = elem79;
-            elem79.read(iprot);
+            final elem28 = t_variety.TestingUnions();
+            this.a_union = elem28;
+            elem28.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -665,114 +665,114 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem80 = iprot.readListBegin();
+            thrift.TList elem29 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem83 = <bool>[];
-            for(int elem82 = 0; elem82 < elem80.length; ++elem82) {
-              bool elem81 = iprot.readBool();
+            final elem32 = <bool>[];
+            for(int elem31 = 0; elem31 < elem29.length; ++elem31) {
+              bool elem30 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem83.add(elem81);
+              elem32.add(elem30);
             }
             iprot.readListEnd();
-            this.deprList = elem83;
+            this.deprList = elem32;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem84 = iprot.readListBegin();
-            final elem88 = <t_variety.Event>[];
-            for(int elem87 = 0; elem87 < elem84.length; ++elem87) {
-              final elem86 = t_variety.Event();
-              t_variety.Event elem85 = elem86;
-              elem86.read(iprot);
-              elem88.add(elem85);
+            thrift.TList elem33 = iprot.readListBegin();
+            final elem37 = <t_variety.Event>[];
+            for(int elem36 = 0; elem36 < elem33.length; ++elem36) {
+              final elem35 = t_variety.Event();
+              t_variety.Event elem34 = elem35;
+              elem35.read(iprot);
+              elem37.add(elem34);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem88;
+            this.eventsDefault = elem37;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem89 = iprot.readMapBegin();
-            final elem93 = <fixnum.Int64, t_variety.Event>{};
-            for(int elem92 = 0; elem92 < elem89.length; ++elem92) {
-              fixnum.Int64 elem94 = iprot.readInt64();
-              final elem91 = t_variety.Event();
-              t_variety.Event elem90 = elem91;
-              elem91.read(iprot);
-              elem93[elem94] = elem90;
+            thrift.TMap elem38 = iprot.readMapBegin();
+            final elem42 = <fixnum.Int64, t_variety.Event>{};
+            for(int elem41 = 0; elem41 < elem38.length; ++elem41) {
+              fixnum.Int64 elem43 = iprot.readInt64();
+              final elem40 = t_variety.Event();
+              t_variety.Event elem39 = elem40;
+              elem40.read(iprot);
+              elem42[elem43] = elem39;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem93;
+            this.eventMapDefault = elem42;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem95 = iprot.readSetBegin();
-            final elem99 = <t_variety.Event>{};
-            for(int elem98 = 0; elem98 < elem95.length; ++elem98) {
-              final elem97 = t_variety.Event();
-              t_variety.Event elem96 = elem97;
-              elem97.read(iprot);
-              elem99.add(elem96);
+            thrift.TSet elem44 = iprot.readSetBegin();
+            final elem48 = <t_variety.Event>{};
+            for(int elem47 = 0; elem47 < elem44.length; ++elem47) {
+              final elem46 = t_variety.Event();
+              t_variety.Event elem45 = elem46;
+              elem46.read(iprot);
+              elem48.add(elem45);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem99;
+            this.eventSetDefault = elem48;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSREQUIRED:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem100 = iprot.readListBegin();
-            final elem104 = <t_variety.Event>[];
-            for(int elem103 = 0; elem103 < elem100.length; ++elem103) {
-              final elem102 = t_variety.Event();
-              t_variety.Event elem101 = elem102;
-              elem102.read(iprot);
-              elem104.add(elem101);
+            thrift.TList elem49 = iprot.readListBegin();
+            final elem53 = <t_variety.Event>[];
+            for(int elem52 = 0; elem52 < elem49.length; ++elem52) {
+              final elem51 = t_variety.Event();
+              t_variety.Event elem50 = elem51;
+              elem51.read(iprot);
+              elem53.add(elem50);
             }
             iprot.readListEnd();
-            this.eventsRequired = elem104;
+            this.eventsRequired = elem53;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPREQUIRED:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem105 = iprot.readMapBegin();
-            final elem109 = <fixnum.Int64, t_variety.Event>{};
-            for(int elem108 = 0; elem108 < elem105.length; ++elem108) {
-              fixnum.Int64 elem110 = iprot.readInt64();
-              final elem107 = t_variety.Event();
-              t_variety.Event elem106 = elem107;
-              elem107.read(iprot);
-              elem109[elem110] = elem106;
+            thrift.TMap elem54 = iprot.readMapBegin();
+            final elem58 = <fixnum.Int64, t_variety.Event>{};
+            for(int elem57 = 0; elem57 < elem54.length; ++elem57) {
+              fixnum.Int64 elem59 = iprot.readInt64();
+              final elem56 = t_variety.Event();
+              t_variety.Event elem55 = elem56;
+              elem56.read(iprot);
+              elem58[elem59] = elem55;
             }
             iprot.readMapEnd();
-            this.eventMapRequired = elem109;
+            this.eventMapRequired = elem58;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETREQUIRED:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem111 = iprot.readSetBegin();
-            final elem115 = <t_variety.Event>{};
-            for(int elem114 = 0; elem114 < elem111.length; ++elem114) {
-              final elem113 = t_variety.Event();
-              t_variety.Event elem112 = elem113;
-              elem113.read(iprot);
-              elem115.add(elem112);
+            thrift.TSet elem60 = iprot.readSetBegin();
+            final elem64 = <t_variety.Event>{};
+            for(int elem63 = 0; elem63 < elem60.length; ++elem63) {
+              final elem62 = t_variety.Event();
+              t_variety.Event elem61 = elem62;
+              elem62.read(iprot);
+              elem64.add(elem61);
             }
             iprot.readSetEnd();
-            this.eventSetRequired = elem115;
+            this.eventSetRequired = elem64;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -793,169 +793,169 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem116 = iD;
+    final elem65 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeInt64(elem116);
+      oprot.writeInt64(elem65);
       oprot.writeFieldEnd();
     }
-    final elem117 = ev;
-    if (elem117 != null) {
+    final elem66 = ev;
+    if (elem66 != null) {
       oprot.writeFieldBegin(_EV_FIELD_DESC);
-      elem117.write(oprot);
+      elem66.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem118 = events;
-    if (elem118 != null) {
+    final elem67 = events;
+    if (elem67 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem118.length));
-      for(var elem119 in elem118) {
-        elem119.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem67.length));
+      for(var elem68 in elem67) {
+        elem68.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem120 = events2;
-    if (elem120 != null) {
+    final elem69 = events2;
+    if (elem69 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem120.length));
-      for(var elem121 in elem120) {
-        elem121.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem69.length));
+      for(var elem70 in elem69) {
+        elem70.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem122 = eventMap;
-    if (elem122 != null) {
+    final elem71 = eventMap;
+    if (elem71 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem122.length));
-      for(var entry in elem122.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem71.length));
+      for(var entry in elem71.entries) {
         oprot.writeInt64(entry.key);
         entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem123 = nums;
-    if (elem123 != null) {
+    final elem72 = nums;
+    if (elem72 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem123.length));
-      for(var elem124 in elem123) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem124.length));
-        for(var elem125 in elem124) {
-          oprot.writeI32(elem125);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem72.length));
+      for(var elem73 in elem72) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem73.length));
+        for(var elem74 in elem73) {
+          oprot.writeI32(elem74);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem126 = enums;
-    if (elem126 != null) {
+    final elem75 = enums;
+    if (elem75 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem126.length));
-      for(var elem127 in elem126) {
-        oprot.writeI32(elem127);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem75.length));
+      for(var elem76 in elem75) {
+        oprot.writeI32(elem76);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem128 = aBoolField;
+    final elem77 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem128);
+    oprot.writeBool(elem77);
     oprot.writeFieldEnd();
-    final elem129 = a_union;
-    if (elem129 != null) {
+    final elem78 = a_union;
+    if (elem78 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem129.write(oprot);
+      elem78.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem130 = typedefOfTypedef;
-    if (elem130 != null) {
+    final elem79 = typedefOfTypedef;
+    if (elem79 != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem130);
+      oprot.writeString(elem79);
       oprot.writeFieldEnd();
     }
-    final elem131 = depr;
+    final elem80 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem131);
+    oprot.writeBool(elem80);
     oprot.writeFieldEnd();
-    final elem132 = deprBinary;
+    final elem81 = deprBinary;
     // ignore: deprecated_member_use
-    if (elem132 != null) {
+    if (elem81 != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem132);
+      oprot.writeBinary(elem81);
       oprot.writeFieldEnd();
     }
-    final elem133 = deprList;
+    final elem82 = deprList;
     // ignore: deprecated_member_use
-    if (elem133 != null) {
+    if (elem82 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem133.length));
-      for(var elem134 in elem133) {
-        oprot.writeBool(elem134);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem82.length));
+      for(var elem83 in elem82) {
+        oprot.writeBool(elem83);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem135 = eventsDefault;
-    if (isSetEventsDefault() && elem135 != null) {
+    final elem84 = eventsDefault;
+    if (isSetEventsDefault() && elem84 != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem135.length));
-      for(var elem136 in elem135) {
-        elem136.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem84.length));
+      for(var elem85 in elem84) {
+        elem85.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem137 = eventMapDefault;
-    if (isSetEventMapDefault() && elem137 != null) {
+    final elem86 = eventMapDefault;
+    if (isSetEventMapDefault() && elem86 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem137.length));
-      for(var entry in elem137.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem86.length));
+      for(var entry in elem86.entries) {
         oprot.writeInt64(entry.key);
         entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem138 = eventSetDefault;
-    if (isSetEventSetDefault() && elem138 != null) {
+    final elem87 = eventSetDefault;
+    if (isSetEventSetDefault() && elem87 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem138.length));
-      for(var elem139 in elem138) {
-        elem139.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem87.length));
+      for(var elem88 in elem87) {
+        elem88.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem140 = eventsRequired;
-    if (elem140 != null) {
+    final elem89 = eventsRequired;
+    if (elem89 != null) {
       oprot.writeFieldBegin(_EVENTS_REQUIRED_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem140.length));
-      for(var elem141 in elem140) {
-        elem141.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem89.length));
+      for(var elem90 in elem89) {
+        elem90.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem142 = eventMapRequired;
-    if (elem142 != null) {
+    final elem91 = eventMapRequired;
+    if (elem91 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_REQUIRED_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem142.length));
-      for(var entry in elem142.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem91.length));
+      for(var entry in elem91.entries) {
         oprot.writeInt64(entry.key);
         entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem143 = eventSetRequired;
-    if (elem143 != null) {
+    final elem92 = eventSetRequired;
+    if (elem92 != null) {
       oprot.writeFieldBegin(_EVENT_SET_REQUIRED_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem143.length));
-      for(var elem144 in elem143) {
-        elem144.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem92.length));
+      for(var elem93 in elem92) {
+        elem93.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_events_scope.dart
@@ -123,9 +123,9 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem191 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem191.length));
-      for(var entry in elem191.entries) {
+    for(var elem0 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem0.length));
+      for(var entry in elem0.entries) {
         oprot.writeInt64(entry.key);
         entry.value.write(oprot);
       }
@@ -175,9 +175,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final elem192 = t_variety.Event();
-      t_variety.Event req = elem192;
-      elem192.read(iprot);
+      final elem1 = t_variety.Event();
+      t_variety.Event req = elem1;
+      elem1.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -264,20 +264,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem193 = iprot.readListBegin();
+      thrift.TList elem2 = iprot.readListBegin();
       final req = <Map<fixnum.Int64, t_variety.Event>>[];
-      for(int elem200 = 0; elem200 < elem193.length; ++elem200) {
-        thrift.TMap elem195 = iprot.readMapBegin();
-        final elem194 = <fixnum.Int64, t_variety.Event>{};
-        for(int elem198 = 0; elem198 < elem195.length; ++elem198) {
-          fixnum.Int64 elem199 = iprot.readInt64();
-          final elem197 = t_variety.Event();
-          t_variety.Event elem196 = elem197;
-          elem197.read(iprot);
-          elem194[elem199] = elem196;
+      for(int elem9 = 0; elem9 < elem2.length; ++elem9) {
+        thrift.TMap elem4 = iprot.readMapBegin();
+        final elem3 = <fixnum.Int64, t_variety.Event>{};
+        for(int elem7 = 0; elem7 < elem4.length; ++elem7) {
+          fixnum.Int64 elem8 = iprot.readInt64();
+          final elem6 = t_variety.Event();
+          t_variety.Event elem5 = elem6;
+          elem6.read(iprot);
+          elem3[elem8] = elem5;
         }
         iprot.readMapEnd();
-        req.add(elem194);
+        req.add(elem3);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_foo_args.dart
@@ -149,22 +149,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem145 = newMessage;
-    if (elem145 != null) {
+    final elem0 = newMessage;
+    if (elem0 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem145);
+      oprot.writeString(elem0);
       oprot.writeFieldEnd();
     }
-    final elem146 = messageArgs;
-    if (elem146 != null) {
+    final elem1 = messageArgs;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem146);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem147 = messageResult;
-    if (elem147 != null) {
+    final elem2 = messageResult;
+    if (elem2 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem147);
+      oprot.writeString(elem2);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_foo_service.dart
@@ -413,20 +413,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem164 = num;
+    final elem0 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem164);
+    oprot.writeI32(elem0);
     oprot.writeFieldEnd();
-    final elem165 = str;
-    if (elem165 != null) {
+    final elem1 = str;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem165);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem166 = event;
-    if (elem166 != null) {
+    final elem2 = event;
+    if (elem2 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem166.write(oprot);
+      elem2.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -459,18 +459,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem167 = t_variety.AwesomeException();
-            this.awe = elem167;
-            elem167.read(iprot);
+            final elem3 = t_variety.AwesomeException();
+            this.awe = elem3;
+            elem3.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            final elem168 = t_actual_base_dart.api_exception();
-            this.api = elem168;
-            elem168.read(iprot);
+            final elem4 = t_actual_base_dart.api_exception();
+            this.api = elem4;
+            elem4.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -504,15 +504,15 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem169 = id;
+    final elem5 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(elem169);
+    oprot.writeInt64(elem5);
     oprot.writeFieldEnd();
-    final elem170 = req;
-    if (elem170 != null) {
+    final elem6 = req;
+    if (elem6 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem170.length));
-      for(var entry in elem170.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem6.length));
+      for(var entry in elem6.entries) {
         oprot.writeI32(entry.key);
         oprot.writeString(entry.value);
       }
@@ -541,16 +541,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem171 = bin;
-    if (elem171 != null) {
+    final elem7 = bin;
+    if (elem7 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem171);
+      oprot.writeBinary(elem7);
       oprot.writeFieldEnd();
     }
-    final elem172 = str;
-    if (elem172 != null) {
+    final elem8 = str;
+    if (elem8 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem172);
+      oprot.writeString(elem8);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -582,9 +582,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem173 = t_actual_base_dart.api_exception();
-            this.api = elem173;
-            elem173.read(iprot);
+            final elem9 = t_actual_base_dart.api_exception();
+            this.api = elem9;
+            elem9.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -620,17 +620,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem174 = opt_num;
+    final elem10 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem174);
+    oprot.writeI32(elem10);
     oprot.writeFieldEnd();
-    final elem175 = default_num;
+    final elem11 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem175);
+    oprot.writeI32(elem11);
     oprot.writeFieldEnd();
-    final elem176 = req_num;
+    final elem12 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem176);
+    oprot.writeI32(elem12);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -691,22 +691,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem177 = list_type;
-    if (elem177 != null) {
+    final elem13 = list_type;
+    if (elem13 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem177.length));
-      for(var elem178 in elem177) {
-        oprot.writeInt64(elem178);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem13.length));
+      for(var elem14 in elem13) {
+        oprot.writeInt64(elem14);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem179 = set_type;
-    if (elem179 != null) {
+    final elem15 = set_type;
+    if (elem15 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem179.length));
-      for(var elem180 in elem179) {
-        oprot.writeInt64(elem180);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem15.length));
+      for(var elem16 in elem15) {
+        oprot.writeInt64(elem16);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -732,14 +732,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem181 = iprot.readListBegin();
-            final elem184 = <fixnum.Int64>[];
-            for(int elem183 = 0; elem183 < elem181.length; ++elem183) {
-              fixnum.Int64 elem182 = iprot.readInt64();
-              elem184.add(elem182);
+            thrift.TList elem17 = iprot.readListBegin();
+            final elem20 = <fixnum.Int64>[];
+            for(int elem19 = 0; elem19 < elem17.length; ++elem19) {
+              fixnum.Int64 elem18 = iprot.readInt64();
+              elem20.add(elem18);
             }
             iprot.readListEnd();
-            this.success = elem184;
+            this.success = elem20;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -790,9 +790,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem185 = t_validStructs.Thing();
-            this.success = elem185;
-            elem185.read(iprot);
+            final elem21 = t_validStructs.Thing();
+            this.success = elem21;
+            elem21.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -875,10 +875,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem186 = a;
-    if (elem186 != null) {
+    final elem22 = a;
+    if (elem22 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem186.write(oprot);
+      elem22.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -902,9 +902,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem187 = t_subdir_include_ns.A();
-            this.success = elem187;
-            elem187.read(iprot);
+            final elem23 = t_subdir_include_ns.A();
+            this.success = elem23;
+            elem23.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -936,10 +936,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem188 = newMessage;
-    if (elem188 != null) {
+    final elem24 = newMessage;
+    if (elem24 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem188);
+      oprot.writeString(elem24);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -995,10 +995,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem189 = messageArgs;
-    if (elem189 != null) {
+    final elem25 = messageArgs;
+    if (elem25 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem189);
+      oprot.writeString(elem25);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1054,10 +1054,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem190 = messageResult;
-    if (elem190 != null) {
+    final elem26 = messageResult;
+    if (elem26 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem190);
+      oprot.writeString(elem26);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.int64/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_test_lowercase.dart
@@ -104,9 +104,9 @@ class TestLowercase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem2 = lowercaseInt;
+    final elem0 = lowercaseInt;
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
-    oprot.writeI32(elem2);
+    oprot.writeI32(elem0);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_defaults.dart
@@ -526,18 +526,18 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem6 = t_variety.Event();
-            this.ev1 = elem6;
-            elem6.read(iprot);
+            final elem0 = t_variety.Event();
+            this.ev1 = elem0;
+            elem0.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
-            final elem7 = t_variety.Event();
-            this.ev2 = elem7;
-            elem7.read(iprot);
+            final elem1 = t_variety.Event();
+            this.ev2 = elem1;
+            elem1.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -566,14 +566,14 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LISTFIELD:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem8 = iprot.readListBegin();
-            final elem11 = <int>[];
-            for(int elem10 = 0; elem10 < elem8.length; ++elem10) {
-              int elem9 = iprot.readI32();
-              elem11.add(elem9);
+            thrift.TList elem2 = iprot.readListBegin();
+            final elem5 = <int>[];
+            for(int elem4 = 0; elem4 < elem2.length; ++elem4) {
+              int elem3 = iprot.readI32();
+              elem5.add(elem3);
             }
             iprot.readListEnd();
-            this.listfield = elem11;
+            this.listfield = elem5;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -616,57 +616,57 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LIST2:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem12 = iprot.readListBegin();
-            final elem15 = <int>[];
-            for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
-              int elem13 = iprot.readI32();
-              elem15.add(elem13);
+            thrift.TList elem6 = iprot.readListBegin();
+            final elem9 = <int>[];
+            for(int elem8 = 0; elem8 < elem6.length; ++elem8) {
+              int elem7 = iprot.readI32();
+              elem9.add(elem7);
             }
             iprot.readListEnd();
-            this.list2 = elem15;
+            this.list2 = elem9;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST3:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem16 = iprot.readListBegin();
-            final elem19 = <int>[];
-            for(int elem18 = 0; elem18 < elem16.length; ++elem18) {
-              int elem17 = iprot.readI32();
-              elem19.add(elem17);
+            thrift.TList elem10 = iprot.readListBegin();
+            final elem13 = <int>[];
+            for(int elem12 = 0; elem12 < elem10.length; ++elem12) {
+              int elem11 = iprot.readI32();
+              elem13.add(elem11);
             }
             iprot.readListEnd();
-            this.list3 = elem19;
+            this.list3 = elem13;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST4:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem20 = iprot.readListBegin();
-            final elem23 = <int>[];
-            for(int elem22 = 0; elem22 < elem20.length; ++elem22) {
-              int elem21 = iprot.readI32();
-              elem23.add(elem21);
+            thrift.TList elem14 = iprot.readListBegin();
+            final elem17 = <int>[];
+            for(int elem16 = 0; elem16 < elem14.length; ++elem16) {
+              int elem15 = iprot.readI32();
+              elem17.add(elem15);
             }
             iprot.readListEnd();
-            this.list4 = elem23;
+            this.list4 = elem17;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case A_MAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem24 = iprot.readMapBegin();
-            final elem27 = <String, String>{};
-            for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
-              String elem28 = iprot.readString();
-              String elem25 = iprot.readString();
-              elem27[elem28] = elem25;
+            thrift.TMap elem18 = iprot.readMapBegin();
+            final elem21 = <String, String>{};
+            for(int elem20 = 0; elem20 < elem18.length; ++elem20) {
+              String elem22 = iprot.readString();
+              String elem19 = iprot.readString();
+              elem21[elem22] = elem19;
             }
             iprot.readMapEnd();
-            this.a_map = elem27;
+            this.a_map = elem21;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -703,126 +703,126 @@ class TestingDefaults implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem29 = iD2;
+    final elem23 = iD2;
     if (isSetID2()) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
-      oprot.writeInt64(elem29);
+      oprot.writeInt64(elem23);
       oprot.writeFieldEnd();
     }
-    final elem30 = ev1;
-    if (elem30 != null) {
+    final elem24 = ev1;
+    if (elem24 != null) {
       oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      elem30.write(oprot);
+      elem24.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem31 = ev2;
-    if (elem31 != null) {
+    final elem25 = ev2;
+    if (elem25 != null) {
       oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      elem31.write(oprot);
+      elem25.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem32 = iD;
+    final elem26 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeInt64(elem32);
+    oprot.writeInt64(elem26);
     oprot.writeFieldEnd();
-    final elem33 = thing;
-    if (elem33 != null) {
+    final elem27 = thing;
+    if (elem27 != null) {
       oprot.writeFieldBegin(_THING_FIELD_DESC);
-      oprot.writeString(elem33);
+      oprot.writeString(elem27);
       oprot.writeFieldEnd();
     }
-    final elem34 = thing2;
-    if (isSetThing2() && elem34 != null) {
+    final elem28 = thing2;
+    if (isSetThing2() && elem28 != null) {
       oprot.writeFieldBegin(_THING2_FIELD_DESC);
-      oprot.writeString(elem34);
+      oprot.writeString(elem28);
       oprot.writeFieldEnd();
     }
-    final elem35 = listfield;
-    if (elem35 != null) {
+    final elem29 = listfield;
+    if (elem29 != null) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem35.length));
-      for(var elem36 in elem35) {
-        oprot.writeI32(elem36);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem29.length));
+      for(var elem30 in elem29) {
+        oprot.writeI32(elem30);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem37 = iD3;
+    final elem31 = iD3;
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
-    oprot.writeInt64(elem37);
+    oprot.writeInt64(elem31);
     oprot.writeFieldEnd();
-    final elem38 = bin_field;
-    if (elem38 != null) {
+    final elem32 = bin_field;
+    if (elem32 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_FIELD_DESC);
-      oprot.writeBinary(elem38);
+      oprot.writeBinary(elem32);
       oprot.writeFieldEnd();
     }
-    final elem39 = bin_field2;
-    if (isSetBin_field2() && elem39 != null) {
+    final elem33 = bin_field2;
+    if (isSetBin_field2() && elem33 != null) {
       oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
-      oprot.writeBinary(elem39);
+      oprot.writeBinary(elem33);
       oprot.writeFieldEnd();
     }
-    final elem40 = bin_field3;
-    if (elem40 != null) {
+    final elem34 = bin_field3;
+    if (elem34 != null) {
       oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
-      oprot.writeBinary(elem40);
+      oprot.writeBinary(elem34);
       oprot.writeFieldEnd();
     }
-    final elem41 = bin_field4;
-    if (isSetBin_field4() && elem41 != null) {
+    final elem35 = bin_field4;
+    if (isSetBin_field4() && elem35 != null) {
       oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
-      oprot.writeBinary(elem41);
+      oprot.writeBinary(elem35);
       oprot.writeFieldEnd();
     }
-    final elem42 = list2;
-    if (isSetList2() && elem42 != null) {
+    final elem36 = list2;
+    if (isSetList2() && elem36 != null) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem42.length));
-      for(var elem43 in elem42) {
-        oprot.writeI32(elem43);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem36.length));
+      for(var elem37 in elem36) {
+        oprot.writeI32(elem37);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem44 = list3;
-    if (isSetList3() && elem44 != null) {
+    final elem38 = list3;
+    if (isSetList3() && elem38 != null) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem44.length));
-      for(var elem45 in elem44) {
-        oprot.writeI32(elem45);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem38.length));
+      for(var elem39 in elem38) {
+        oprot.writeI32(elem39);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem46 = list4;
-    if (elem46 != null) {
+    final elem40 = list4;
+    if (elem40 != null) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem46.length));
-      for(var elem47 in elem46) {
-        oprot.writeI32(elem47);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem40.length));
+      for(var elem41 in elem40) {
+        oprot.writeI32(elem41);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem48 = a_map;
-    if (isSetA_map() && elem48 != null) {
+    final elem42 = a_map;
+    if (isSetA_map() && elem42 != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem48.length));
-      for(var entry in elem48.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem42.length));
+      for(var entry in elem42.entries) {
         oprot.writeString(entry.key);
         oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem49 = status;
+    final elem43 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem49);
+    oprot.writeI32(elem43);
     oprot.writeFieldEnd();
-    final elem50 = base_status;
+    final elem44 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(elem50);
+    oprot.writeI32(elem44);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.int64/variety/f_testing_unions.dart
@@ -301,15 +301,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem148 = iprot.readMapBegin();
-            final elem151 = <int, String>{};
-            for(int elem150 = 0; elem150 < elem148.length; ++elem150) {
-              int elem152 = iprot.readI32();
-              String elem149 = iprot.readString();
-              elem151[elem152] = elem149;
+            thrift.TMap elem0 = iprot.readMapBegin();
+            final elem3 = <int, String>{};
+            for(int elem2 = 0; elem2 < elem0.length; ++elem2) {
+              int elem4 = iprot.readI32();
+              String elem1 = iprot.readString();
+              elem3[elem4] = elem1;
             }
             iprot.readMapEnd();
-            this.requests = elem151;
+            this.requests = elem3;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -354,58 +354,58 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem153 = anID;
+    final elem5 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeInt64(elem153);
+      oprot.writeInt64(elem5);
       oprot.writeFieldEnd();
     }
-    final elem154 = aString;
-    if (isSetAString() && elem154 != null) {
+    final elem6 = aString;
+    if (isSetAString() && elem6 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem154);
+      oprot.writeString(elem6);
       oprot.writeFieldEnd();
     }
-    final elem155 = someotherthing;
+    final elem7 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem155);
+      oprot.writeI32(elem7);
       oprot.writeFieldEnd();
     }
-    final elem156 = anInt16;
+    final elem8 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem156);
+      oprot.writeI16(elem8);
       oprot.writeFieldEnd();
     }
-    final elem157 = requests;
-    if (isSetRequests() && elem157 != null) {
+    final elem9 = requests;
+    if (isSetRequests() && elem9 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem157.length));
-      for(var entry in elem157.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem9.length));
+      for(var entry in elem9.entries) {
         oprot.writeI32(entry.key);
         oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem158 = bin_field_in_union;
-    if (isSetBin_field_in_union() && elem158 != null) {
+    final elem10 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem10 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem158);
+      oprot.writeBinary(elem10);
       oprot.writeFieldEnd();
     }
-    final elem159 = depr;
+    final elem11 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem159);
+      oprot.writeBool(elem11);
       oprot.writeFieldEnd();
     }
-    final elem160 = wHOA_BUDDY;
+    final elem12 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem160);
+      oprot.writeBool(elem12);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_nested_thing.dart
@@ -61,16 +61,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem203 = iprot.readListBegin();
-            final elem207 = <t_actual_base_dart.thing>[];
-            for(int elem206 = 0; elem206 < elem203.length; ++elem206) {
-              final elem205 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem204 = elem205;
-              elem205.read(iprot);
-              elem207.add(elem204);
+            thrift.TList elem0 = iprot.readListBegin();
+            final elem4 = <t_actual_base_dart.thing>[];
+            for(int elem3 = 0; elem3 < elem0.length; ++elem3) {
+              final elem2 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem1 = elem2;
+              elem2.read(iprot);
+              elem4.add(elem1);
             }
             iprot.readListEnd();
-            this.things = elem207;
+            this.things = elem4;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -91,12 +91,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem208 = things;
-    if (elem208 != null) {
+    final elem5 = things;
+    if (elem5 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem208.length));
-      for(var elem209 in elem208) {
-        elem209.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem5.length));
+      for(var elem6 in elem5) {
+        elem6.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullunset/actual_base/f_thing.dart
@@ -103,14 +103,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem201 = an_id;
+    final elem0 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem201);
+    oprot.writeI32(elem0);
     oprot.writeFieldEnd();
-    final elem202 = a_string;
-    if (elem202 != null) {
+    final elem1 = a_string;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem202);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_awesome_exception.dart
@@ -138,19 +138,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem161 = iD;
+    final elem0 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem161);
+    oprot.writeI64(elem0);
     oprot.writeFieldEnd();
-    final elem162 = reason;
-    if (elem162 != null) {
+    final elem1 = reason;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem162);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem163 = depr;
+    final elem2 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem163);
+    oprot.writeBool(elem2);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_event.dart
@@ -142,19 +142,19 @@ class Event implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem3 = iD;
+    final elem0 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem3);
+    oprot.writeI64(elem0);
     oprot.writeFieldEnd();
-    final elem4 = message;
-    if (elem4 != null) {
+    final elem1 = message;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem4);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem5 = yES_NO;
+    final elem2 = yES_NO;
     oprot.writeFieldBegin(_YE_S__NO_FIELD_DESC);
-    oprot.writeBool(elem5);
+    oprot.writeBool(elem2);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_event_wrapper.dart
@@ -365,92 +365,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            final elem51 = t_variety.Event();
-            this.ev = elem51;
-            elem51.read(iprot);
+            final elem0 = t_variety.Event();
+            this.ev = elem0;
+            elem0.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem52 = iprot.readListBegin();
-            final elem56 = <t_variety.Event>[];
-            for(int elem55 = 0; elem55 < elem52.length; ++elem55) {
-              final elem54 = t_variety.Event();
-              t_variety.Event elem53 = elem54;
-              elem54.read(iprot);
-              elem56.add(elem53);
+            thrift.TList elem1 = iprot.readListBegin();
+            final elem5 = <t_variety.Event>[];
+            for(int elem4 = 0; elem4 < elem1.length; ++elem4) {
+              final elem3 = t_variety.Event();
+              t_variety.Event elem2 = elem3;
+              elem3.read(iprot);
+              elem5.add(elem2);
             }
             iprot.readListEnd();
-            this.events = elem56;
+            this.events = elem5;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem57 = iprot.readSetBegin();
-            final elem61 = <t_variety.Event>{};
-            for(int elem60 = 0; elem60 < elem57.length; ++elem60) {
-              final elem59 = t_variety.Event();
-              t_variety.Event elem58 = elem59;
-              elem59.read(iprot);
-              elem61.add(elem58);
+            thrift.TSet elem6 = iprot.readSetBegin();
+            final elem10 = <t_variety.Event>{};
+            for(int elem9 = 0; elem9 < elem6.length; ++elem9) {
+              final elem8 = t_variety.Event();
+              t_variety.Event elem7 = elem8;
+              elem8.read(iprot);
+              elem10.add(elem7);
             }
             iprot.readSetEnd();
-            this.events2 = elem61;
+            this.events2 = elem10;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem62 = iprot.readMapBegin();
-            final elem66 = <int, t_variety.Event>{};
-            for(int elem65 = 0; elem65 < elem62.length; ++elem65) {
-              int elem67 = iprot.readI64();
-              final elem64 = t_variety.Event();
-              t_variety.Event elem63 = elem64;
-              elem64.read(iprot);
-              elem66[elem67] = elem63;
+            thrift.TMap elem11 = iprot.readMapBegin();
+            final elem15 = <int, t_variety.Event>{};
+            for(int elem14 = 0; elem14 < elem11.length; ++elem14) {
+              int elem16 = iprot.readI64();
+              final elem13 = t_variety.Event();
+              t_variety.Event elem12 = elem13;
+              elem13.read(iprot);
+              elem15[elem16] = elem12;
             }
             iprot.readMapEnd();
-            this.eventMap = elem66;
+            this.eventMap = elem15;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem68 = iprot.readListBegin();
-            final elem74 = <List<int>>[];
-            for(int elem73 = 0; elem73 < elem68.length; ++elem73) {
-              thrift.TList elem70 = iprot.readListBegin();
-              final elem69 = <int>[];
-              for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
-                int elem71 = iprot.readI32();
-                elem69.add(elem71);
+            thrift.TList elem17 = iprot.readListBegin();
+            final elem23 = <List<int>>[];
+            for(int elem22 = 0; elem22 < elem17.length; ++elem22) {
+              thrift.TList elem19 = iprot.readListBegin();
+              final elem18 = <int>[];
+              for(int elem21 = 0; elem21 < elem19.length; ++elem21) {
+                int elem20 = iprot.readI32();
+                elem18.add(elem20);
               }
               iprot.readListEnd();
-              elem74.add(elem69);
+              elem23.add(elem18);
             }
             iprot.readListEnd();
-            this.nums = elem74;
+            this.nums = elem23;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem75 = iprot.readListBegin();
-            final elem78 = <int>[];
-            for(int elem77 = 0; elem77 < elem75.length; ++elem77) {
-              int elem76 = iprot.readI32();
-              elem78.add(elem76);
+            thrift.TList elem24 = iprot.readListBegin();
+            final elem27 = <int>[];
+            for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
+              int elem25 = iprot.readI32();
+              elem27.add(elem25);
             }
             iprot.readListEnd();
-            this.enums = elem78;
+            this.enums = elem27;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -464,9 +464,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            final elem79 = t_variety.TestingUnions();
-            this.a_union = elem79;
-            elem79.read(iprot);
+            final elem28 = t_variety.TestingUnions();
+            this.a_union = elem28;
+            elem28.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -496,114 +496,114 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem80 = iprot.readListBegin();
+            thrift.TList elem29 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem83 = <bool>[];
-            for(int elem82 = 0; elem82 < elem80.length; ++elem82) {
-              bool elem81 = iprot.readBool();
+            final elem32 = <bool>[];
+            for(int elem31 = 0; elem31 < elem29.length; ++elem31) {
+              bool elem30 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem83.add(elem81);
+              elem32.add(elem30);
             }
             iprot.readListEnd();
-            this.deprList = elem83;
+            this.deprList = elem32;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem84 = iprot.readListBegin();
-            final elem88 = <t_variety.Event>[];
-            for(int elem87 = 0; elem87 < elem84.length; ++elem87) {
-              final elem86 = t_variety.Event();
-              t_variety.Event elem85 = elem86;
-              elem86.read(iprot);
-              elem88.add(elem85);
+            thrift.TList elem33 = iprot.readListBegin();
+            final elem37 = <t_variety.Event>[];
+            for(int elem36 = 0; elem36 < elem33.length; ++elem36) {
+              final elem35 = t_variety.Event();
+              t_variety.Event elem34 = elem35;
+              elem35.read(iprot);
+              elem37.add(elem34);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem88;
+            this.eventsDefault = elem37;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem89 = iprot.readMapBegin();
-            final elem93 = <int, t_variety.Event>{};
-            for(int elem92 = 0; elem92 < elem89.length; ++elem92) {
-              int elem94 = iprot.readI64();
-              final elem91 = t_variety.Event();
-              t_variety.Event elem90 = elem91;
-              elem91.read(iprot);
-              elem93[elem94] = elem90;
+            thrift.TMap elem38 = iprot.readMapBegin();
+            final elem42 = <int, t_variety.Event>{};
+            for(int elem41 = 0; elem41 < elem38.length; ++elem41) {
+              int elem43 = iprot.readI64();
+              final elem40 = t_variety.Event();
+              t_variety.Event elem39 = elem40;
+              elem40.read(iprot);
+              elem42[elem43] = elem39;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem93;
+            this.eventMapDefault = elem42;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem95 = iprot.readSetBegin();
-            final elem99 = <t_variety.Event>{};
-            for(int elem98 = 0; elem98 < elem95.length; ++elem98) {
-              final elem97 = t_variety.Event();
-              t_variety.Event elem96 = elem97;
-              elem97.read(iprot);
-              elem99.add(elem96);
+            thrift.TSet elem44 = iprot.readSetBegin();
+            final elem48 = <t_variety.Event>{};
+            for(int elem47 = 0; elem47 < elem44.length; ++elem47) {
+              final elem46 = t_variety.Event();
+              t_variety.Event elem45 = elem46;
+              elem46.read(iprot);
+              elem48.add(elem45);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem99;
+            this.eventSetDefault = elem48;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSREQUIRED:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem100 = iprot.readListBegin();
-            final elem104 = <t_variety.Event>[];
-            for(int elem103 = 0; elem103 < elem100.length; ++elem103) {
-              final elem102 = t_variety.Event();
-              t_variety.Event elem101 = elem102;
-              elem102.read(iprot);
-              elem104.add(elem101);
+            thrift.TList elem49 = iprot.readListBegin();
+            final elem53 = <t_variety.Event>[];
+            for(int elem52 = 0; elem52 < elem49.length; ++elem52) {
+              final elem51 = t_variety.Event();
+              t_variety.Event elem50 = elem51;
+              elem51.read(iprot);
+              elem53.add(elem50);
             }
             iprot.readListEnd();
-            this.eventsRequired = elem104;
+            this.eventsRequired = elem53;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPREQUIRED:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem105 = iprot.readMapBegin();
-            final elem109 = <int, t_variety.Event>{};
-            for(int elem108 = 0; elem108 < elem105.length; ++elem108) {
-              int elem110 = iprot.readI64();
-              final elem107 = t_variety.Event();
-              t_variety.Event elem106 = elem107;
-              elem107.read(iprot);
-              elem109[elem110] = elem106;
+            thrift.TMap elem54 = iprot.readMapBegin();
+            final elem58 = <int, t_variety.Event>{};
+            for(int elem57 = 0; elem57 < elem54.length; ++elem57) {
+              int elem59 = iprot.readI64();
+              final elem56 = t_variety.Event();
+              t_variety.Event elem55 = elem56;
+              elem56.read(iprot);
+              elem58[elem59] = elem55;
             }
             iprot.readMapEnd();
-            this.eventMapRequired = elem109;
+            this.eventMapRequired = elem58;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETREQUIRED:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem111 = iprot.readSetBegin();
-            final elem115 = <t_variety.Event>{};
-            for(int elem114 = 0; elem114 < elem111.length; ++elem114) {
-              final elem113 = t_variety.Event();
-              t_variety.Event elem112 = elem113;
-              elem113.read(iprot);
-              elem115.add(elem112);
+            thrift.TSet elem60 = iprot.readSetBegin();
+            final elem64 = <t_variety.Event>{};
+            for(int elem63 = 0; elem63 < elem60.length; ++elem63) {
+              final elem62 = t_variety.Event();
+              t_variety.Event elem61 = elem62;
+              elem62.read(iprot);
+              elem64.add(elem61);
             }
             iprot.readSetEnd();
-            this.eventSetRequired = elem115;
+            this.eventSetRequired = elem64;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -624,162 +624,162 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem116 = iD;
-    if (elem116 != null) {
+    final elem65 = iD;
+    if (elem65 != null) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(elem116);
+      oprot.writeI64(elem65);
       oprot.writeFieldEnd();
     }
-    final elem117 = ev!;
+    final elem66 = ev!;
     oprot.writeFieldBegin(_EV_FIELD_DESC);
-    elem117.write(oprot);
+    elem66.write(oprot);
     oprot.writeFieldEnd();
-    final elem118 = events;
-    if (elem118 != null) {
+    final elem67 = events;
+    if (elem67 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem118.length));
-      for(var elem119 in elem118) {
-        elem119.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem67.length));
+      for(var elem68 in elem67) {
+        elem68.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem120 = events2;
-    if (elem120 != null) {
+    final elem69 = events2;
+    if (elem69 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem120.length));
-      for(var elem121 in elem120) {
-        elem121.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem69.length));
+      for(var elem70 in elem69) {
+        elem70.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem122 = eventMap;
-    if (elem122 != null) {
+    final elem71 = eventMap;
+    if (elem71 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem122.length));
-      for(var entry in elem122.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem71.length));
+      for(var entry in elem71.entries) {
         oprot.writeI64(entry.key);
         entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem123 = nums;
-    if (elem123 != null) {
+    final elem72 = nums;
+    if (elem72 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem123.length));
-      for(var elem124 in elem123) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem124.length));
-        for(var elem125 in elem124) {
-          oprot.writeI32(elem125);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem72.length));
+      for(var elem73 in elem72) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem73.length));
+        for(var elem74 in elem73) {
+          oprot.writeI32(elem74);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem126 = enums;
-    if (elem126 != null) {
+    final elem75 = enums;
+    if (elem75 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem126.length));
-      for(var elem127 in elem126) {
-        oprot.writeI32(elem127);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem75.length));
+      for(var elem76 in elem75) {
+        oprot.writeI32(elem76);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem128 = aBoolField;
+    final elem77 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem128);
+    oprot.writeBool(elem77);
     oprot.writeFieldEnd();
-    final elem129 = a_union;
-    if (elem129 != null) {
+    final elem78 = a_union;
+    if (elem78 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem129.write(oprot);
+      elem78.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem130 = typedefOfTypedef;
-    if (elem130 != null) {
+    final elem79 = typedefOfTypedef;
+    if (elem79 != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem130);
+      oprot.writeString(elem79);
       oprot.writeFieldEnd();
     }
-    final elem131 = depr;
+    final elem80 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem131);
+    oprot.writeBool(elem80);
     oprot.writeFieldEnd();
-    final elem132 = deprBinary;
+    final elem81 = deprBinary;
     // ignore: deprecated_member_use
-    if (elem132 != null) {
+    if (elem81 != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem132);
+      oprot.writeBinary(elem81);
       oprot.writeFieldEnd();
     }
-    final elem133 = deprList;
+    final elem82 = deprList;
     // ignore: deprecated_member_use
-    if (elem133 != null) {
+    if (elem82 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem133.length));
-      for(var elem134 in elem133) {
-        oprot.writeBool(elem134);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem82.length));
+      for(var elem83 in elem82) {
+        oprot.writeBool(elem83);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem135 = eventsDefault;
-    if (elem135 != null) {
+    final elem84 = eventsDefault;
+    if (elem84 != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem135.length));
-      for(var elem136 in elem135) {
-        elem136.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem84.length));
+      for(var elem85 in elem84) {
+        elem85.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem137 = eventMapDefault;
-    if (elem137 != null) {
+    final elem86 = eventMapDefault;
+    if (elem86 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem137.length));
-      for(var entry in elem137.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem86.length));
+      for(var entry in elem86.entries) {
         oprot.writeI64(entry.key);
         entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem138 = eventSetDefault;
-    if (elem138 != null) {
+    final elem87 = eventSetDefault;
+    if (elem87 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem138.length));
-      for(var elem139 in elem138) {
-        elem139.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem87.length));
+      for(var elem88 in elem87) {
+        elem88.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem140 = eventsRequired!;
+    final elem89 = eventsRequired!;
     oprot.writeFieldBegin(_EVENTS_REQUIRED_FIELD_DESC);
-    oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem140.length));
-    for(var elem141 in elem140) {
-      elem141.write(oprot);
+    oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem89.length));
+    for(var elem90 in elem89) {
+      elem90.write(oprot);
     }
     oprot.writeListEnd();
     oprot.writeFieldEnd();
-    final elem142 = eventMapRequired!;
+    final elem91 = eventMapRequired!;
     oprot.writeFieldBegin(_EVENT_MAP_REQUIRED_FIELD_DESC);
-    oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem142.length));
-    for(var entry in elem142.entries) {
+    oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem91.length));
+    for(var entry in elem91.entries) {
       oprot.writeI64(entry.key);
       entry.value.write(oprot);
     }
     oprot.writeMapEnd();
     oprot.writeFieldEnd();
-    final elem143 = eventSetRequired!;
+    final elem92 = eventSetRequired!;
     oprot.writeFieldBegin(_EVENT_SET_REQUIRED_FIELD_DESC);
-    oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem143.length));
-    for(var elem144 in elem143) {
-      elem144.write(oprot);
+    oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem92.length));
+    for(var elem93 in elem92) {
+      elem93.write(oprot);
     }
     oprot.writeSetEnd();
     oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_events_scope.dart
@@ -123,9 +123,9 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem191 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem191.length));
-      for(var entry in elem191.entries) {
+    for(var elem0 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem0.length));
+      for(var entry in elem0.entries) {
         oprot.writeI64(entry.key);
         entry.value.write(oprot);
       }
@@ -175,9 +175,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final elem192 = t_variety.Event();
-      t_variety.Event req = elem192;
-      elem192.read(iprot);
+      final elem1 = t_variety.Event();
+      t_variety.Event req = elem1;
+      elem1.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -264,20 +264,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem193 = iprot.readListBegin();
+      thrift.TList elem2 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem200 = 0; elem200 < elem193.length; ++elem200) {
-        thrift.TMap elem195 = iprot.readMapBegin();
-        final elem194 = <int, t_variety.Event>{};
-        for(int elem198 = 0; elem198 < elem195.length; ++elem198) {
-          int elem199 = iprot.readI64();
-          final elem197 = t_variety.Event();
-          t_variety.Event elem196 = elem197;
-          elem197.read(iprot);
-          elem194[elem199] = elem196;
+      for(int elem9 = 0; elem9 < elem2.length; ++elem9) {
+        thrift.TMap elem4 = iprot.readMapBegin();
+        final elem3 = <int, t_variety.Event>{};
+        for(int elem7 = 0; elem7 < elem4.length; ++elem7) {
+          int elem8 = iprot.readI64();
+          final elem6 = t_variety.Event();
+          t_variety.Event elem5 = elem6;
+          elem6.read(iprot);
+          elem3[elem8] = elem5;
         }
         iprot.readMapEnd();
-        req.add(elem194);
+        req.add(elem3);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_foo_args.dart
@@ -130,22 +130,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem145 = newMessage;
-    if (elem145 != null) {
+    final elem0 = newMessage;
+    if (elem0 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem145);
+      oprot.writeString(elem0);
       oprot.writeFieldEnd();
     }
-    final elem146 = messageArgs;
-    if (elem146 != null) {
+    final elem1 = messageArgs;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem146);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem147 = messageResult;
-    if (elem147 != null) {
+    final elem2 = messageResult;
+    if (elem2 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem147);
+      oprot.writeString(elem2);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_foo_service.dart
@@ -412,20 +412,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem164 = num;
+    final elem0 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem164);
+    oprot.writeI32(elem0);
     oprot.writeFieldEnd();
-    final elem165 = str;
-    if (elem165 != null) {
+    final elem1 = str;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem165);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem166 = event;
-    if (elem166 != null) {
+    final elem2 = event;
+    if (elem2 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem166.write(oprot);
+      elem2.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -458,18 +458,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem167 = t_variety.AwesomeException();
-            this.awe = elem167;
-            elem167.read(iprot);
+            final elem3 = t_variety.AwesomeException();
+            this.awe = elem3;
+            elem3.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            final elem168 = t_actual_base_dart.api_exception();
-            this.api = elem168;
-            elem168.read(iprot);
+            final elem4 = t_actual_base_dart.api_exception();
+            this.api = elem4;
+            elem4.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -503,15 +503,15 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem169 = id;
+    final elem5 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem169);
+    oprot.writeI64(elem5);
     oprot.writeFieldEnd();
-    final elem170 = req;
-    if (elem170 != null) {
+    final elem6 = req;
+    if (elem6 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem170.length));
-      for(var entry in elem170.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem6.length));
+      for(var entry in elem6.entries) {
         oprot.writeI32(entry.key);
         oprot.writeString(entry.value);
       }
@@ -540,16 +540,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem171 = bin;
-    if (elem171 != null) {
+    final elem7 = bin;
+    if (elem7 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem171);
+      oprot.writeBinary(elem7);
       oprot.writeFieldEnd();
     }
-    final elem172 = str;
-    if (elem172 != null) {
+    final elem8 = str;
+    if (elem8 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem172);
+      oprot.writeString(elem8);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -581,9 +581,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem173 = t_actual_base_dart.api_exception();
-            this.api = elem173;
-            elem173.read(iprot);
+            final elem9 = t_actual_base_dart.api_exception();
+            this.api = elem9;
+            elem9.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -619,17 +619,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem174 = opt_num;
+    final elem10 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem174);
+    oprot.writeI32(elem10);
     oprot.writeFieldEnd();
-    final elem175 = default_num;
+    final elem11 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem175);
+    oprot.writeI32(elem11);
     oprot.writeFieldEnd();
-    final elem176 = req_num;
+    final elem12 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem176);
+    oprot.writeI32(elem12);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -690,22 +690,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem177 = list_type;
-    if (elem177 != null) {
+    final elem13 = list_type;
+    if (elem13 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem177.length));
-      for(var elem178 in elem177) {
-        oprot.writeI64(elem178);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem13.length));
+      for(var elem14 in elem13) {
+        oprot.writeI64(elem14);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem179 = set_type;
-    if (elem179 != null) {
+    final elem15 = set_type;
+    if (elem15 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem179.length));
-      for(var elem180 in elem179) {
-        oprot.writeI64(elem180);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem15.length));
+      for(var elem16 in elem15) {
+        oprot.writeI64(elem16);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -731,14 +731,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem181 = iprot.readListBegin();
-            final elem184 = <int>[];
-            for(int elem183 = 0; elem183 < elem181.length; ++elem183) {
-              int elem182 = iprot.readI64();
-              elem184.add(elem182);
+            thrift.TList elem17 = iprot.readListBegin();
+            final elem20 = <int>[];
+            for(int elem19 = 0; elem19 < elem17.length; ++elem19) {
+              int elem18 = iprot.readI64();
+              elem20.add(elem18);
             }
             iprot.readListEnd();
-            this.success = elem184;
+            this.success = elem20;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -789,9 +789,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem185 = t_validStructs.Thing();
-            this.success = elem185;
-            elem185.read(iprot);
+            final elem21 = t_validStructs.Thing();
+            this.success = elem21;
+            elem21.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -874,10 +874,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem186 = a;
-    if (elem186 != null) {
+    final elem22 = a;
+    if (elem22 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem186.write(oprot);
+      elem22.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -901,9 +901,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem187 = t_subdir_include_ns.A();
-            this.success = elem187;
-            elem187.read(iprot);
+            final elem23 = t_subdir_include_ns.A();
+            this.success = elem23;
+            elem23.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -935,10 +935,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem188 = newMessage;
-    if (elem188 != null) {
+    final elem24 = newMessage;
+    if (elem24 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem188);
+      oprot.writeString(elem24);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -994,10 +994,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem189 = messageArgs;
-    if (elem189 != null) {
+    final elem25 = messageArgs;
+    if (elem25 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem189);
+      oprot.writeString(elem25);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1053,10 +1053,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem190 = messageResult;
-    if (elem190 != null) {
+    final elem26 = messageResult;
+    if (elem26 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem190);
+      oprot.writeString(elem26);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_test_lowercase.dart
@@ -86,9 +86,9 @@ class TestLowercase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem2 = lowercaseInt;
+    final elem0 = lowercaseInt;
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
-    oprot.writeI32(elem2);
+    oprot.writeI32(elem0);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_defaults.dart
@@ -367,18 +367,18 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem6 = t_variety.Event();
-            this.ev1 = elem6;
-            elem6.read(iprot);
+            final elem0 = t_variety.Event();
+            this.ev1 = elem0;
+            elem0.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
-            final elem7 = t_variety.Event();
-            this.ev2 = elem7;
-            elem7.read(iprot);
+            final elem1 = t_variety.Event();
+            this.ev2 = elem1;
+            elem1.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -406,14 +406,14 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LISTFIELD:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem8 = iprot.readListBegin();
-            final elem11 = <int>[];
-            for(int elem10 = 0; elem10 < elem8.length; ++elem10) {
-              int elem9 = iprot.readI32();
-              elem11.add(elem9);
+            thrift.TList elem2 = iprot.readListBegin();
+            final elem5 = <int>[];
+            for(int elem4 = 0; elem4 < elem2.length; ++elem4) {
+              int elem3 = iprot.readI32();
+              elem5.add(elem3);
             }
             iprot.readListEnd();
-            this.listfield = elem11;
+            this.listfield = elem5;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -455,57 +455,57 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LIST2:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem12 = iprot.readListBegin();
-            final elem15 = <int>[];
-            for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
-              int elem13 = iprot.readI32();
-              elem15.add(elem13);
+            thrift.TList elem6 = iprot.readListBegin();
+            final elem9 = <int>[];
+            for(int elem8 = 0; elem8 < elem6.length; ++elem8) {
+              int elem7 = iprot.readI32();
+              elem9.add(elem7);
             }
             iprot.readListEnd();
-            this.list2 = elem15;
+            this.list2 = elem9;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST3:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem16 = iprot.readListBegin();
-            final elem19 = <int>[];
-            for(int elem18 = 0; elem18 < elem16.length; ++elem18) {
-              int elem17 = iprot.readI32();
-              elem19.add(elem17);
+            thrift.TList elem10 = iprot.readListBegin();
+            final elem13 = <int>[];
+            for(int elem12 = 0; elem12 < elem10.length; ++elem12) {
+              int elem11 = iprot.readI32();
+              elem13.add(elem11);
             }
             iprot.readListEnd();
-            this.list3 = elem19;
+            this.list3 = elem13;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST4:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem20 = iprot.readListBegin();
-            final elem23 = <int>[];
-            for(int elem22 = 0; elem22 < elem20.length; ++elem22) {
-              int elem21 = iprot.readI32();
-              elem23.add(elem21);
+            thrift.TList elem14 = iprot.readListBegin();
+            final elem17 = <int>[];
+            for(int elem16 = 0; elem16 < elem14.length; ++elem16) {
+              int elem15 = iprot.readI32();
+              elem17.add(elem15);
             }
             iprot.readListEnd();
-            this.list4 = elem23;
+            this.list4 = elem17;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case A_MAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem24 = iprot.readMapBegin();
-            final elem27 = <String, String>{};
-            for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
-              String elem28 = iprot.readString();
-              String elem25 = iprot.readString();
-              elem27[elem28] = elem25;
+            thrift.TMap elem18 = iprot.readMapBegin();
+            final elem21 = <String, String>{};
+            for(int elem20 = 0; elem20 < elem18.length; ++elem20) {
+              String elem22 = iprot.readString();
+              String elem19 = iprot.readString();
+              elem21[elem22] = elem19;
             }
             iprot.readMapEnd();
-            this.a_map = elem27;
+            this.a_map = elem21;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -540,126 +540,126 @@ class TestingDefaults implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem29 = iD2;
-    if (elem29 != null) {
+    final elem23 = iD2;
+    if (elem23 != null) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
-      oprot.writeI64(elem29);
+      oprot.writeI64(elem23);
       oprot.writeFieldEnd();
     }
-    final elem30 = ev1;
-    if (elem30 != null) {
+    final elem24 = ev1;
+    if (elem24 != null) {
       oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      elem30.write(oprot);
+      elem24.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem31 = ev2;
-    if (elem31 != null) {
+    final elem25 = ev2;
+    if (elem25 != null) {
       oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      elem31.write(oprot);
+      elem25.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem32 = iD;
+    final elem26 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem32);
+    oprot.writeI64(elem26);
     oprot.writeFieldEnd();
-    final elem33 = thing;
-    if (elem33 != null) {
+    final elem27 = thing;
+    if (elem27 != null) {
       oprot.writeFieldBegin(_THING_FIELD_DESC);
-      oprot.writeString(elem33);
+      oprot.writeString(elem27);
       oprot.writeFieldEnd();
     }
-    final elem34 = thing2;
-    if (elem34 != null) {
+    final elem28 = thing2;
+    if (elem28 != null) {
       oprot.writeFieldBegin(_THING2_FIELD_DESC);
-      oprot.writeString(elem34);
+      oprot.writeString(elem28);
       oprot.writeFieldEnd();
     }
-    final elem35 = listfield;
-    if (elem35 != null) {
+    final elem29 = listfield;
+    if (elem29 != null) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem35.length));
-      for(var elem36 in elem35) {
-        oprot.writeI32(elem36);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem29.length));
+      for(var elem30 in elem29) {
+        oprot.writeI32(elem30);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem37 = iD3;
+    final elem31 = iD3;
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
-    oprot.writeI64(elem37);
+    oprot.writeI64(elem31);
     oprot.writeFieldEnd();
-    final elem38 = bin_field;
-    if (elem38 != null) {
+    final elem32 = bin_field;
+    if (elem32 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_FIELD_DESC);
-      oprot.writeBinary(elem38);
+      oprot.writeBinary(elem32);
       oprot.writeFieldEnd();
     }
-    final elem39 = bin_field2;
-    if (elem39 != null) {
+    final elem33 = bin_field2;
+    if (elem33 != null) {
       oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
-      oprot.writeBinary(elem39);
+      oprot.writeBinary(elem33);
       oprot.writeFieldEnd();
     }
-    final elem40 = bin_field3;
-    if (elem40 != null) {
+    final elem34 = bin_field3;
+    if (elem34 != null) {
       oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
-      oprot.writeBinary(elem40);
+      oprot.writeBinary(elem34);
       oprot.writeFieldEnd();
     }
-    final elem41 = bin_field4;
-    if (elem41 != null) {
+    final elem35 = bin_field4;
+    if (elem35 != null) {
       oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
-      oprot.writeBinary(elem41);
+      oprot.writeBinary(elem35);
       oprot.writeFieldEnd();
     }
-    final elem42 = list2;
-    if (elem42 != null) {
+    final elem36 = list2;
+    if (elem36 != null) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem42.length));
-      for(var elem43 in elem42) {
-        oprot.writeI32(elem43);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem36.length));
+      for(var elem37 in elem36) {
+        oprot.writeI32(elem37);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem44 = list3;
-    if (elem44 != null) {
+    final elem38 = list3;
+    if (elem38 != null) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem44.length));
-      for(var elem45 in elem44) {
-        oprot.writeI32(elem45);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem38.length));
+      for(var elem39 in elem38) {
+        oprot.writeI32(elem39);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem46 = list4;
-    if (elem46 != null) {
+    final elem40 = list4;
+    if (elem40 != null) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem46.length));
-      for(var elem47 in elem46) {
-        oprot.writeI32(elem47);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem40.length));
+      for(var elem41 in elem40) {
+        oprot.writeI32(elem41);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem48 = a_map;
-    if (elem48 != null) {
+    final elem42 = a_map;
+    if (elem42 != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem48.length));
-      for(var entry in elem48.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem42.length));
+      for(var entry in elem42.entries) {
         oprot.writeString(entry.key);
         oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem49 = status;
+    final elem43 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem49);
+    oprot.writeI32(elem43);
     oprot.writeFieldEnd();
-    final elem50 = base_status;
+    final elem44 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(elem50);
+    oprot.writeI32(elem44);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullunset/variety/f_testing_unions.dart
@@ -203,15 +203,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem148 = iprot.readMapBegin();
-            final elem151 = <int, String>{};
-            for(int elem150 = 0; elem150 < elem148.length; ++elem150) {
-              int elem152 = iprot.readI32();
-              String elem149 = iprot.readString();
-              elem151[elem152] = elem149;
+            thrift.TMap elem0 = iprot.readMapBegin();
+            final elem3 = <int, String>{};
+            for(int elem2 = 0; elem2 < elem0.length; ++elem2) {
+              int elem4 = iprot.readI32();
+              String elem1 = iprot.readString();
+              elem3[elem4] = elem1;
             }
             iprot.readMapEnd();
-            this.requests = elem151;
+            this.requests = elem3;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -254,58 +254,58 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem153 = anID;
-    if (elem153 != null) {
+    final elem5 = anID;
+    if (elem5 != null) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(elem153);
+      oprot.writeI64(elem5);
       oprot.writeFieldEnd();
     }
-    final elem154 = aString;
-    if (elem154 != null) {
+    final elem6 = aString;
+    if (elem6 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem154);
+      oprot.writeString(elem6);
       oprot.writeFieldEnd();
     }
-    final elem155 = someotherthing;
-    if (elem155 != null) {
+    final elem7 = someotherthing;
+    if (elem7 != null) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem155);
+      oprot.writeI32(elem7);
       oprot.writeFieldEnd();
     }
-    final elem156 = anInt16;
-    if (elem156 != null) {
+    final elem8 = anInt16;
+    if (elem8 != null) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem156);
+      oprot.writeI16(elem8);
       oprot.writeFieldEnd();
     }
-    final elem157 = requests;
-    if (elem157 != null) {
+    final elem9 = requests;
+    if (elem9 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem157.length));
-      for(var entry in elem157.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem9.length));
+      for(var entry in elem9.entries) {
         oprot.writeI32(entry.key);
         oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem158 = bin_field_in_union;
-    if (elem158 != null) {
+    final elem10 = bin_field_in_union;
+    if (elem10 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem158);
+      oprot.writeBinary(elem10);
       oprot.writeFieldEnd();
     }
-    final elem159 = depr;
+    final elem11 = depr;
     // ignore: deprecated_member_use
-    if (elem159 != null) {
+    if (elem11 != null) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem159);
+      oprot.writeBool(elem11);
       oprot.writeFieldEnd();
     }
-    final elem160 = wHOA_BUDDY;
-    if (elem160 != null) {
+    final elem12 = wHOA_BUDDY;
+    if (elem12 != null) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem160);
+      oprot.writeBool(elem12);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunsetsafe/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart.nullunsetsafe/actual_base/f_nested_thing.dart
@@ -61,16 +61,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem203 = iprot.readListBegin();
-            final elem207 = <t_actual_base_dart.thing>[];
-            for(int elem206 = 0; elem206 < elem203.length; ++elem206) {
-              final elem205 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem204 = elem205;
-              elem205.read(iprot);
-              elem207.add(elem204);
+            thrift.TList elem0 = iprot.readListBegin();
+            final elem4 = <t_actual_base_dart.thing>[];
+            for(int elem3 = 0; elem3 < elem0.length; ++elem3) {
+              final elem2 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem1 = elem2;
+              elem2.read(iprot);
+              elem4.add(elem1);
             }
             iprot.readListEnd();
-            this.things = elem207;
+            this.things = elem4;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -91,12 +91,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem208 = things;
-    if (elem208 != null) {
+    final elem5 = things;
+    if (elem5 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem208.length));
-      for(var elem209 in elem208) {
-        elem209.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem5.length));
+      for(var elem6 in elem5) {
+        elem6.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullunsetsafe/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart.nullunsetsafe/actual_base/f_thing.dart
@@ -103,14 +103,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem201 = an_id;
+    final elem0 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem201);
+    oprot.writeI32(elem0);
     oprot.writeFieldEnd();
-    final elem202 = a_string;
-    if (elem202 != null) {
+    final elem1 = a_string;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem202);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunsetsafe/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart.nullunsetsafe/variety/f_awesome_exception.dart
@@ -138,19 +138,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem161 = iD;
+    final elem0 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem161);
+    oprot.writeI64(elem0);
     oprot.writeFieldEnd();
-    final elem162 = reason;
-    if (elem162 != null) {
+    final elem1 = reason;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem162);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem163 = depr;
+    final elem2 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem163);
+    oprot.writeBool(elem2);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunsetsafe/variety/f_event.dart
+++ b/compiler/testdata/expected/dart.nullunsetsafe/variety/f_event.dart
@@ -142,19 +142,19 @@ class Event implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem3 = iD;
+    final elem0 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem3);
+    oprot.writeI64(elem0);
     oprot.writeFieldEnd();
-    final elem4 = message;
-    if (elem4 != null) {
+    final elem1 = message;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem4);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem5 = yES_NO;
+    final elem2 = yES_NO;
     oprot.writeFieldBegin(_YE_S__NO_FIELD_DESC);
-    oprot.writeBool(elem5);
+    oprot.writeBool(elem2);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunsetsafe/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart.nullunsetsafe/variety/f_event_wrapper.dart
@@ -365,92 +365,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            final elem51 = t_variety.Event();
-            this.ev = elem51;
-            elem51.read(iprot);
+            final elem0 = t_variety.Event();
+            this.ev = elem0;
+            elem0.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem52 = iprot.readListBegin();
-            final elem56 = <t_variety.Event>[];
-            for(int elem55 = 0; elem55 < elem52.length; ++elem55) {
-              final elem54 = t_variety.Event();
-              t_variety.Event elem53 = elem54;
-              elem54.read(iprot);
-              elem56.add(elem53);
+            thrift.TList elem1 = iprot.readListBegin();
+            final elem5 = <t_variety.Event>[];
+            for(int elem4 = 0; elem4 < elem1.length; ++elem4) {
+              final elem3 = t_variety.Event();
+              t_variety.Event elem2 = elem3;
+              elem3.read(iprot);
+              elem5.add(elem2);
             }
             iprot.readListEnd();
-            this.events = elem56;
+            this.events = elem5;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem57 = iprot.readSetBegin();
-            final elem61 = <t_variety.Event>{};
-            for(int elem60 = 0; elem60 < elem57.length; ++elem60) {
-              final elem59 = t_variety.Event();
-              t_variety.Event elem58 = elem59;
-              elem59.read(iprot);
-              elem61.add(elem58);
+            thrift.TSet elem6 = iprot.readSetBegin();
+            final elem10 = <t_variety.Event>{};
+            for(int elem9 = 0; elem9 < elem6.length; ++elem9) {
+              final elem8 = t_variety.Event();
+              t_variety.Event elem7 = elem8;
+              elem8.read(iprot);
+              elem10.add(elem7);
             }
             iprot.readSetEnd();
-            this.events2 = elem61;
+            this.events2 = elem10;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem62 = iprot.readMapBegin();
-            final elem66 = <int, t_variety.Event>{};
-            for(int elem65 = 0; elem65 < elem62.length; ++elem65) {
-              int elem67 = iprot.readI64();
-              final elem64 = t_variety.Event();
-              t_variety.Event elem63 = elem64;
-              elem64.read(iprot);
-              elem66[elem67] = elem63;
+            thrift.TMap elem11 = iprot.readMapBegin();
+            final elem15 = <int, t_variety.Event>{};
+            for(int elem14 = 0; elem14 < elem11.length; ++elem14) {
+              int elem16 = iprot.readI64();
+              final elem13 = t_variety.Event();
+              t_variety.Event elem12 = elem13;
+              elem13.read(iprot);
+              elem15[elem16] = elem12;
             }
             iprot.readMapEnd();
-            this.eventMap = elem66;
+            this.eventMap = elem15;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem68 = iprot.readListBegin();
-            final elem74 = <List<int>>[];
-            for(int elem73 = 0; elem73 < elem68.length; ++elem73) {
-              thrift.TList elem70 = iprot.readListBegin();
-              final elem69 = <int>[];
-              for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
-                int elem71 = iprot.readI32();
-                elem69.add(elem71);
+            thrift.TList elem17 = iprot.readListBegin();
+            final elem23 = <List<int>>[];
+            for(int elem22 = 0; elem22 < elem17.length; ++elem22) {
+              thrift.TList elem19 = iprot.readListBegin();
+              final elem18 = <int>[];
+              for(int elem21 = 0; elem21 < elem19.length; ++elem21) {
+                int elem20 = iprot.readI32();
+                elem18.add(elem20);
               }
               iprot.readListEnd();
-              elem74.add(elem69);
+              elem23.add(elem18);
             }
             iprot.readListEnd();
-            this.nums = elem74;
+            this.nums = elem23;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem75 = iprot.readListBegin();
-            final elem78 = <int>[];
-            for(int elem77 = 0; elem77 < elem75.length; ++elem77) {
-              int elem76 = iprot.readI32();
-              elem78.add(elem76);
+            thrift.TList elem24 = iprot.readListBegin();
+            final elem27 = <int>[];
+            for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
+              int elem25 = iprot.readI32();
+              elem27.add(elem25);
             }
             iprot.readListEnd();
-            this.enums = elem78;
+            this.enums = elem27;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -464,9 +464,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            final elem79 = t_variety.TestingUnions();
-            this.a_union = elem79;
-            elem79.read(iprot);
+            final elem28 = t_variety.TestingUnions();
+            this.a_union = elem28;
+            elem28.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -496,114 +496,114 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem80 = iprot.readListBegin();
+            thrift.TList elem29 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem83 = <bool>[];
-            for(int elem82 = 0; elem82 < elem80.length; ++elem82) {
-              bool elem81 = iprot.readBool();
+            final elem32 = <bool>[];
+            for(int elem31 = 0; elem31 < elem29.length; ++elem31) {
+              bool elem30 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem83.add(elem81);
+              elem32.add(elem30);
             }
             iprot.readListEnd();
-            this.deprList = elem83;
+            this.deprList = elem32;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem84 = iprot.readListBegin();
-            final elem88 = <t_variety.Event>[];
-            for(int elem87 = 0; elem87 < elem84.length; ++elem87) {
-              final elem86 = t_variety.Event();
-              t_variety.Event elem85 = elem86;
-              elem86.read(iprot);
-              elem88.add(elem85);
+            thrift.TList elem33 = iprot.readListBegin();
+            final elem37 = <t_variety.Event>[];
+            for(int elem36 = 0; elem36 < elem33.length; ++elem36) {
+              final elem35 = t_variety.Event();
+              t_variety.Event elem34 = elem35;
+              elem35.read(iprot);
+              elem37.add(elem34);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem88;
+            this.eventsDefault = elem37;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem89 = iprot.readMapBegin();
-            final elem93 = <int, t_variety.Event>{};
-            for(int elem92 = 0; elem92 < elem89.length; ++elem92) {
-              int elem94 = iprot.readI64();
-              final elem91 = t_variety.Event();
-              t_variety.Event elem90 = elem91;
-              elem91.read(iprot);
-              elem93[elem94] = elem90;
+            thrift.TMap elem38 = iprot.readMapBegin();
+            final elem42 = <int, t_variety.Event>{};
+            for(int elem41 = 0; elem41 < elem38.length; ++elem41) {
+              int elem43 = iprot.readI64();
+              final elem40 = t_variety.Event();
+              t_variety.Event elem39 = elem40;
+              elem40.read(iprot);
+              elem42[elem43] = elem39;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem93;
+            this.eventMapDefault = elem42;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem95 = iprot.readSetBegin();
-            final elem99 = <t_variety.Event>{};
-            for(int elem98 = 0; elem98 < elem95.length; ++elem98) {
-              final elem97 = t_variety.Event();
-              t_variety.Event elem96 = elem97;
-              elem97.read(iprot);
-              elem99.add(elem96);
+            thrift.TSet elem44 = iprot.readSetBegin();
+            final elem48 = <t_variety.Event>{};
+            for(int elem47 = 0; elem47 < elem44.length; ++elem47) {
+              final elem46 = t_variety.Event();
+              t_variety.Event elem45 = elem46;
+              elem46.read(iprot);
+              elem48.add(elem45);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem99;
+            this.eventSetDefault = elem48;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSREQUIRED:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem100 = iprot.readListBegin();
-            final elem104 = <t_variety.Event>[];
-            for(int elem103 = 0; elem103 < elem100.length; ++elem103) {
-              final elem102 = t_variety.Event();
-              t_variety.Event elem101 = elem102;
-              elem102.read(iprot);
-              elem104.add(elem101);
+            thrift.TList elem49 = iprot.readListBegin();
+            final elem53 = <t_variety.Event>[];
+            for(int elem52 = 0; elem52 < elem49.length; ++elem52) {
+              final elem51 = t_variety.Event();
+              t_variety.Event elem50 = elem51;
+              elem51.read(iprot);
+              elem53.add(elem50);
             }
             iprot.readListEnd();
-            this.eventsRequired = elem104;
+            this.eventsRequired = elem53;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPREQUIRED:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem105 = iprot.readMapBegin();
-            final elem109 = <int, t_variety.Event>{};
-            for(int elem108 = 0; elem108 < elem105.length; ++elem108) {
-              int elem110 = iprot.readI64();
-              final elem107 = t_variety.Event();
-              t_variety.Event elem106 = elem107;
-              elem107.read(iprot);
-              elem109[elem110] = elem106;
+            thrift.TMap elem54 = iprot.readMapBegin();
+            final elem58 = <int, t_variety.Event>{};
+            for(int elem57 = 0; elem57 < elem54.length; ++elem57) {
+              int elem59 = iprot.readI64();
+              final elem56 = t_variety.Event();
+              t_variety.Event elem55 = elem56;
+              elem56.read(iprot);
+              elem58[elem59] = elem55;
             }
             iprot.readMapEnd();
-            this.eventMapRequired = elem109;
+            this.eventMapRequired = elem58;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETREQUIRED:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem111 = iprot.readSetBegin();
-            final elem115 = <t_variety.Event>{};
-            for(int elem114 = 0; elem114 < elem111.length; ++elem114) {
-              final elem113 = t_variety.Event();
-              t_variety.Event elem112 = elem113;
-              elem113.read(iprot);
-              elem115.add(elem112);
+            thrift.TSet elem60 = iprot.readSetBegin();
+            final elem64 = <t_variety.Event>{};
+            for(int elem63 = 0; elem63 < elem60.length; ++elem63) {
+              final elem62 = t_variety.Event();
+              t_variety.Event elem61 = elem62;
+              elem62.read(iprot);
+              elem64.add(elem61);
             }
             iprot.readSetEnd();
-            this.eventSetRequired = elem115;
+            this.eventSetRequired = elem64;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -624,162 +624,162 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem116 = iD;
-    if (elem116 != null) {
+    final elem65 = iD;
+    if (elem65 != null) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(elem116);
+      oprot.writeI64(elem65);
       oprot.writeFieldEnd();
     }
-    final elem117 = ev!;
+    final elem66 = ev!;
     oprot.writeFieldBegin(_EV_FIELD_DESC);
-    elem117.write(oprot);
+    elem66.write(oprot);
     oprot.writeFieldEnd();
-    final elem118 = events;
-    if (elem118 != null) {
+    final elem67 = events;
+    if (elem67 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem118.length));
-      for(var elem119 in elem118) {
-        elem119.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem67.length));
+      for(var elem68 in elem67) {
+        elem68.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem120 = events2;
-    if (elem120 != null) {
+    final elem69 = events2;
+    if (elem69 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem120.length));
-      for(var elem121 in elem120) {
-        elem121.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem69.length));
+      for(var elem70 in elem69) {
+        elem70.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem122 = eventMap;
-    if (elem122 != null) {
+    final elem71 = eventMap;
+    if (elem71 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem122.length));
-      for(var entry in elem122.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem71.length));
+      for(var entry in elem71.entries) {
         oprot.writeI64(entry.key);
         entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem123 = nums;
-    if (elem123 != null) {
+    final elem72 = nums;
+    if (elem72 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem123.length));
-      for(var elem124 in elem123) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem124.length));
-        for(var elem125 in elem124) {
-          oprot.writeI32(elem125);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem72.length));
+      for(var elem73 in elem72) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem73.length));
+        for(var elem74 in elem73) {
+          oprot.writeI32(elem74);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem126 = enums;
-    if (elem126 != null) {
+    final elem75 = enums;
+    if (elem75 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem126.length));
-      for(var elem127 in elem126) {
-        oprot.writeI32(elem127);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem75.length));
+      for(var elem76 in elem75) {
+        oprot.writeI32(elem76);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem128 = aBoolField;
+    final elem77 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem128);
+    oprot.writeBool(elem77);
     oprot.writeFieldEnd();
-    final elem129 = a_union;
-    if (elem129 != null) {
+    final elem78 = a_union;
+    if (elem78 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem129.write(oprot);
+      elem78.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem130 = typedefOfTypedef;
-    if (elem130 != null) {
+    final elem79 = typedefOfTypedef;
+    if (elem79 != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem130);
+      oprot.writeString(elem79);
       oprot.writeFieldEnd();
     }
-    final elem131 = depr;
+    final elem80 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem131);
+    oprot.writeBool(elem80);
     oprot.writeFieldEnd();
-    final elem132 = deprBinary;
+    final elem81 = deprBinary;
     // ignore: deprecated_member_use
-    if (elem132 != null) {
+    if (elem81 != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem132);
+      oprot.writeBinary(elem81);
       oprot.writeFieldEnd();
     }
-    final elem133 = deprList;
+    final elem82 = deprList;
     // ignore: deprecated_member_use
-    if (elem133 != null) {
+    if (elem82 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem133.length));
-      for(var elem134 in elem133) {
-        oprot.writeBool(elem134);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem82.length));
+      for(var elem83 in elem82) {
+        oprot.writeBool(elem83);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem135 = eventsDefault;
-    if (elem135 != null) {
+    final elem84 = eventsDefault;
+    if (elem84 != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem135.length));
-      for(var elem136 in elem135) {
-        elem136.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem84.length));
+      for(var elem85 in elem84) {
+        elem85.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem137 = eventMapDefault;
-    if (elem137 != null) {
+    final elem86 = eventMapDefault;
+    if (elem86 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem137.length));
-      for(var entry in elem137.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem86.length));
+      for(var entry in elem86.entries) {
         oprot.writeI64(entry.key);
         entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem138 = eventSetDefault;
-    if (elem138 != null) {
+    final elem87 = eventSetDefault;
+    if (elem87 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem138.length));
-      for(var elem139 in elem138) {
-        elem139.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem87.length));
+      for(var elem88 in elem87) {
+        elem88.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem140 = eventsRequired!;
+    final elem89 = eventsRequired!;
     oprot.writeFieldBegin(_EVENTS_REQUIRED_FIELD_DESC);
-    oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem140.length));
-    for(var elem141 in elem140) {
-      elem141.write(oprot);
+    oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem89.length));
+    for(var elem90 in elem89) {
+      elem90.write(oprot);
     }
     oprot.writeListEnd();
     oprot.writeFieldEnd();
-    final elem142 = eventMapRequired!;
+    final elem91 = eventMapRequired!;
     oprot.writeFieldBegin(_EVENT_MAP_REQUIRED_FIELD_DESC);
-    oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem142.length));
-    for(var entry in elem142.entries) {
+    oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem91.length));
+    for(var entry in elem91.entries) {
       oprot.writeI64(entry.key);
       entry.value.write(oprot);
     }
     oprot.writeMapEnd();
     oprot.writeFieldEnd();
-    final elem143 = eventSetRequired!;
+    final elem92 = eventSetRequired!;
     oprot.writeFieldBegin(_EVENT_SET_REQUIRED_FIELD_DESC);
-    oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem143.length));
-    for(var elem144 in elem143) {
-      elem144.write(oprot);
+    oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem92.length));
+    for(var elem93 in elem92) {
+      elem93.write(oprot);
     }
     oprot.writeSetEnd();
     oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart.nullunsetsafe/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart.nullunsetsafe/variety/f_events_scope.dart
@@ -123,9 +123,9 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem191 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem191.length));
-      for(var entry in elem191.entries) {
+    for(var elem0 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem0.length));
+      for(var entry in elem0.entries) {
         oprot.writeI64(entry.key);
         entry.value.write(oprot);
       }
@@ -175,9 +175,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final elem192 = t_variety.Event();
-      t_variety.Event req = elem192;
-      elem192.read(iprot);
+      final elem1 = t_variety.Event();
+      t_variety.Event req = elem1;
+      elem1.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -264,20 +264,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem193 = iprot.readListBegin();
+      thrift.TList elem2 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem200 = 0; elem200 < elem193.length; ++elem200) {
-        thrift.TMap elem195 = iprot.readMapBegin();
-        final elem194 = <int, t_variety.Event>{};
-        for(int elem198 = 0; elem198 < elem195.length; ++elem198) {
-          int elem199 = iprot.readI64();
-          final elem197 = t_variety.Event();
-          t_variety.Event elem196 = elem197;
-          elem197.read(iprot);
-          elem194[elem199] = elem196;
+      for(int elem9 = 0; elem9 < elem2.length; ++elem9) {
+        thrift.TMap elem4 = iprot.readMapBegin();
+        final elem3 = <int, t_variety.Event>{};
+        for(int elem7 = 0; elem7 < elem4.length; ++elem7) {
+          int elem8 = iprot.readI64();
+          final elem6 = t_variety.Event();
+          t_variety.Event elem5 = elem6;
+          elem6.read(iprot);
+          elem3[elem8] = elem5;
         }
         iprot.readMapEnd();
-        req.add(elem194);
+        req.add(elem3);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart.nullunsetsafe/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart.nullunsetsafe/variety/f_foo_args.dart
@@ -130,22 +130,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem145 = newMessage;
-    if (elem145 != null) {
+    final elem0 = newMessage;
+    if (elem0 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem145);
+      oprot.writeString(elem0);
       oprot.writeFieldEnd();
     }
-    final elem146 = messageArgs;
-    if (elem146 != null) {
+    final elem1 = messageArgs;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem146);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem147 = messageResult;
-    if (elem147 != null) {
+    final elem2 = messageResult;
+    if (elem2 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem147);
+      oprot.writeString(elem2);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunsetsafe/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart.nullunsetsafe/variety/f_foo_service.dart
@@ -412,20 +412,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem164 = num;
+    final elem0 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem164);
+    oprot.writeI32(elem0);
     oprot.writeFieldEnd();
-    final elem165 = str;
-    if (elem165 != null) {
+    final elem1 = str;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem165);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem166 = event;
-    if (elem166 != null) {
+    final elem2 = event;
+    if (elem2 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem166.write(oprot);
+      elem2.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -458,18 +458,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem167 = t_variety.AwesomeException();
-            this.awe = elem167;
-            elem167.read(iprot);
+            final elem3 = t_variety.AwesomeException();
+            this.awe = elem3;
+            elem3.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            final elem168 = t_actual_base_dart.api_exception();
-            this.api = elem168;
-            elem168.read(iprot);
+            final elem4 = t_actual_base_dart.api_exception();
+            this.api = elem4;
+            elem4.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -503,15 +503,15 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem169 = id;
+    final elem5 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem169);
+    oprot.writeI64(elem5);
     oprot.writeFieldEnd();
-    final elem170 = req;
-    if (elem170 != null) {
+    final elem6 = req;
+    if (elem6 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem170.length));
-      for(var entry in elem170.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem6.length));
+      for(var entry in elem6.entries) {
         oprot.writeI32(entry.key);
         oprot.writeString(entry.value);
       }
@@ -540,16 +540,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem171 = bin;
-    if (elem171 != null) {
+    final elem7 = bin;
+    if (elem7 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem171);
+      oprot.writeBinary(elem7);
       oprot.writeFieldEnd();
     }
-    final elem172 = str;
-    if (elem172 != null) {
+    final elem8 = str;
+    if (elem8 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem172);
+      oprot.writeString(elem8);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -581,9 +581,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem173 = t_actual_base_dart.api_exception();
-            this.api = elem173;
-            elem173.read(iprot);
+            final elem9 = t_actual_base_dart.api_exception();
+            this.api = elem9;
+            elem9.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -619,17 +619,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem174 = opt_num;
+    final elem10 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem174);
+    oprot.writeI32(elem10);
     oprot.writeFieldEnd();
-    final elem175 = default_num;
+    final elem11 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem175);
+    oprot.writeI32(elem11);
     oprot.writeFieldEnd();
-    final elem176 = req_num;
+    final elem12 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem176);
+    oprot.writeI32(elem12);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -690,22 +690,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem177 = list_type;
-    if (elem177 != null) {
+    final elem13 = list_type;
+    if (elem13 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem177.length));
-      for(var elem178 in elem177) {
-        oprot.writeI64(elem178);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem13.length));
+      for(var elem14 in elem13) {
+        oprot.writeI64(elem14);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem179 = set_type;
-    if (elem179 != null) {
+    final elem15 = set_type;
+    if (elem15 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem179.length));
-      for(var elem180 in elem179) {
-        oprot.writeI64(elem180);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem15.length));
+      for(var elem16 in elem15) {
+        oprot.writeI64(elem16);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -731,14 +731,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem181 = iprot.readListBegin();
-            final elem184 = <int>[];
-            for(int elem183 = 0; elem183 < elem181.length; ++elem183) {
-              int elem182 = iprot.readI64();
-              elem184.add(elem182);
+            thrift.TList elem17 = iprot.readListBegin();
+            final elem20 = <int>[];
+            for(int elem19 = 0; elem19 < elem17.length; ++elem19) {
+              int elem18 = iprot.readI64();
+              elem20.add(elem18);
             }
             iprot.readListEnd();
-            this.success = elem184;
+            this.success = elem20;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -789,9 +789,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem185 = t_validStructs.Thing();
-            this.success = elem185;
-            elem185.read(iprot);
+            final elem21 = t_validStructs.Thing();
+            this.success = elem21;
+            elem21.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -874,10 +874,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem186 = a;
-    if (elem186 != null) {
+    final elem22 = a;
+    if (elem22 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem186.write(oprot);
+      elem22.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -901,9 +901,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem187 = t_subdir_include_ns.A();
-            this.success = elem187;
-            elem187.read(iprot);
+            final elem23 = t_subdir_include_ns.A();
+            this.success = elem23;
+            elem23.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -935,10 +935,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem188 = newMessage;
-    if (elem188 != null) {
+    final elem24 = newMessage;
+    if (elem24 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem188);
+      oprot.writeString(elem24);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -994,10 +994,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem189 = messageArgs;
-    if (elem189 != null) {
+    final elem25 = messageArgs;
+    if (elem25 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem189);
+      oprot.writeString(elem25);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1053,10 +1053,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem190 = messageResult;
-    if (elem190 != null) {
+    final elem26 = messageResult;
+    if (elem26 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem190);
+      oprot.writeString(elem26);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart.nullunsetsafe/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart.nullunsetsafe/variety/f_test_lowercase.dart
@@ -86,9 +86,9 @@ class TestLowercase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem2 = lowercaseInt;
+    final elem0 = lowercaseInt;
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
-    oprot.writeI32(elem2);
+    oprot.writeI32(elem0);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunsetsafe/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart.nullunsetsafe/variety/f_testing_defaults.dart
@@ -367,18 +367,18 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem6 = t_variety.Event();
-            this.ev1 = elem6;
-            elem6.read(iprot);
+            final elem0 = t_variety.Event();
+            this.ev1 = elem0;
+            elem0.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
-            final elem7 = t_variety.Event();
-            this.ev2 = elem7;
-            elem7.read(iprot);
+            final elem1 = t_variety.Event();
+            this.ev2 = elem1;
+            elem1.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -406,14 +406,14 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LISTFIELD:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem8 = iprot.readListBegin();
-            final elem11 = <int>[];
-            for(int elem10 = 0; elem10 < elem8.length; ++elem10) {
-              int elem9 = iprot.readI32();
-              elem11.add(elem9);
+            thrift.TList elem2 = iprot.readListBegin();
+            final elem5 = <int>[];
+            for(int elem4 = 0; elem4 < elem2.length; ++elem4) {
+              int elem3 = iprot.readI32();
+              elem5.add(elem3);
             }
             iprot.readListEnd();
-            this.listfield = elem11;
+            this.listfield = elem5;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -455,57 +455,57 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LIST2:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem12 = iprot.readListBegin();
-            final elem15 = <int>[];
-            for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
-              int elem13 = iprot.readI32();
-              elem15.add(elem13);
+            thrift.TList elem6 = iprot.readListBegin();
+            final elem9 = <int>[];
+            for(int elem8 = 0; elem8 < elem6.length; ++elem8) {
+              int elem7 = iprot.readI32();
+              elem9.add(elem7);
             }
             iprot.readListEnd();
-            this.list2 = elem15;
+            this.list2 = elem9;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST3:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem16 = iprot.readListBegin();
-            final elem19 = <int>[];
-            for(int elem18 = 0; elem18 < elem16.length; ++elem18) {
-              int elem17 = iprot.readI32();
-              elem19.add(elem17);
+            thrift.TList elem10 = iprot.readListBegin();
+            final elem13 = <int>[];
+            for(int elem12 = 0; elem12 < elem10.length; ++elem12) {
+              int elem11 = iprot.readI32();
+              elem13.add(elem11);
             }
             iprot.readListEnd();
-            this.list3 = elem19;
+            this.list3 = elem13;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST4:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem20 = iprot.readListBegin();
-            final elem23 = <int>[];
-            for(int elem22 = 0; elem22 < elem20.length; ++elem22) {
-              int elem21 = iprot.readI32();
-              elem23.add(elem21);
+            thrift.TList elem14 = iprot.readListBegin();
+            final elem17 = <int>[];
+            for(int elem16 = 0; elem16 < elem14.length; ++elem16) {
+              int elem15 = iprot.readI32();
+              elem17.add(elem15);
             }
             iprot.readListEnd();
-            this.list4 = elem23;
+            this.list4 = elem17;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case A_MAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem24 = iprot.readMapBegin();
-            final elem27 = <String, String>{};
-            for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
-              String elem28 = iprot.readString();
-              String elem25 = iprot.readString();
-              elem27[elem28] = elem25;
+            thrift.TMap elem18 = iprot.readMapBegin();
+            final elem21 = <String, String>{};
+            for(int elem20 = 0; elem20 < elem18.length; ++elem20) {
+              String elem22 = iprot.readString();
+              String elem19 = iprot.readString();
+              elem21[elem22] = elem19;
             }
             iprot.readMapEnd();
-            this.a_map = elem27;
+            this.a_map = elem21;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -540,126 +540,126 @@ class TestingDefaults implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem29 = iD2;
-    if (elem29 != null) {
+    final elem23 = iD2;
+    if (elem23 != null) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
-      oprot.writeI64(elem29);
+      oprot.writeI64(elem23);
       oprot.writeFieldEnd();
     }
-    final elem30 = ev1;
-    if (elem30 != null) {
+    final elem24 = ev1;
+    if (elem24 != null) {
       oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      elem30.write(oprot);
+      elem24.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem31 = ev2;
-    if (elem31 != null) {
+    final elem25 = ev2;
+    if (elem25 != null) {
       oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      elem31.write(oprot);
+      elem25.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem32 = iD;
+    final elem26 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem32);
+    oprot.writeI64(elem26);
     oprot.writeFieldEnd();
-    final elem33 = thing;
-    if (elem33 != null) {
+    final elem27 = thing;
+    if (elem27 != null) {
       oprot.writeFieldBegin(_THING_FIELD_DESC);
-      oprot.writeString(elem33);
+      oprot.writeString(elem27);
       oprot.writeFieldEnd();
     }
-    final elem34 = thing2;
-    if (elem34 != null) {
+    final elem28 = thing2;
+    if (elem28 != null) {
       oprot.writeFieldBegin(_THING2_FIELD_DESC);
-      oprot.writeString(elem34);
+      oprot.writeString(elem28);
       oprot.writeFieldEnd();
     }
-    final elem35 = listfield;
-    if (elem35 != null) {
+    final elem29 = listfield;
+    if (elem29 != null) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem35.length));
-      for(var elem36 in elem35) {
-        oprot.writeI32(elem36);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem29.length));
+      for(var elem30 in elem29) {
+        oprot.writeI32(elem30);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem37 = iD3;
+    final elem31 = iD3;
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
-    oprot.writeI64(elem37);
+    oprot.writeI64(elem31);
     oprot.writeFieldEnd();
-    final elem38 = bin_field;
-    if (elem38 != null) {
+    final elem32 = bin_field;
+    if (elem32 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_FIELD_DESC);
-      oprot.writeBinary(elem38);
+      oprot.writeBinary(elem32);
       oprot.writeFieldEnd();
     }
-    final elem39 = bin_field2;
-    if (elem39 != null) {
+    final elem33 = bin_field2;
+    if (elem33 != null) {
       oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
-      oprot.writeBinary(elem39);
+      oprot.writeBinary(elem33);
       oprot.writeFieldEnd();
     }
-    final elem40 = bin_field3;
-    if (elem40 != null) {
+    final elem34 = bin_field3;
+    if (elem34 != null) {
       oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
-      oprot.writeBinary(elem40);
+      oprot.writeBinary(elem34);
       oprot.writeFieldEnd();
     }
-    final elem41 = bin_field4;
-    if (elem41 != null) {
+    final elem35 = bin_field4;
+    if (elem35 != null) {
       oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
-      oprot.writeBinary(elem41);
+      oprot.writeBinary(elem35);
       oprot.writeFieldEnd();
     }
-    final elem42 = list2;
-    if (elem42 != null) {
+    final elem36 = list2;
+    if (elem36 != null) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem42.length));
-      for(var elem43 in elem42) {
-        oprot.writeI32(elem43);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem36.length));
+      for(var elem37 in elem36) {
+        oprot.writeI32(elem37);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem44 = list3;
-    if (elem44 != null) {
+    final elem38 = list3;
+    if (elem38 != null) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem44.length));
-      for(var elem45 in elem44) {
-        oprot.writeI32(elem45);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem38.length));
+      for(var elem39 in elem38) {
+        oprot.writeI32(elem39);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem46 = list4;
-    if (elem46 != null) {
+    final elem40 = list4;
+    if (elem40 != null) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem46.length));
-      for(var elem47 in elem46) {
-        oprot.writeI32(elem47);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem40.length));
+      for(var elem41 in elem40) {
+        oprot.writeI32(elem41);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem48 = a_map;
-    if (elem48 != null) {
+    final elem42 = a_map;
+    if (elem42 != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem48.length));
-      for(var entry in elem48.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem42.length));
+      for(var entry in elem42.entries) {
         oprot.writeString(entry.key);
         oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem49 = status;
+    final elem43 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem49);
+    oprot.writeI32(elem43);
     oprot.writeFieldEnd();
-    final elem50 = base_status;
+    final elem44 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(elem50);
+    oprot.writeI32(elem44);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart.nullunsetsafe/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart.nullunsetsafe/variety/f_testing_unions.dart
@@ -203,15 +203,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem148 = iprot.readMapBegin();
-            final elem151 = <int, String>{};
-            for(int elem150 = 0; elem150 < elem148.length; ++elem150) {
-              int elem152 = iprot.readI32();
-              String elem149 = iprot.readString();
-              elem151[elem152] = elem149;
+            thrift.TMap elem0 = iprot.readMapBegin();
+            final elem3 = <int, String>{};
+            for(int elem2 = 0; elem2 < elem0.length; ++elem2) {
+              int elem4 = iprot.readI32();
+              String elem1 = iprot.readString();
+              elem3[elem4] = elem1;
             }
             iprot.readMapEnd();
-            this.requests = elem151;
+            this.requests = elem3;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -254,58 +254,58 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem153 = anID;
-    if (elem153 != null) {
+    final elem5 = anID;
+    if (elem5 != null) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(elem153);
+      oprot.writeI64(elem5);
       oprot.writeFieldEnd();
     }
-    final elem154 = aString;
-    if (elem154 != null) {
+    final elem6 = aString;
+    if (elem6 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem154);
+      oprot.writeString(elem6);
       oprot.writeFieldEnd();
     }
-    final elem155 = someotherthing;
-    if (elem155 != null) {
+    final elem7 = someotherthing;
+    if (elem7 != null) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem155);
+      oprot.writeI32(elem7);
       oprot.writeFieldEnd();
     }
-    final elem156 = anInt16;
-    if (elem156 != null) {
+    final elem8 = anInt16;
+    if (elem8 != null) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem156);
+      oprot.writeI16(elem8);
       oprot.writeFieldEnd();
     }
-    final elem157 = requests;
-    if (elem157 != null) {
+    final elem9 = requests;
+    if (elem9 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem157.length));
-      for(var entry in elem157.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem9.length));
+      for(var entry in elem9.entries) {
         oprot.writeI32(entry.key);
         oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem158 = bin_field_in_union;
-    if (elem158 != null) {
+    final elem10 = bin_field_in_union;
+    if (elem10 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem158);
+      oprot.writeBinary(elem10);
       oprot.writeFieldEnd();
     }
-    final elem159 = depr;
+    final elem11 = depr;
     // ignore: deprecated_member_use
-    if (elem159 != null) {
+    if (elem11 != null) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem159);
+      oprot.writeBool(elem11);
       oprot.writeFieldEnd();
     }
-    final elem160 = wHOA_BUDDY;
-    if (elem160 != null) {
+    final elem12 = wHOA_BUDDY;
+    if (elem12 != null) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem160);
+      oprot.writeBool(elem12);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_nested_thing.dart
@@ -67,16 +67,16 @@ class nested_thing implements thrift.TBase {
       switch (field.id) {
         case THINGS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem203 = iprot.readListBegin();
-            final elem207 = <t_actual_base_dart.thing>[];
-            for(int elem206 = 0; elem206 < elem203.length; ++elem206) {
-              final elem205 = t_actual_base_dart.thing();
-              t_actual_base_dart.thing elem204 = elem205;
-              elem205.read(iprot);
-              elem207.add(elem204);
+            thrift.TList elem0 = iprot.readListBegin();
+            final elem4 = <t_actual_base_dart.thing>[];
+            for(int elem3 = 0; elem3 < elem0.length; ++elem3) {
+              final elem2 = t_actual_base_dart.thing();
+              t_actual_base_dart.thing elem1 = elem2;
+              elem2.read(iprot);
+              elem4.add(elem1);
             }
             iprot.readListEnd();
-            this.things = elem207;
+            this.things = elem4;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -97,12 +97,12 @@ class nested_thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem208 = things;
-    if (elem208 != null) {
+    final elem5 = things;
+    if (elem5 != null) {
       oprot.writeFieldBegin(_THINGS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem208.length));
-      for(var elem209 in elem208) {
-        elem209.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem5.length));
+      for(var elem6 in elem5) {
+        elem6.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart/actual_base/f_thing.dart
+++ b/compiler/testdata/expected/dart/actual_base/f_thing.dart
@@ -126,14 +126,14 @@ class thing implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem201 = an_id;
+    final elem0 = an_id;
     oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-    oprot.writeI32(elem201);
+    oprot.writeI32(elem0);
     oprot.writeFieldEnd();
-    final elem202 = a_string;
-    if (elem202 != null) {
+    final elem1 = a_string;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem202);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/include_vendor/f_my_scope_scope.dart
+++ b/compiler/testdata/expected/dart/include_vendor/f_my_scope_scope.dart
@@ -95,9 +95,9 @@ class MyScopeSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final elem4 = t_vendor_namespace.Item();
-      t_vendor_namespace.Item req = elem4;
-      elem4.read(iprot);
+      final elem0 = t_vendor_namespace.Item();
+      t_vendor_namespace.Item req = elem0;
+      elem0.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }

--- a/compiler/testdata/expected/dart/include_vendor/f_my_service_service.dart
+++ b/compiler/testdata/expected/dart/include_vendor/f_my_service_service.dart
@@ -110,18 +110,18 @@ class getItem_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem2 = t_vendor_namespace.Item();
-            this.success = elem2;
-            elem2.read(iprot);
+            final elem0 = t_vendor_namespace.Item();
+            this.success = elem0;
+            elem0.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem3 = t_excepts.InvalidData();
-            this.d = elem3;
-            elem3.read(iprot);
+            final elem1 = t_excepts.InvalidData();
+            this.d = elem1;
+            elem1.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }

--- a/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
+++ b/compiler/testdata/expected/dart/variety/f_awesome_exception.dart
@@ -184,19 +184,19 @@ class AwesomeException extends Error implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem161 = iD;
+    final elem0 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem161);
+    oprot.writeI64(elem0);
     oprot.writeFieldEnd();
-    final elem162 = reason;
-    if (elem162 != null) {
+    final elem1 = reason;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_REASON_FIELD_DESC);
-      oprot.writeString(elem162);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem163 = depr;
+    final elem2 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem163);
+    oprot.writeBool(elem2);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_event.dart
+++ b/compiler/testdata/expected/dart/variety/f_event.dart
@@ -180,19 +180,19 @@ class Event implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem3 = iD;
+    final elem0 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem3);
+    oprot.writeI64(elem0);
     oprot.writeFieldEnd();
-    final elem4 = message;
-    if (elem4 != null) {
+    final elem1 = message;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem4);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem5 = yES_NO;
+    final elem2 = yES_NO;
     oprot.writeFieldBegin(_YE_S__NO_FIELD_DESC);
-    oprot.writeBool(elem5);
+    oprot.writeBool(elem2);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
+++ b/compiler/testdata/expected/dart/variety/f_event_wrapper.dart
@@ -531,92 +531,92 @@ class EventWrapper implements thrift.TBase {
           break;
         case EV:
           if (field.type == thrift.TType.STRUCT) {
-            final elem51 = t_variety.Event();
-            this.ev = elem51;
-            elem51.read(iprot);
+            final elem0 = t_variety.Event();
+            this.ev = elem0;
+            elem0.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem52 = iprot.readListBegin();
-            final elem56 = <t_variety.Event>[];
-            for(int elem55 = 0; elem55 < elem52.length; ++elem55) {
-              final elem54 = t_variety.Event();
-              t_variety.Event elem53 = elem54;
-              elem54.read(iprot);
-              elem56.add(elem53);
+            thrift.TList elem1 = iprot.readListBegin();
+            final elem5 = <t_variety.Event>[];
+            for(int elem4 = 0; elem4 < elem1.length; ++elem4) {
+              final elem3 = t_variety.Event();
+              t_variety.Event elem2 = elem3;
+              elem3.read(iprot);
+              elem5.add(elem2);
             }
             iprot.readListEnd();
-            this.events = elem56;
+            this.events = elem5;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTS2:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem57 = iprot.readSetBegin();
-            final elem61 = <t_variety.Event>{};
-            for(int elem60 = 0; elem60 < elem57.length; ++elem60) {
-              final elem59 = t_variety.Event();
-              t_variety.Event elem58 = elem59;
-              elem59.read(iprot);
-              elem61.add(elem58);
+            thrift.TSet elem6 = iprot.readSetBegin();
+            final elem10 = <t_variety.Event>{};
+            for(int elem9 = 0; elem9 < elem6.length; ++elem9) {
+              final elem8 = t_variety.Event();
+              t_variety.Event elem7 = elem8;
+              elem8.read(iprot);
+              elem10.add(elem7);
             }
             iprot.readSetEnd();
-            this.events2 = elem61;
+            this.events2 = elem10;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem62 = iprot.readMapBegin();
-            final elem66 = <int, t_variety.Event>{};
-            for(int elem65 = 0; elem65 < elem62.length; ++elem65) {
-              int elem67 = iprot.readI64();
-              final elem64 = t_variety.Event();
-              t_variety.Event elem63 = elem64;
-              elem64.read(iprot);
-              elem66[elem67] = elem63;
+            thrift.TMap elem11 = iprot.readMapBegin();
+            final elem15 = <int, t_variety.Event>{};
+            for(int elem14 = 0; elem14 < elem11.length; ++elem14) {
+              int elem16 = iprot.readI64();
+              final elem13 = t_variety.Event();
+              t_variety.Event elem12 = elem13;
+              elem13.read(iprot);
+              elem15[elem16] = elem12;
             }
             iprot.readMapEnd();
-            this.eventMap = elem66;
+            this.eventMap = elem15;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case NUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem68 = iprot.readListBegin();
-            final elem74 = <List<int>>[];
-            for(int elem73 = 0; elem73 < elem68.length; ++elem73) {
-              thrift.TList elem70 = iprot.readListBegin();
-              final elem69 = <int>[];
-              for(int elem72 = 0; elem72 < elem70.length; ++elem72) {
-                int elem71 = iprot.readI32();
-                elem69.add(elem71);
+            thrift.TList elem17 = iprot.readListBegin();
+            final elem23 = <List<int>>[];
+            for(int elem22 = 0; elem22 < elem17.length; ++elem22) {
+              thrift.TList elem19 = iprot.readListBegin();
+              final elem18 = <int>[];
+              for(int elem21 = 0; elem21 < elem19.length; ++elem21) {
+                int elem20 = iprot.readI32();
+                elem18.add(elem20);
               }
               iprot.readListEnd();
-              elem74.add(elem69);
+              elem23.add(elem18);
             }
             iprot.readListEnd();
-            this.nums = elem74;
+            this.nums = elem23;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case ENUMS:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem75 = iprot.readListBegin();
-            final elem78 = <int>[];
-            for(int elem77 = 0; elem77 < elem75.length; ++elem77) {
-              int elem76 = iprot.readI32();
-              elem78.add(elem76);
+            thrift.TList elem24 = iprot.readListBegin();
+            final elem27 = <int>[];
+            for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
+              int elem25 = iprot.readI32();
+              elem27.add(elem25);
             }
             iprot.readListEnd();
-            this.enums = elem78;
+            this.enums = elem27;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -631,9 +631,9 @@ class EventWrapper implements thrift.TBase {
           break;
         case A_UNION:
           if (field.type == thrift.TType.STRUCT) {
-            final elem79 = t_variety.TestingUnions();
-            this.a_union = elem79;
-            elem79.read(iprot);
+            final elem28 = t_variety.TestingUnions();
+            this.a_union = elem28;
+            elem28.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -664,114 +664,114 @@ class EventWrapper implements thrift.TBase {
           break;
         case DEPRLIST:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem80 = iprot.readListBegin();
+            thrift.TList elem29 = iprot.readListBegin();
             // ignore: deprecated_member_use
-            final elem83 = <bool>[];
-            for(int elem82 = 0; elem82 < elem80.length; ++elem82) {
-              bool elem81 = iprot.readBool();
+            final elem32 = <bool>[];
+            for(int elem31 = 0; elem31 < elem29.length; ++elem31) {
+              bool elem30 = iprot.readBool();
               // ignore: deprecated_member_use
-              elem83.add(elem81);
+              elem32.add(elem30);
             }
             iprot.readListEnd();
-            this.deprList = elem83;
+            this.deprList = elem32;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSDEFAULT:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem84 = iprot.readListBegin();
-            final elem88 = <t_variety.Event>[];
-            for(int elem87 = 0; elem87 < elem84.length; ++elem87) {
-              final elem86 = t_variety.Event();
-              t_variety.Event elem85 = elem86;
-              elem86.read(iprot);
-              elem88.add(elem85);
+            thrift.TList elem33 = iprot.readListBegin();
+            final elem37 = <t_variety.Event>[];
+            for(int elem36 = 0; elem36 < elem33.length; ++elem36) {
+              final elem35 = t_variety.Event();
+              t_variety.Event elem34 = elem35;
+              elem35.read(iprot);
+              elem37.add(elem34);
             }
             iprot.readListEnd();
-            this.eventsDefault = elem88;
+            this.eventsDefault = elem37;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPDEFAULT:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem89 = iprot.readMapBegin();
-            final elem93 = <int, t_variety.Event>{};
-            for(int elem92 = 0; elem92 < elem89.length; ++elem92) {
-              int elem94 = iprot.readI64();
-              final elem91 = t_variety.Event();
-              t_variety.Event elem90 = elem91;
-              elem91.read(iprot);
-              elem93[elem94] = elem90;
+            thrift.TMap elem38 = iprot.readMapBegin();
+            final elem42 = <int, t_variety.Event>{};
+            for(int elem41 = 0; elem41 < elem38.length; ++elem41) {
+              int elem43 = iprot.readI64();
+              final elem40 = t_variety.Event();
+              t_variety.Event elem39 = elem40;
+              elem40.read(iprot);
+              elem42[elem43] = elem39;
             }
             iprot.readMapEnd();
-            this.eventMapDefault = elem93;
+            this.eventMapDefault = elem42;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETDEFAULT:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem95 = iprot.readSetBegin();
-            final elem99 = <t_variety.Event>{};
-            for(int elem98 = 0; elem98 < elem95.length; ++elem98) {
-              final elem97 = t_variety.Event();
-              t_variety.Event elem96 = elem97;
-              elem97.read(iprot);
-              elem99.add(elem96);
+            thrift.TSet elem44 = iprot.readSetBegin();
+            final elem48 = <t_variety.Event>{};
+            for(int elem47 = 0; elem47 < elem44.length; ++elem47) {
+              final elem46 = t_variety.Event();
+              t_variety.Event elem45 = elem46;
+              elem46.read(iprot);
+              elem48.add(elem45);
             }
             iprot.readSetEnd();
-            this.eventSetDefault = elem99;
+            this.eventSetDefault = elem48;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSREQUIRED:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem100 = iprot.readListBegin();
-            final elem104 = <t_variety.Event>[];
-            for(int elem103 = 0; elem103 < elem100.length; ++elem103) {
-              final elem102 = t_variety.Event();
-              t_variety.Event elem101 = elem102;
-              elem102.read(iprot);
-              elem104.add(elem101);
+            thrift.TList elem49 = iprot.readListBegin();
+            final elem53 = <t_variety.Event>[];
+            for(int elem52 = 0; elem52 < elem49.length; ++elem52) {
+              final elem51 = t_variety.Event();
+              t_variety.Event elem50 = elem51;
+              elem51.read(iprot);
+              elem53.add(elem50);
             }
             iprot.readListEnd();
-            this.eventsRequired = elem104;
+            this.eventsRequired = elem53;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTMAPREQUIRED:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem105 = iprot.readMapBegin();
-            final elem109 = <int, t_variety.Event>{};
-            for(int elem108 = 0; elem108 < elem105.length; ++elem108) {
-              int elem110 = iprot.readI64();
-              final elem107 = t_variety.Event();
-              t_variety.Event elem106 = elem107;
-              elem107.read(iprot);
-              elem109[elem110] = elem106;
+            thrift.TMap elem54 = iprot.readMapBegin();
+            final elem58 = <int, t_variety.Event>{};
+            for(int elem57 = 0; elem57 < elem54.length; ++elem57) {
+              int elem59 = iprot.readI64();
+              final elem56 = t_variety.Event();
+              t_variety.Event elem55 = elem56;
+              elem56.read(iprot);
+              elem58[elem59] = elem55;
             }
             iprot.readMapEnd();
-            this.eventMapRequired = elem109;
+            this.eventMapRequired = elem58;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EVENTSETREQUIRED:
           if (field.type == thrift.TType.SET) {
-            thrift.TSet elem111 = iprot.readSetBegin();
-            final elem115 = <t_variety.Event>{};
-            for(int elem114 = 0; elem114 < elem111.length; ++elem114) {
-              final elem113 = t_variety.Event();
-              t_variety.Event elem112 = elem113;
-              elem113.read(iprot);
-              elem115.add(elem112);
+            thrift.TSet elem60 = iprot.readSetBegin();
+            final elem64 = <t_variety.Event>{};
+            for(int elem63 = 0; elem63 < elem60.length; ++elem63) {
+              final elem62 = t_variety.Event();
+              t_variety.Event elem61 = elem62;
+              elem62.read(iprot);
+              elem64.add(elem61);
             }
             iprot.readSetEnd();
-            this.eventSetRequired = elem115;
+            this.eventSetRequired = elem64;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -792,169 +792,169 @@ class EventWrapper implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem116 = iD;
+    final elem65 = iD;
     if (isSetID()) {
       oprot.writeFieldBegin(_ID_FIELD_DESC);
-      oprot.writeI64(elem116);
+      oprot.writeI64(elem65);
       oprot.writeFieldEnd();
     }
-    final elem117 = ev;
-    if (elem117 != null) {
+    final elem66 = ev;
+    if (elem66 != null) {
       oprot.writeFieldBegin(_EV_FIELD_DESC);
-      elem117.write(oprot);
+      elem66.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem118 = events;
-    if (elem118 != null) {
+    final elem67 = events;
+    if (elem67 != null) {
       oprot.writeFieldBegin(_EVENTS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem118.length));
-      for(var elem119 in elem118) {
-        elem119.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem67.length));
+      for(var elem68 in elem67) {
+        elem68.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem120 = events2;
-    if (elem120 != null) {
+    final elem69 = events2;
+    if (elem69 != null) {
       oprot.writeFieldBegin(_EVENTS2_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem120.length));
-      for(var elem121 in elem120) {
-        elem121.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem69.length));
+      for(var elem70 in elem69) {
+        elem70.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem122 = eventMap;
-    if (elem122 != null) {
+    final elem71 = eventMap;
+    if (elem71 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem122.length));
-      for(var entry in elem122.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem71.length));
+      for(var entry in elem71.entries) {
         oprot.writeI64(entry.key);
         entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem123 = nums;
-    if (elem123 != null) {
+    final elem72 = nums;
+    if (elem72 != null) {
       oprot.writeFieldBegin(_NUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem123.length));
-      for(var elem124 in elem123) {
-        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem124.length));
-        for(var elem125 in elem124) {
-          oprot.writeI32(elem125);
+      oprot.writeListBegin(thrift.TList(thrift.TType.LIST, elem72.length));
+      for(var elem73 in elem72) {
+        oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem73.length));
+        for(var elem74 in elem73) {
+          oprot.writeI32(elem74);
         }
         oprot.writeListEnd();
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem126 = enums;
-    if (elem126 != null) {
+    final elem75 = enums;
+    if (elem75 != null) {
       oprot.writeFieldBegin(_ENUMS_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem126.length));
-      for(var elem127 in elem126) {
-        oprot.writeI32(elem127);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem75.length));
+      for(var elem76 in elem75) {
+        oprot.writeI32(elem76);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem128 = aBoolField;
+    final elem77 = aBoolField;
     oprot.writeFieldBegin(_A_BOOL_FIELD_FIELD_DESC);
-    oprot.writeBool(elem128);
+    oprot.writeBool(elem77);
     oprot.writeFieldEnd();
-    final elem129 = a_union;
-    if (elem129 != null) {
+    final elem78 = a_union;
+    if (elem78 != null) {
       oprot.writeFieldBegin(_A_UNION_FIELD_DESC);
-      elem129.write(oprot);
+      elem78.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem130 = typedefOfTypedef;
-    if (elem130 != null) {
+    final elem79 = typedefOfTypedef;
+    if (elem79 != null) {
       oprot.writeFieldBegin(_TYPEDEF_OF_TYPEDEF_FIELD_DESC);
-      oprot.writeString(elem130);
+      oprot.writeString(elem79);
       oprot.writeFieldEnd();
     }
-    final elem131 = depr;
+    final elem80 = depr;
     oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-    oprot.writeBool(elem131);
+    oprot.writeBool(elem80);
     oprot.writeFieldEnd();
-    final elem132 = deprBinary;
+    final elem81 = deprBinary;
     // ignore: deprecated_member_use
-    if (elem132 != null) {
+    if (elem81 != null) {
       oprot.writeFieldBegin(_DEPR_BINARY_FIELD_DESC);
-      oprot.writeBinary(elem132);
+      oprot.writeBinary(elem81);
       oprot.writeFieldEnd();
     }
-    final elem133 = deprList;
+    final elem82 = deprList;
     // ignore: deprecated_member_use
-    if (elem133 != null) {
+    if (elem82 != null) {
       oprot.writeFieldBegin(_DEPR_LIST_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem133.length));
-      for(var elem134 in elem133) {
-        oprot.writeBool(elem134);
+      oprot.writeListBegin(thrift.TList(thrift.TType.BOOL, elem82.length));
+      for(var elem83 in elem82) {
+        oprot.writeBool(elem83);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem135 = eventsDefault;
-    if (isSetEventsDefault() && elem135 != null) {
+    final elem84 = eventsDefault;
+    if (isSetEventsDefault() && elem84 != null) {
       oprot.writeFieldBegin(_EVENTS_DEFAULT_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem135.length));
-      for(var elem136 in elem135) {
-        elem136.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem84.length));
+      for(var elem85 in elem84) {
+        elem85.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem137 = eventMapDefault;
-    if (isSetEventMapDefault() && elem137 != null) {
+    final elem86 = eventMapDefault;
+    if (isSetEventMapDefault() && elem86 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_DEFAULT_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem137.length));
-      for(var entry in elem137.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem86.length));
+      for(var entry in elem86.entries) {
         oprot.writeI64(entry.key);
         entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem138 = eventSetDefault;
-    if (isSetEventSetDefault() && elem138 != null) {
+    final elem87 = eventSetDefault;
+    if (isSetEventSetDefault() && elem87 != null) {
       oprot.writeFieldBegin(_EVENT_SET_DEFAULT_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem138.length));
-      for(var elem139 in elem138) {
-        elem139.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem87.length));
+      for(var elem88 in elem87) {
+        elem88.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
     }
-    final elem140 = eventsRequired;
-    if (elem140 != null) {
+    final elem89 = eventsRequired;
+    if (elem89 != null) {
       oprot.writeFieldBegin(_EVENTS_REQUIRED_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem140.length));
-      for(var elem141 in elem140) {
-        elem141.write(oprot);
+      oprot.writeListBegin(thrift.TList(thrift.TType.STRUCT, elem89.length));
+      for(var elem90 in elem89) {
+        elem90.write(oprot);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem142 = eventMapRequired;
-    if (elem142 != null) {
+    final elem91 = eventMapRequired;
+    if (elem91 != null) {
       oprot.writeFieldBegin(_EVENT_MAP_REQUIRED_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem142.length));
-      for(var entry in elem142.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem91.length));
+      for(var entry in elem91.entries) {
         oprot.writeI64(entry.key);
         entry.value.write(oprot);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem143 = eventSetRequired;
-    if (elem143 != null) {
+    final elem92 = eventSetRequired;
+    if (elem92 != null) {
       oprot.writeFieldBegin(_EVENT_SET_REQUIRED_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem143.length));
-      for(var elem144 in elem143) {
-        elem144.write(oprot);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.STRUCT, elem92.length));
+      for(var elem93 in elem92) {
+        elem93.write(oprot);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();

--- a/compiler/testdata/expected/dart/variety/f_events_scope.dart
+++ b/compiler/testdata/expected/dart/variety/f_events_scope.dart
@@ -123,9 +123,9 @@ class EventsPublisher {
     oprot.writeRequestHeader(ctx);
     oprot.writeMessageBegin(msg);
     oprot.writeListBegin(thrift.TList(thrift.TType.MAP, req.length));
-    for(var elem191 in req) {
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem191.length));
-      for(var entry in elem191.entries) {
+    for(var elem0 in req) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I64, thrift.TType.STRUCT, elem0.length));
+      for(var entry in elem0.entries) {
         oprot.writeI64(entry.key);
         entry.value.write(oprot);
       }
@@ -175,9 +175,9 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      final elem192 = t_variety.Event();
-      t_variety.Event req = elem192;
-      elem192.read(iprot);
+      final elem1 = t_variety.Event();
+      t_variety.Event req = elem1;
+      elem1.read(iprot);
       iprot.readMessageEnd();
       method([ctx, req]);
     }
@@ -264,20 +264,20 @@ class EventsSubscriber {
         throw thrift.TApplicationError(
         frugal.FrugalTApplicationErrorType.UNKNOWN_METHOD, tMsg.name);
       }
-      thrift.TList elem193 = iprot.readListBegin();
+      thrift.TList elem2 = iprot.readListBegin();
       final req = <Map<int, t_variety.Event>>[];
-      for(int elem200 = 0; elem200 < elem193.length; ++elem200) {
-        thrift.TMap elem195 = iprot.readMapBegin();
-        final elem194 = <int, t_variety.Event>{};
-        for(int elem198 = 0; elem198 < elem195.length; ++elem198) {
-          int elem199 = iprot.readI64();
-          final elem197 = t_variety.Event();
-          t_variety.Event elem196 = elem197;
-          elem197.read(iprot);
-          elem194[elem199] = elem196;
+      for(int elem9 = 0; elem9 < elem2.length; ++elem9) {
+        thrift.TMap elem4 = iprot.readMapBegin();
+        final elem3 = <int, t_variety.Event>{};
+        for(int elem7 = 0; elem7 < elem4.length; ++elem7) {
+          int elem8 = iprot.readI64();
+          final elem6 = t_variety.Event();
+          t_variety.Event elem5 = elem6;
+          elem6.read(iprot);
+          elem3[elem8] = elem5;
         }
         iprot.readMapEnd();
-        req.add(elem194);
+        req.add(elem3);
       }
       iprot.readListEnd();
       iprot.readMessageEnd();

--- a/compiler/testdata/expected/dart/variety/f_foo_args.dart
+++ b/compiler/testdata/expected/dart/variety/f_foo_args.dart
@@ -148,22 +148,22 @@ class FooArgs implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem145 = newMessage;
-    if (elem145 != null) {
+    final elem0 = newMessage;
+    if (elem0 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem145);
+      oprot.writeString(elem0);
       oprot.writeFieldEnd();
     }
-    final elem146 = messageArgs;
-    if (elem146 != null) {
+    final elem1 = messageArgs;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem146);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem147 = messageResult;
-    if (elem147 != null) {
+    final elem2 = messageResult;
+    if (elem2 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem147);
+      oprot.writeString(elem2);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_foo_service.dart
+++ b/compiler/testdata/expected/dart/variety/f_foo_service.dart
@@ -412,20 +412,20 @@ class blah_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem164 = num;
+    final elem0 = num;
     oprot.writeFieldBegin(_NUM_FIELD_DESC);
-    oprot.writeI32(elem164);
+    oprot.writeI32(elem0);
     oprot.writeFieldEnd();
-    final elem165 = str;
-    if (elem165 != null) {
+    final elem1 = str;
+    if (elem1 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem165);
+      oprot.writeString(elem1);
       oprot.writeFieldEnd();
     }
-    final elem166 = event;
-    if (elem166 != null) {
+    final elem2 = event;
+    if (elem2 != null) {
       oprot.writeFieldBegin(_EVENT_FIELD_DESC);
-      elem166.write(oprot);
+      elem2.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -458,18 +458,18 @@ class blah_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem167 = t_variety.AwesomeException();
-            this.awe = elem167;
-            elem167.read(iprot);
+            final elem3 = t_variety.AwesomeException();
+            this.awe = elem3;
+            elem3.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case 2:
           if (field.type == thrift.TType.STRUCT) {
-            final elem168 = t_actual_base_dart.api_exception();
-            this.api = elem168;
-            elem168.read(iprot);
+            final elem4 = t_actual_base_dart.api_exception();
+            this.api = elem4;
+            elem4.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -503,15 +503,15 @@ class oneWay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem169 = id;
+    final elem5 = id;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem169);
+    oprot.writeI64(elem5);
     oprot.writeFieldEnd();
-    final elem170 = req;
-    if (elem170 != null) {
+    final elem6 = req;
+    if (elem6 != null) {
       oprot.writeFieldBegin(_REQ_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem170.length));
-      for(var entry in elem170.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem6.length));
+      for(var entry in elem6.entries) {
         oprot.writeI32(entry.key);
         oprot.writeString(entry.value);
       }
@@ -540,16 +540,16 @@ class bin_method_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem171 = bin;
-    if (elem171 != null) {
+    final elem7 = bin;
+    if (elem7 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_DESC);
-      oprot.writeBinary(elem171);
+      oprot.writeBinary(elem7);
       oprot.writeFieldEnd();
     }
-    final elem172 = str;
-    if (elem172 != null) {
+    final elem8 = str;
+    if (elem8 != null) {
       oprot.writeFieldBegin(_STR_FIELD_DESC);
-      oprot.writeString(elem172);
+      oprot.writeString(elem8);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -581,9 +581,9 @@ class bin_method_result extends frugal.FGeneratedArgsResultBase {
           break;
         case 1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem173 = t_actual_base_dart.api_exception();
-            this.api = elem173;
-            elem173.read(iprot);
+            final elem9 = t_actual_base_dart.api_exception();
+            this.api = elem9;
+            elem9.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -619,17 +619,17 @@ class param_modifiers_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem174 = opt_num;
+    final elem10 = opt_num;
     oprot.writeFieldBegin(_OPT_NUM_FIELD_DESC);
-    oprot.writeI32(elem174);
+    oprot.writeI32(elem10);
     oprot.writeFieldEnd();
-    final elem175 = default_num;
+    final elem11 = default_num;
     oprot.writeFieldBegin(_DEFAULT_NUM_FIELD_DESC);
-    oprot.writeI32(elem175);
+    oprot.writeI32(elem11);
     oprot.writeFieldEnd();
-    final elem176 = req_num;
+    final elem12 = req_num;
     oprot.writeFieldBegin(_REQ_NUM_FIELD_DESC);
-    oprot.writeI32(elem176);
+    oprot.writeI32(elem12);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();
@@ -690,22 +690,22 @@ class underlying_types_test_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem177 = list_type;
-    if (elem177 != null) {
+    final elem13 = list_type;
+    if (elem13 != null) {
       oprot.writeFieldBegin(_LIST_TYPE_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem177.length));
-      for(var elem178 in elem177) {
-        oprot.writeI64(elem178);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I64, elem13.length));
+      for(var elem14 in elem13) {
+        oprot.writeI64(elem14);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem179 = set_type;
-    if (elem179 != null) {
+    final elem15 = set_type;
+    if (elem15 != null) {
       oprot.writeFieldBegin(_SET_TYPE_FIELD_DESC);
-      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem179.length));
-      for(var elem180 in elem179) {
-        oprot.writeI64(elem180);
+      oprot.writeSetBegin(thrift.TSet(thrift.TType.I64, elem15.length));
+      for(var elem16 in elem15) {
+        oprot.writeI64(elem16);
       }
       oprot.writeSetEnd();
       oprot.writeFieldEnd();
@@ -731,14 +731,14 @@ class underlying_types_test_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem181 = iprot.readListBegin();
-            final elem184 = <int>[];
-            for(int elem183 = 0; elem183 < elem181.length; ++elem183) {
-              int elem182 = iprot.readI64();
-              elem184.add(elem182);
+            thrift.TList elem17 = iprot.readListBegin();
+            final elem20 = <int>[];
+            for(int elem19 = 0; elem19 < elem17.length; ++elem19) {
+              int elem18 = iprot.readI64();
+              elem20.add(elem18);
             }
             iprot.readListEnd();
-            this.success = elem184;
+            this.success = elem20;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -789,9 +789,9 @@ class getThing_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem185 = t_validStructs.Thing();
-            this.success = elem185;
-            elem185.read(iprot);
+            final elem21 = t_validStructs.Thing();
+            this.success = elem21;
+            elem21.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -874,10 +874,10 @@ class use_subdir_struct_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem186 = a;
-    if (elem186 != null) {
+    final elem22 = a;
+    if (elem22 != null) {
       oprot.writeFieldBegin(_A_FIELD_DESC);
-      elem186.write(oprot);
+      elem22.write(oprot);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -901,9 +901,9 @@ class use_subdir_struct_result extends frugal.FGeneratedArgsResultBase {
       switch (field.id) {
         case 0:
           if (field.type == thrift.TType.STRUCT) {
-            final elem187 = t_subdir_include_ns.A();
-            this.success = elem187;
-            elem187.read(iprot);
+            final elem23 = t_subdir_include_ns.A();
+            this.success = elem23;
+            elem23.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -935,10 +935,10 @@ class sayHelloWith_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem188 = newMessage;
-    if (elem188 != null) {
+    final elem24 = newMessage;
+    if (elem24 != null) {
       oprot.writeFieldBegin(_NEW_MESSAGE_FIELD_DESC);
-      oprot.writeString(elem188);
+      oprot.writeString(elem24);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -994,10 +994,10 @@ class whatDoYouSay_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem189 = messageArgs;
-    if (elem189 != null) {
+    final elem25 = messageArgs;
+    if (elem25 != null) {
       oprot.writeFieldBegin(_MESSAGE_ARGS_FIELD_DESC);
-      oprot.writeString(elem189);
+      oprot.writeString(elem25);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();
@@ -1053,10 +1053,10 @@ class sayAgain_args extends frugal.FGeneratedArgsResultBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem190 = messageResult;
-    if (elem190 != null) {
+    final elem26 = messageResult;
+    if (elem26 != null) {
       oprot.writeFieldBegin(_MESSAGE_RESULT_FIELD_DESC);
-      oprot.writeString(elem190);
+      oprot.writeString(elem26);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();

--- a/compiler/testdata/expected/dart/variety/f_test_lowercase.dart
+++ b/compiler/testdata/expected/dart/variety/f_test_lowercase.dart
@@ -103,9 +103,9 @@ class TestLowercase implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem2 = lowercaseInt;
+    final elem0 = lowercaseInt;
     oprot.writeFieldBegin(_LOWERCASE_INT_FIELD_DESC);
-    oprot.writeI32(elem2);
+    oprot.writeI32(elem0);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_defaults.dart
@@ -525,18 +525,18 @@ class TestingDefaults implements thrift.TBase {
           break;
         case EV1:
           if (field.type == thrift.TType.STRUCT) {
-            final elem6 = t_variety.Event();
-            this.ev1 = elem6;
-            elem6.read(iprot);
+            final elem0 = t_variety.Event();
+            this.ev1 = elem0;
+            elem0.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case EV2:
           if (field.type == thrift.TType.STRUCT) {
-            final elem7 = t_variety.Event();
-            this.ev2 = elem7;
-            elem7.read(iprot);
+            final elem1 = t_variety.Event();
+            this.ev2 = elem1;
+            elem1.read(iprot);
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -565,14 +565,14 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LISTFIELD:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem8 = iprot.readListBegin();
-            final elem11 = <int>[];
-            for(int elem10 = 0; elem10 < elem8.length; ++elem10) {
-              int elem9 = iprot.readI32();
-              elem11.add(elem9);
+            thrift.TList elem2 = iprot.readListBegin();
+            final elem5 = <int>[];
+            for(int elem4 = 0; elem4 < elem2.length; ++elem4) {
+              int elem3 = iprot.readI32();
+              elem5.add(elem3);
             }
             iprot.readListEnd();
-            this.listfield = elem11;
+            this.listfield = elem5;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -615,57 +615,57 @@ class TestingDefaults implements thrift.TBase {
           break;
         case LIST2:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem12 = iprot.readListBegin();
-            final elem15 = <int>[];
-            for(int elem14 = 0; elem14 < elem12.length; ++elem14) {
-              int elem13 = iprot.readI32();
-              elem15.add(elem13);
+            thrift.TList elem6 = iprot.readListBegin();
+            final elem9 = <int>[];
+            for(int elem8 = 0; elem8 < elem6.length; ++elem8) {
+              int elem7 = iprot.readI32();
+              elem9.add(elem7);
             }
             iprot.readListEnd();
-            this.list2 = elem15;
+            this.list2 = elem9;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST3:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem16 = iprot.readListBegin();
-            final elem19 = <int>[];
-            for(int elem18 = 0; elem18 < elem16.length; ++elem18) {
-              int elem17 = iprot.readI32();
-              elem19.add(elem17);
+            thrift.TList elem10 = iprot.readListBegin();
+            final elem13 = <int>[];
+            for(int elem12 = 0; elem12 < elem10.length; ++elem12) {
+              int elem11 = iprot.readI32();
+              elem13.add(elem11);
             }
             iprot.readListEnd();
-            this.list3 = elem19;
+            this.list3 = elem13;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case LIST4:
           if (field.type == thrift.TType.LIST) {
-            thrift.TList elem20 = iprot.readListBegin();
-            final elem23 = <int>[];
-            for(int elem22 = 0; elem22 < elem20.length; ++elem22) {
-              int elem21 = iprot.readI32();
-              elem23.add(elem21);
+            thrift.TList elem14 = iprot.readListBegin();
+            final elem17 = <int>[];
+            for(int elem16 = 0; elem16 < elem14.length; ++elem16) {
+              int elem15 = iprot.readI32();
+              elem17.add(elem15);
             }
             iprot.readListEnd();
-            this.list4 = elem23;
+            this.list4 = elem17;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
           break;
         case A_MAP:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem24 = iprot.readMapBegin();
-            final elem27 = <String, String>{};
-            for(int elem26 = 0; elem26 < elem24.length; ++elem26) {
-              String elem28 = iprot.readString();
-              String elem25 = iprot.readString();
-              elem27[elem28] = elem25;
+            thrift.TMap elem18 = iprot.readMapBegin();
+            final elem21 = <String, String>{};
+            for(int elem20 = 0; elem20 < elem18.length; ++elem20) {
+              String elem22 = iprot.readString();
+              String elem19 = iprot.readString();
+              elem21[elem22] = elem19;
             }
             iprot.readMapEnd();
-            this.a_map = elem27;
+            this.a_map = elem21;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -702,126 +702,126 @@ class TestingDefaults implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem29 = iD2;
+    final elem23 = iD2;
     if (isSetID2()) {
       oprot.writeFieldBegin(_I_D2_FIELD_DESC);
-      oprot.writeI64(elem29);
+      oprot.writeI64(elem23);
       oprot.writeFieldEnd();
     }
-    final elem30 = ev1;
-    if (elem30 != null) {
+    final elem24 = ev1;
+    if (elem24 != null) {
       oprot.writeFieldBegin(_EV1_FIELD_DESC);
-      elem30.write(oprot);
+      elem24.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem31 = ev2;
-    if (elem31 != null) {
+    final elem25 = ev2;
+    if (elem25 != null) {
       oprot.writeFieldBegin(_EV2_FIELD_DESC);
-      elem31.write(oprot);
+      elem25.write(oprot);
       oprot.writeFieldEnd();
     }
-    final elem32 = iD;
+    final elem26 = iD;
     oprot.writeFieldBegin(_ID_FIELD_DESC);
-    oprot.writeI64(elem32);
+    oprot.writeI64(elem26);
     oprot.writeFieldEnd();
-    final elem33 = thing;
-    if (elem33 != null) {
+    final elem27 = thing;
+    if (elem27 != null) {
       oprot.writeFieldBegin(_THING_FIELD_DESC);
-      oprot.writeString(elem33);
+      oprot.writeString(elem27);
       oprot.writeFieldEnd();
     }
-    final elem34 = thing2;
-    if (isSetThing2() && elem34 != null) {
+    final elem28 = thing2;
+    if (isSetThing2() && elem28 != null) {
       oprot.writeFieldBegin(_THING2_FIELD_DESC);
-      oprot.writeString(elem34);
+      oprot.writeString(elem28);
       oprot.writeFieldEnd();
     }
-    final elem35 = listfield;
-    if (elem35 != null) {
+    final elem29 = listfield;
+    if (elem29 != null) {
       oprot.writeFieldBegin(_LISTFIELD_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem35.length));
-      for(var elem36 in elem35) {
-        oprot.writeI32(elem36);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem29.length));
+      for(var elem30 in elem29) {
+        oprot.writeI32(elem30);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem37 = iD3;
+    final elem31 = iD3;
     oprot.writeFieldBegin(_I_D3_FIELD_DESC);
-    oprot.writeI64(elem37);
+    oprot.writeI64(elem31);
     oprot.writeFieldEnd();
-    final elem38 = bin_field;
-    if (elem38 != null) {
+    final elem32 = bin_field;
+    if (elem32 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_FIELD_DESC);
-      oprot.writeBinary(elem38);
+      oprot.writeBinary(elem32);
       oprot.writeFieldEnd();
     }
-    final elem39 = bin_field2;
-    if (isSetBin_field2() && elem39 != null) {
+    final elem33 = bin_field2;
+    if (isSetBin_field2() && elem33 != null) {
       oprot.writeFieldBegin(_BIN_FIELD2_FIELD_DESC);
-      oprot.writeBinary(elem39);
+      oprot.writeBinary(elem33);
       oprot.writeFieldEnd();
     }
-    final elem40 = bin_field3;
-    if (elem40 != null) {
+    final elem34 = bin_field3;
+    if (elem34 != null) {
       oprot.writeFieldBegin(_BIN_FIELD3_FIELD_DESC);
-      oprot.writeBinary(elem40);
+      oprot.writeBinary(elem34);
       oprot.writeFieldEnd();
     }
-    final elem41 = bin_field4;
-    if (isSetBin_field4() && elem41 != null) {
+    final elem35 = bin_field4;
+    if (isSetBin_field4() && elem35 != null) {
       oprot.writeFieldBegin(_BIN_FIELD4_FIELD_DESC);
-      oprot.writeBinary(elem41);
+      oprot.writeBinary(elem35);
       oprot.writeFieldEnd();
     }
-    final elem42 = list2;
-    if (isSetList2() && elem42 != null) {
+    final elem36 = list2;
+    if (isSetList2() && elem36 != null) {
       oprot.writeFieldBegin(_LIST2_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem42.length));
-      for(var elem43 in elem42) {
-        oprot.writeI32(elem43);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem36.length));
+      for(var elem37 in elem36) {
+        oprot.writeI32(elem37);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem44 = list3;
-    if (isSetList3() && elem44 != null) {
+    final elem38 = list3;
+    if (isSetList3() && elem38 != null) {
       oprot.writeFieldBegin(_LIST3_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem44.length));
-      for(var elem45 in elem44) {
-        oprot.writeI32(elem45);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem38.length));
+      for(var elem39 in elem38) {
+        oprot.writeI32(elem39);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem46 = list4;
-    if (elem46 != null) {
+    final elem40 = list4;
+    if (elem40 != null) {
       oprot.writeFieldBegin(_LIST4_FIELD_DESC);
-      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem46.length));
-      for(var elem47 in elem46) {
-        oprot.writeI32(elem47);
+      oprot.writeListBegin(thrift.TList(thrift.TType.I32, elem40.length));
+      for(var elem41 in elem40) {
+        oprot.writeI32(elem41);
       }
       oprot.writeListEnd();
       oprot.writeFieldEnd();
     }
-    final elem48 = a_map;
-    if (isSetA_map() && elem48 != null) {
+    final elem42 = a_map;
+    if (isSetA_map() && elem42 != null) {
       oprot.writeFieldBegin(_A_MAP_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem48.length));
-      for(var entry in elem48.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.STRING, thrift.TType.STRING, elem42.length));
+      for(var entry in elem42.entries) {
         oprot.writeString(entry.key);
         oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem49 = status;
+    final elem43 = status;
     oprot.writeFieldBegin(_STATUS_FIELD_DESC);
-    oprot.writeI32(elem49);
+    oprot.writeI32(elem43);
     oprot.writeFieldEnd();
-    final elem50 = base_status;
+    final elem44 = base_status;
     oprot.writeFieldBegin(_BASE_STATUS_FIELD_DESC);
-    oprot.writeI32(elem50);
+    oprot.writeI32(elem44);
     oprot.writeFieldEnd();
     oprot.writeFieldStop();
     oprot.writeStructEnd();

--- a/compiler/testdata/expected/dart/variety/f_testing_unions.dart
+++ b/compiler/testdata/expected/dart/variety/f_testing_unions.dart
@@ -300,15 +300,15 @@ class TestingUnions implements thrift.TBase {
           break;
         case REQUESTS:
           if (field.type == thrift.TType.MAP) {
-            thrift.TMap elem148 = iprot.readMapBegin();
-            final elem151 = <int, String>{};
-            for(int elem150 = 0; elem150 < elem148.length; ++elem150) {
-              int elem152 = iprot.readI32();
-              String elem149 = iprot.readString();
-              elem151[elem152] = elem149;
+            thrift.TMap elem0 = iprot.readMapBegin();
+            final elem3 = <int, String>{};
+            for(int elem2 = 0; elem2 < elem0.length; ++elem2) {
+              int elem4 = iprot.readI32();
+              String elem1 = iprot.readString();
+              elem3[elem4] = elem1;
             }
             iprot.readMapEnd();
-            this.requests = elem151;
+            this.requests = elem3;
           } else {
             thrift.TProtocolUtil.skip(iprot, field.type);
           }
@@ -353,58 +353,58 @@ class TestingUnions implements thrift.TBase {
     validate();
 
     oprot.writeStructBegin(_STRUCT_DESC);
-    final elem153 = anID;
+    final elem5 = anID;
     if (isSetAnID()) {
       oprot.writeFieldBegin(_AN_ID_FIELD_DESC);
-      oprot.writeI64(elem153);
+      oprot.writeI64(elem5);
       oprot.writeFieldEnd();
     }
-    final elem154 = aString;
-    if (isSetAString() && elem154 != null) {
+    final elem6 = aString;
+    if (isSetAString() && elem6 != null) {
       oprot.writeFieldBegin(_A_STRING_FIELD_DESC);
-      oprot.writeString(elem154);
+      oprot.writeString(elem6);
       oprot.writeFieldEnd();
     }
-    final elem155 = someotherthing;
+    final elem7 = someotherthing;
     if (isSetSomeotherthing()) {
       oprot.writeFieldBegin(_SOMEOTHERTHING_FIELD_DESC);
-      oprot.writeI32(elem155);
+      oprot.writeI32(elem7);
       oprot.writeFieldEnd();
     }
-    final elem156 = anInt16;
+    final elem8 = anInt16;
     if (isSetAnInt16()) {
       oprot.writeFieldBegin(_AN_INT16_FIELD_DESC);
-      oprot.writeI16(elem156);
+      oprot.writeI16(elem8);
       oprot.writeFieldEnd();
     }
-    final elem157 = requests;
-    if (isSetRequests() && elem157 != null) {
+    final elem9 = requests;
+    if (isSetRequests() && elem9 != null) {
       oprot.writeFieldBegin(_REQUESTS_FIELD_DESC);
-      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem157.length));
-      for(var entry in elem157.entries) {
+      oprot.writeMapBegin(thrift.TMap(thrift.TType.I32, thrift.TType.STRING, elem9.length));
+      for(var entry in elem9.entries) {
         oprot.writeI32(entry.key);
         oprot.writeString(entry.value);
       }
       oprot.writeMapEnd();
       oprot.writeFieldEnd();
     }
-    final elem158 = bin_field_in_union;
-    if (isSetBin_field_in_union() && elem158 != null) {
+    final elem10 = bin_field_in_union;
+    if (isSetBin_field_in_union() && elem10 != null) {
       oprot.writeFieldBegin(_BIN_FIELD_IN_UNION_FIELD_DESC);
-      oprot.writeBinary(elem158);
+      oprot.writeBinary(elem10);
       oprot.writeFieldEnd();
     }
-    final elem159 = depr;
+    final elem11 = depr;
     // ignore: deprecated_member_use
     if (isSetDepr()) {
       oprot.writeFieldBegin(_DEPR_FIELD_DESC);
-      oprot.writeBool(elem159);
+      oprot.writeBool(elem11);
       oprot.writeFieldEnd();
     }
-    final elem160 = wHOA_BUDDY;
+    final elem12 = wHOA_BUDDY;
     if (isSetWHOA_BUDDY()) {
       oprot.writeFieldBegin(_WHO_A__BUDDY_FIELD_DESC);
-      oprot.writeBool(elem160);
+      oprot.writeBool(elem12);
       oprot.writeFieldEnd();
     }
     oprot.writeFieldStop();


### PR DESCRIPTION
### Story:
Currently, the dart generator creates variables using a counter that always increases. Because of this, changing one part of a frugal file can cascade changes to many dart files because that counter creates new variables for all files generated after the file which created more ids than it previously did. It would be nice if this wasn't the case, and only the dart file needing regeneration would produce a diff.

We should be able to track the element counter per file, as these variables are never exposed outside a file, there shouldn't be any conflicts. One potential issue with this approach is if we start writing a file, switch to writing a second file, then come back to the first file, our element counter may now collide. I don't think we ever do this, though.

### Acceptance Criteria:
- [ ] Code has been tested and results documented
- [ ] Unit tests have been updated
- [ ] Updates to documentation if necessary
- [ ] Verify and document changes to any other Messaging components
- [ ] Pull request made against the 'develop' branch, not master

### Design Notes:
TODO

### How To Test:
- using the dart generator, observe the element counter restarts for each file
- no element collisions are observed in a dart file

### My Test Results:
TODO

#### Reviewers:
